### PR TITLE
Make CSR submission version-aware

### DIFF
--- a/plans/action/install.pp
+++ b/plans/action/install.pp
@@ -288,9 +288,7 @@ plan peadm::action::install (
   )
 
   # Ensure certificate requests have been submitted
-  run_command(@(HEREDOC), $agent_installer_targets)
-    /opt/puppetlabs/bin/puppet ssl submit_request
-    | HEREDOC
+  run_task('peadm::submit_csr', $agent_installer_targets)
 
   # TODO: come up with an intelligent way to validate that the expected CSRs
   # have been submitted and are available for signing, prior to signing them.

--- a/tasks/submit_csr.json
+++ b/tasks/submit_csr.json
@@ -1,0 +1,8 @@
+{
+  "description": "Submit a certificate signing request",
+  "parameters": { },
+  "input_method": "stdin",
+  "implementations": [
+    {"name": "submit_csr.rb"}
+  ]
+}

--- a/tasks/submit_csr.rb
+++ b/tasks/submit_csr.rb
@@ -1,0 +1,40 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+#
+# rubocop:disable Style/GlobalVars
+require 'json'
+require 'open3'
+
+def main
+  params = JSON.parse(STDIN.read)
+  majver = %x{/opt/puppetlabs/bin/puppet --version}
+             .chomp
+             .split('.')
+             .first
+             .to_i
+
+  if majver < 6
+    conf = %x{puppet config print dns_alt_names certname}
+             .chomp
+             .split("\n")
+             .map {|line| line.split(' = ') }
+             .to_h
+
+    cmd = ['/opt/puppetlabs/bin/puppet', 'certificate', 'generate',
+           '--ca-location', 'remote',
+           '--dns-alt-names', conf['dns_alt_names'],
+           conf['certname']
+          ]
+  else
+    cmd = ['/opt/puppetlabs/bin/puppet', 'ssl', 'submit_request']
+  end
+
+  stdout, status = Open3.capture2(*cmd)
+  puts stdout
+  if status.success?
+    exit 0
+  else
+    exit 1
+  end
+end
+
+main


### PR DESCRIPTION
So that Puppet 5 (PE 2018.1) can be supported.