### PR TITLE
Deploy combined with GCP, macOS, Terraform

### DIFF
--- a/functions/target_host.pp
+++ b/functions/target_host.pp
@@ -3,10 +3,10 @@ function peadm::target_host(
 ) >> Variant[String, Undef] {
   case $target {
     Target: {
-      $target.host
+      $target.name
     }
     Array[Target,1,1]: {
-      $target[0].host
+      $target[0].name
     }
     Array[Target,0,0]: {
       undef

--- a/functions/target_name.pp
+++ b/functions/target_name.pp
@@ -1,4 +1,4 @@
-function peadm::target_host(
+function peadm::target_name(
   Variant[Target, Array[Target,0,1]] $target,
 ) >> Variant[String, Undef] {
   case $target {
@@ -12,7 +12,7 @@ function peadm::target_host(
       undef
     }
     default: {
-      fail('Unexpected input type to peadm::target_host function')
+      fail('Unexpected input type to peadm::target_name function')
     }
   }
 }

--- a/plans/unit/configure.pp
+++ b/plans/unit/configure.pp
@@ -46,10 +46,10 @@ plan peadm::unit::configure (
   # commented-out values should be used once GH-1244 is resolved.
 
   # WORKAROUND: GH-1244
-  $master_host_string = $master_target.peadm::target_host()
-  $master_replica_host_string = $master_replica_target.peadm::target_host()
-  $puppetdb_database_host_string = $puppetdb_database_target.peadm::target_host()
-  $puppetdb_database_replica_host_string = $puppetdb_database_replica_target.peadm::target_host()
+  $master_host_string = $master_target.peadm::target_name()
+  $master_replica_host_string = $master_replica_target.peadm::target_name()
+  $puppetdb_database_host_string = $puppetdb_database_target.peadm::target_name()
+  $puppetdb_database_replica_host_string = $puppetdb_database_replica_target.peadm::target_name()
 
   apply($master_target) {
     # Necessary to give the sandboxed Puppet executor the configuration
@@ -65,10 +65,10 @@ plan peadm::unit::configure (
 
     class { 'peadm::setup::node_manager':
       # WORKAROUND: GH-1244
-      master_host                    => $master_host_string, # $master_target.peadm::target_host(),
-      master_replica_host            => $master_replica_host_string, # $master_replica_target.peadm::target_host(),
-      puppetdb_database_host         => $puppetdb_database_host_string, # $puppetdb_database_target.peadm::target_host(),
-      puppetdb_database_replica_host => $puppetdb_database_replica_host_string, # $puppetdb_database_replica_target.peadm::target_host(),
+      master_host                    => $master_host_string, # $master_target.peadm::target_name(),
+      master_replica_host            => $master_replica_host_string, # $master_replica_target.peadm::target_name(),
+      puppetdb_database_host         => $puppetdb_database_host_string, # $puppetdb_database_target.peadm::target_name(),
+      puppetdb_database_replica_host => $puppetdb_database_replica_host_string, # $puppetdb_database_replica_target.peadm::target_name(),
       compiler_pool_address          => $compiler_pool_address,
       require                        => File['node_manager.yaml'],
     }
@@ -100,13 +100,13 @@ plan peadm::unit::configure (
   if $arch['high-availability'] {
     # Run the PE Replica Provision
     run_task('peadm::provision_replica', $master_target,
-      master_replica => $master_replica_target.peadm::target_host(),
+      master_replica => $master_replica_target.peadm::target_name(),
       token_file     => $token_file,
     )
 
     # Run the PE Replica Enable
     run_task('peadm::enable_replica', $master_target,
-      master_replica => $master_replica_target.peadm::target_host(),
+      master_replica => $master_replica_target.peadm::target_name(),
       token_file     => $token_file,
     )
   }

--- a/plans/unit/install.pp
+++ b/plans/unit/install.pp
@@ -117,9 +117,9 @@ plan peadm::unit::install (
   # Generate all the needed pe.conf files
   $master_pe_conf = peadm::generate_pe_conf({
     'console_admin_password'                                          => $console_password,
-    'puppet_enterprise::puppet_master_host'                           => $master_target.peadm::target_host(),
+    'puppet_enterprise::puppet_master_host'                           => $master_target.peadm::target_name(),
     'pe_install::puppet_master_dnsaltnames'                           => $dns_alt_names,
-    'puppet_enterprise::profile::puppetdb::database_host'             => $puppetdb_database_target.peadm::target_host(),
+    'puppet_enterprise::profile::puppetdb::database_host'             => $puppetdb_database_target.peadm::target_name(),
     'puppet_enterprise::profile::master::code_manager_auto_configure' => true,
     'puppet_enterprise::profile::master::r10k_private_key'            => '/etc/puppetlabs/puppetserver/ssh/id-control_repo.rsa',
     'puppet_enterprise::profile::master::r10k_remote'                 => $r10k_remote,
@@ -127,14 +127,14 @@ plan peadm::unit::install (
 
   $puppetdb_database_pe_conf = peadm::generate_pe_conf({
     'console_admin_password'                => 'not used',
-    'puppet_enterprise::puppet_master_host' => $master_target.peadm::target_host(),
-    'puppet_enterprise::database_host'      => $puppetdb_database_target.peadm::target_host(),
+    'puppet_enterprise::puppet_master_host' => $master_target.peadm::target_name(),
+    'puppet_enterprise::database_host'      => $puppetdb_database_target.peadm::target_name(),
   } + $pe_conf_data)
 
   $puppetdb_database_replica_pe_conf = peadm::generate_pe_conf({
     'console_admin_password'                => 'not used',
-    'puppet_enterprise::puppet_master_host' => $master_target.peadm::target_host(),
-    'puppet_enterprise::database_host'      => $puppetdb_database_replica_target.peadm::target_host(),
+    'puppet_enterprise::puppet_master_host' => $master_target.peadm::target_name(),
+    'puppet_enterprise::database_host'      => $puppetdb_database_replica_target.peadm::target_name(),
   } + $pe_conf_data)
 
   # Upload the pe.conf files to the hosts that need them
@@ -253,7 +253,7 @@ plan peadm::unit::install (
 
   # Deploy the PE agent to all remaining hosts
   run_task('peadm::agent_install', $master_replica_target,
-    server        => $master_target.peadm::target_host(),
+    server        => $master_target.peadm::target_name(),
     install_flags => [
       '--puppet-service-ensure', 'stopped',
       "main:dns_alt_names=${dns_alt_names_csv}",
@@ -263,7 +263,7 @@ plan peadm::unit::install (
   )
 
   run_task('peadm::agent_install', $compiler_a_targets,
-    server        => $master_target.peadm::target_host(),
+    server        => $master_target.peadm::target_name(),
     install_flags => [
       '--puppet-service-ensure', 'stopped',
       "main:dns_alt_names=${dns_alt_names_csv}",
@@ -273,7 +273,7 @@ plan peadm::unit::install (
   )
 
   run_task('peadm::agent_install', $compiler_b_targets,
-    server        => $master_target.peadm::target_host(),
+    server        => $master_target.peadm::target_name(),
     install_flags => [
       '--puppet-service-ensure', 'stopped',
       "main:dns_alt_names=${dns_alt_names_csv}",

--- a/plans/unit/install.pp
+++ b/plans/unit/install.pp
@@ -210,7 +210,7 @@ plan peadm::unit::install (
   }
 
   # Configure autosigning for the puppetdb database hosts 'cause they need it
-  $autosign_conf = $database_targets.reduce('') |$memo,$target| { "${target.host}\n${memo}" }
+  $autosign_conf = $database_targets.reduce('') |$memo,$target| { "${target.name}\n${memo}" }
   run_task('peadm::mkdir_p_file', $master_target,
     path    => '/etc/puppetlabs/puppet/autosign.conf',
     owner   => 'pe-puppet',
@@ -295,7 +295,7 @@ plan peadm::unit::install (
   if !empty($agent_installer_targets) {
     run_command(inline_epp(@(HEREDOC/L)), $master_target)
       /opt/puppetlabs/bin/puppetserver ca sign --certname \
-        <%= $agent_installer_targets.map |$target| { $target.host }.join(',') -%>
+        <%= $agent_installer_targets.map |$target| { $target.name }.join(',') -%>
       | HEREDOC
   }
 

--- a/tasks/filesize.sh
+++ b/tasks/filesize.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 
-size=$(stat -c%s "$PT_path" 2>/dev/null || echo null)
+case $(uname) in
+Darwin)
+  options="-f%z"
+  ;;
+*)
+  options="-c%s"
+  ;;
+esac
+
+size=$(stat "$options" "$PT_path" 2>/dev/null || echo null)
 
 # Output a JSON result for ease of Task usage in Puppet Task Plans
 if [ "$size" = "null" ]; then


### PR DESCRIPTION
	This commit includes the changes that were required to automate
	the deployment of the PE XL architecture when Bolt and Terraform
	were linked together on macOS, targeted at GCP. The use case
	being a single Bolt plan that can quickly stamp out new
	infrastructure for customers.

	Reasoning for filesize.sh change is because of parameter
	mismatches between Linux and macOS. Other changes are a result
	of needing to access nodes using external IP address when
	initiating automation from outside the cloud provider, e.x. your
	laptop and requiring that all services are wired together using
	internal DNS names.