### PR TITLE
Node manager switch

### DIFF
--- a/manifests/setup/node_manager.pp
+++ b/manifests/setup/node_manager.pp
@@ -13,11 +13,12 @@
 #
 class peadm::setup::node_manager (
   String[1] $master_host,
-  String[1] $puppetdb_database_host,
+  String[1] $puppetdb_database_host = $master_host,
+
   String[1] $compiler_pool_address,
 
   Optional[String[1]] $master_replica_host            = undef,
-  Optional[String[1]] $puppetdb_database_replica_host = undef,
+  Optional[String[1]] $puppetdb_database_replica_host = $master_replica_host,
 ) {
 
   ##################################################
@@ -129,9 +130,7 @@ class peadm::setup::node_manager (
       },
       variables => { 'peadm_replica' => true },
     }
-  }
 
-  if $puppetdb_database_replica_host {
     node_group { 'PE Master B':
       ensure => present,
       parent => 'PE Infrastructure',
@@ -148,14 +147,7 @@ class peadm::setup::node_manager (
         },
       },
     }
-  }
 
-  if ($puppetdb_database_replica_host) or ($master_replica_host) {
-    if ($puppetdb_database_replica_host) {
-      $dbhost = $puppetdb_database_replica_host
-    } else {
-      $dbhost = $puppetdb_database_host
-    }
     node_group { 'PE Compiler Group B':
       ensure  => 'present',
       parent  => 'PE Master',
@@ -165,7 +157,7 @@ class peadm::setup::node_manager (
       ],
       classes => {
         'puppet_enterprise::profile::puppetdb' => {
-          'database_host' => $dbhost,
+          'database_host' => $puppetdb_database_replica_host,
         },
         'puppet_enterprise::profile::master'   => {
           'puppetdb_host' => ['${clientcert}', $master_host], # lint:ignore:single_quote_string_with_variables

--- a/manifests/setup/node_manager.pp
+++ b/manifests/setup/node_manager.pp
@@ -150,26 +150,12 @@ class peadm::setup::node_manager (
     }
   }
 
-  if ($puppetdb_database_replica_host) {
-    node_group { 'PE Compiler Group B':
-      ensure  => 'present',
-      parent  => 'PE Master',
-      rule    => ['and',
-        ['=', ['trusted', 'extensions', 'pp_application'], 'puppet/compiler'],
-        ['=', ['trusted', 'extensions', 'pp_cluster'], 'B'],
-      ],
-      classes => {
-        'puppet_enterprise::profile::puppetdb' => {
-          'database_host' => $puppetdb_database_replica_host,
-        },
-        'puppet_enterprise::profile::master'   => {
-          'puppetdb_host' => ['${clientcert}', $master_host], # lint:ignore:single_quote_string_with_variables
-          'puppetdb_port' => [8081],
-        }
-      },
-      data    => $compiler_data,
+  if ($puppetdb_database_replica_host) or ($master_replica_host) {
+    if ($puppetdb_database_replica_host) {
+      $dbhost = $puppetdb_database_replica_host
+    } else {
+      $dbhost = $puppetdb_database_host
     }
-  } elsif ($master_replica_host) {
     node_group { 'PE Compiler Group B':
       ensure  => 'present',
       parent  => 'PE Master',
@@ -179,7 +165,7 @@ class peadm::setup::node_manager (
       ],
       classes => {
         'puppet_enterprise::profile::puppetdb' => {
-          'database_host' => $puppetdb_database_host,
+          'database_host' => $dbhost,
         },
         'puppet_enterprise::profile::master'   => {
           'puppetdb_host' => ['${clientcert}', $master_host], # lint:ignore:single_quote_string_with_variables

--- a/manifests/setup/node_manager.pp
+++ b/manifests/setup/node_manager.pp
@@ -148,7 +148,9 @@ class peadm::setup::node_manager (
         },
       },
     }
+  }
 
+  if ($puppetdb_database_replica_host) {
     node_group { 'PE Compiler Group B':
       ensure  => 'present',
       parent  => 'PE Master',
@@ -159,6 +161,25 @@ class peadm::setup::node_manager (
       classes => {
         'puppet_enterprise::profile::puppetdb' => {
           'database_host' => $puppetdb_database_replica_host,
+        },
+        'puppet_enterprise::profile::master'   => {
+          'puppetdb_host' => ['${clientcert}', $master_host], # lint:ignore:single_quote_string_with_variables
+          'puppetdb_port' => [8081],
+        }
+      },
+      data    => $compiler_data,
+    }
+  } elsif ($master_replica_host) {
+    node_group { 'PE Compiler Group B':
+      ensure  => 'present',
+      parent  => 'PE Master',
+      rule    => ['and',
+        ['=', ['trusted', 'extensions', 'pp_application'], 'puppet/compiler'],
+        ['=', ['trusted', 'extensions', 'pp_cluster'], 'B'],
+      ],
+      classes => {
+        'puppet_enterprise::profile::puppetdb' => {
+          'database_host' => $puppetdb_database_host,
         },
         'puppet_enterprise::profile::master'   => {
           'puppetdb_host' => ['${clientcert}', $master_host], # lint:ignore:single_quote_string_with_variables

--- a/manifests/setup/node_manager.pp
+++ b/manifests/setup/node_manager.pp
@@ -12,12 +12,21 @@
 #               }'
 #
 class peadm::setup::node_manager (
+  # Common
   String[1] $master_host,
-  String[1] $puppetdb_database_host = $master_host,
-
   String[1] $compiler_pool_address,
 
+  # High Availability
   Optional[String[1]] $master_replica_host            = undef,
+
+  # For the next two parameters, the default values are appropriate when
+  # deploying Standard or Large architectures. These values only need to be
+  # specified differently when deploying an Extra Large architecture.
+
+  # Specify when using Extra Large
+  String[1]           $puppetdb_database_host         = $master_host,
+
+  # Specify when using Extra Large AND High Availability
   Optional[String[1]] $puppetdb_database_replica_host = $master_replica_host,
 ) {
 

--- a/plans/action/configure.pp
+++ b/plans/action/configure.pp
@@ -25,10 +25,7 @@ plan peadm::action::configure (
   $master_replica_target            = peadm::get_targets($master_replica_host, 1)
   $puppetdb_database_replica_target = peadm::get_targets($puppetdb_database_replica_host, 1)
   $compiler_targets                 = peadm::get_targets($compiler_hosts)
-  $puppetdb_database_target         = $puppetdb_database_host ? {
-    undef   => $master_target,
-    default => peadm::get_targets($puppetdb_database_host, 1)
-  }
+  $puppetdb_database_target         = peadm::get_targets($puppetdb_database_host, 1)
 
   # Ensure input valid for a supported architecture
   $arch = peadm::validate_architecture(


### PR DESCRIPTION
Discovered a use case where compiler group B was not being created when the infrastructure did not have a puppetdb replica, but did have a master replica.  This caused compilers classified for cluster B to not be classified since the group did not exist.

This update addresses that.