### PR TITLE
Partially revert fcd04d0

### DIFF
--- a/manifests/setup/node_manager.pp
+++ b/manifests/setup/node_manager.pp
@@ -91,8 +91,8 @@ class peadm::setup::node_manager (
       'puppet_enterprise::profile::primary_master_replica' => {
         'database_host_puppetdb' => $puppetdb_database_host,
       },
-      'puppet_enterprise' => {
-        'puppetdb_database_host' => $puppetdb_database_host,
+      'puppet_enterprise::profile::puppetdb'               => {
+        'database_host' => $puppetdb_database_host,
       },
     },
   }
@@ -145,8 +145,8 @@ class peadm::setup::node_manager (
         'puppet_enterprise::profile::primary_master_replica' => {
           'database_host_puppetdb' => $puppetdb_database_replica_host,
         },
-        'puppet_enterprise' => {
-          'puppetdb_database_host' => $puppetdb_database_replica_host,
+        'puppet_enterprise::profile::puppetdb'               => {
+          'database_host' => $puppetdb_database_replica_host,
         },
       },
     }


### PR DESCRIPTION
Turns out it doesn't quite work to use the high-level parameter for the
compilers.

    Warning: Unable to fetch my node definition, but the agent run will continue:
    Warning: Error 500 on SERVER: Server Error: Classification of <replica> failed due
    to a classification conflict: The node was classified into groups named:
      "PE Master B"
      "PE Infrastructure Agent"
      "All Environments"
      "PE HA Replica"

    These groups defined conflicting values for class parameters for the classes:
      "puppet_enterprise"