### PR TITLE
Eliminate default private key parameter value

### DIFF
--- a/plans/action/install.pp
+++ b/plans/action/install.pp
@@ -129,8 +129,11 @@ plan peadm::action::install (
     'pe_install::puppet_master_dnsaltnames'                           => $dns_alt_names,
     'puppet_enterprise::puppetdb_database_host'                       => $puppetdb_database_target.peadm::target_name(),
     'puppet_enterprise::profile::master::code_manager_auto_configure' => true,
-    'puppet_enterprise::profile::master::r10k_private_key'            => '/etc/puppetlabs/puppetserver/ssh/id-control_repo.rsa',
     'puppet_enterprise::profile::master::r10k_remote'                 => $r10k_remote,
+    'puppet_enterprise::profile::master::r10k_private_key'            => $r10k_private_key ? {
+      undef   => undef,
+      default => '/etc/puppetlabs/puppetserver/ssh/id-control_repo.rsa',
+    },
   } + $pe_conf_data)
 
   $puppetdb_database_pe_conf = peadm::generate_pe_conf({


### PR DESCRIPTION
We have observed setting r10k_private_key by default can cause conflicts with advanced code manager configuration keys passed in by pe_conf_data. To avoid the need to zero-out the r10k_private_key value, if the top-level r10k_private_key settings are not given to peadm::provision, do not set a pe.conf value for r10k_private_key.