### PR TITLE
Remove use of pp_role

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This Puppet module contains Puppet Task Plans used to deploy and manage at-scale
 
 Use this module to deploy Puppet Enterprise 2019.x Standard, Large, and Extra Large architecture.
 
-* This deployment depends on and assumes the use of trusted facts. Specifically, `pp_role` and `pp_environment`.
+* This deployment depends on and assumes the use of trusted facts. Specifically, `pp_application` and `pp_cluster`.
 * This deployment assumes that at least for PE infrastructure nodes, Puppet certnames are correct, resolvable FQDNs.
 
 ## Documentation

--- a/installer/primary-master/csr_attributes.yaml
+++ b/installer/primary-master/csr_attributes.yaml
@@ -1,4 +1,3 @@
 ---
 extension_requests:
-  pp_role: "peadm::master"
-  pp_environment: "pe_production"
+  pp_application: "puppet/master"

--- a/installer/puppetdb-database/csr_attributes.yaml
+++ b/installer/puppetdb-database/csr_attributes.yaml
@@ -1,4 +1,3 @@
 ---
 extension_requests:
-  pp_role: "peadm::puppetdb_database"
-  pp_environment: "pe_production"
+  pp_application: "puppet/puppetdb-database"

--- a/manifests/setup/node_manager.pp
+++ b/manifests/setup/node_manager.pp
@@ -7,7 +7,7 @@
 # This class will be applied during master bootstrap using e.g.
 #
 #     puppet apply \
-#       --exec 'class { "peadm::node_manager":
+#       --exec 'class { "peadm::setup::node_manager":
 #                 environments => ["production", "staging", "development"],
 #               }'
 #
@@ -43,7 +43,7 @@ class peadm::setup::node_manager (
   # We modify this group's rule such that all PE infrastructure nodes will be
   # members.
   node_group { 'PE Infrastructure Agent':
-    rule => ['and', ['~', ['trusted', 'extensions', 'pp_role'], '^peadm::']],
+    rule => ['and', ['~', ['trusted', 'extensions', 'pp_application'], '^puppet/']],
   }
 
   # We modify this group to add, as data, the compiler_pool_address only.
@@ -52,7 +52,7 @@ class peadm::setup::node_manager (
   node_group { 'PE Master':
     parent    => 'PE Infrastructure',
     rule      => ['or',
-      ['and', ['=', ['trusted', 'extensions', 'pp_role'], 'peadm::compiler']],
+      ['and', ['=', ['trusted', 'extensions', 'pp_application'], 'puppet/compiler']],
       ['=', 'name', $master_host],
     ],
     data      => {
@@ -71,7 +71,7 @@ class peadm::setup::node_manager (
       parent               => 'PE Infrastructure',
       environment          => 'production',
       override_environment => false,
-      rule                 => ['and', ['=', ['trusted', 'extensions', 'pp_role'], 'peadm::puppetdb_database']],
+      rule                 => ['and', ['=', ['trusted', 'extensions', 'pp_application'], 'puppet/puppetdb-database']],
       classes              => {
         'puppet_enterprise::profile::database' => { },
       },
@@ -84,7 +84,7 @@ class peadm::setup::node_manager (
     ensure => present,
     parent => 'PE Infrastructure',
     rule   => ['and',
-      ['=', ['trusted', 'extensions', 'pp_role'], 'peadm::master'],
+      ['=', ['trusted', 'extensions', 'pp_application'], 'puppet/master'],
       ['=', ['trusted', 'extensions', 'pp_cluster'], 'A'],
     ],
     data   => {
@@ -103,7 +103,7 @@ class peadm::setup::node_manager (
     ensure  => 'present',
     parent  => 'PE Master',
     rule    => ['and',
-      ['=', ['trusted', 'extensions', 'pp_role'], 'peadm::compiler'],
+      ['=', ['trusted', 'extensions', 'pp_application'], 'puppet/compiler'],
       ['=', ['trusted', 'extensions', 'pp_cluster'], 'A'],
     ],
     classes => {
@@ -138,7 +138,7 @@ class peadm::setup::node_manager (
       ensure => present,
       parent => 'PE Infrastructure',
       rule   => ['and',
-        ['=', ['trusted', 'extensions', 'pp_role'], 'peadm::master'],
+        ['=', ['trusted', 'extensions', 'pp_application'], 'puppet/master'],
         ['=', ['trusted', 'extensions', 'pp_cluster'], 'B'],
       ],
       data   => {
@@ -155,7 +155,7 @@ class peadm::setup::node_manager (
       ensure  => 'present',
       parent  => 'PE Master',
       rule    => ['and',
-        ['=', ['trusted', 'extensions', 'pp_role'], 'peadm::compiler'],
+        ['=', ['trusted', 'extensions', 'pp_application'], 'puppet/compiler'],
         ['=', ['trusted', 'extensions', 'pp_cluster'], 'B'],
       ],
       classes => {

--- a/plans/unit/install.pp
+++ b/plans/unit/install.pp
@@ -159,8 +159,7 @@ plan peadm::unit::install (
     content => @(HEREDOC),
       ---
       extension_requests:
-        pp_application: "puppet"
-        pp_role: "peadm::master"
+        pp_application: "puppet/master"
         pp_cluster: "A"
       | HEREDOC
   )
@@ -170,8 +169,7 @@ plan peadm::unit::install (
     content => @(HEREDOC),
       ---
       extension_requests:
-        pp_application: "puppet"
-        pp_role: "peadm::puppetdb_database"
+        pp_application: "puppet/puppetdb-database"
         pp_cluster: "A"
       | HEREDOC
   )
@@ -181,8 +179,7 @@ plan peadm::unit::install (
     content => @(HEREDOC),
       ---
       extension_requests:
-        pp_application: "puppet"
-        pp_role: "peadm::puppetdb_database"
+        pp_application: "puppet/puppetdb-database"
         pp_cluster: "B"
       | HEREDOC
   )
@@ -260,8 +257,7 @@ plan peadm::unit::install (
     install_flags => [
       '--puppet-service-ensure', 'stopped',
       "main:dns_alt_names=${dns_alt_names_csv}",
-      'extension_requests:pp_application=puppet',
-      'extension_requests:pp_role=peadm::master',
+      'extension_requests:pp_application=puppet/master',
       'extension_requests:pp_cluster=B',
     ],
   )
@@ -271,8 +267,7 @@ plan peadm::unit::install (
     install_flags => [
       '--puppet-service-ensure', 'stopped',
       "main:dns_alt_names=${dns_alt_names_csv}",
-      'extension_requests:pp_application=puppet',
-      'extension_requests:pp_role=peadm::compiler',
+      'extension_requests:pp_application=puppet/compiler',
       'extension_requests:pp_cluster=A',
     ],
   )
@@ -282,8 +277,7 @@ plan peadm::unit::install (
     install_flags => [
       '--puppet-service-ensure', 'stopped',
       "main:dns_alt_names=${dns_alt_names_csv}",
-      'extension_requests:pp_application=puppet',
-      'extension_requests:pp_role=peadm::compiler',
+      'extension_requests:pp_application=puppet/compiler',
       'extension_requests:pp_cluster=B',
     ],
   )


### PR DESCRIPTION
The pp_role trusted fact is the most-likely-to-be-used trusted fact we
have. It's not a good idea to require the use of this one for peadm
configuration to work.

Instead, encode the information we need for component identification
into pp_application. Use puppet/ as a prefix, and attach whatever
component role a node has after that.

There's a good argument that we shouldn't use pp_application either.
We're already using it though so we don't lose anything this way, and we
gain the benefit of not using pp_role anymore. So shipping this as an
incremental improvement, with room for more improvement in the future.