### PR TITLE
Rename subdirectory "unit" to "action"

### DIFF
--- a/documentation/basic_usage.md
+++ b/documentation/basic_usage.md
@@ -9,7 +9,7 @@ The current versions of those plans can be found at:
 * [provision.pp](../plans/provision.pp)
 * [upgrade.pp](../plans/upgrade.pp)
 
-Provisioning can be broken down into two actions: [install](../plans/unit/install.pp), and [configure](../plans/unit/configure.pp). Installation currently requires ssh access to the un-provisioned nodes, but configure can be performed using the Orchestrator transport if installation has already been completed.
+Provisioning can be broken down into two actions: [install](../plans/action/install.pp), and [configure](../plans/action/configure.pp). Installation currently requires ssh access to the un-provisioned nodes, but configure can be performed using the Orchestrator transport if installation has already been completed.
 
 Besides getting Puppet Enterprise installed, the key configuration supporting Large and Extra Large architectures is laid out in four classification groups. Links are provided below to a Markdown document that describes the groups, and also to the Puppet manifest that actually configures them:
 

--- a/plans/action/configure.pp
+++ b/plans/action/configure.pp
@@ -1,6 +1,6 @@
 # @summary Configure first-time classification and HA setup
 #
-plan peadm::unit::configure (
+plan peadm::action::configure (
   # Large
   Peadm::SingleTargetSpec           $master_host,
   Optional[TargetSpec]              $compiler_hosts = undef,

--- a/plans/action/install.pp
+++ b/plans/action/install.pp
@@ -13,7 +13,7 @@
 #   Config data to plane into pe.conf when generated on all hosts, this can be
 #   used for tuning data etc.
 #
-plan peadm::unit::install (
+plan peadm::action::install (
   # Standard
   Peadm::SingleTargetSpec           $master_host,
   Optional[Peadm::SingleTargetSpec] $master_replica_host = undef,

--- a/plans/provision.pp
+++ b/plans/provision.pp
@@ -31,7 +31,7 @@ plan peadm::provision (
   Optional[String]                  $stagingdir = undef,
 ) {
 
-  $install_result = run_plan('peadm::unit::install',
+  $install_result = run_plan('peadm::action::install',
     # Standard
     master_host                    => $master_host,
     master_replica_host            => $master_replica_host,
@@ -58,7 +58,7 @@ plan peadm::provision (
     stagingdir                     => $stagingdir,
   )
 
-  $configure_result = run_plan('peadm::unit::configure',
+  $configure_result = run_plan('peadm::action::configure',
     # Standard
     master_host                    => $master_host,
     master_replica_host            => $master_replica_host,


### PR DESCRIPTION
The "action" plans subdirectory contains unit actions that can be
performed, and chained together by higher-level plans. While the term
"unit" is probably the more technically accurate, "action" is more
intuitive as to what these unit plans typically are.