### PR TITLE
Added task which deals with certs restored to target hosts.

### DIFF
--- a/plans/action/install.pp
+++ b/plans/action/install.pp
@@ -164,6 +164,16 @@ plan peadm::action::install (
     upload_path => $upload_tarball_path,
   )
 
+  # Check for a restored CA on the master and if found, remove any 
+  # existing signed certs.  We want the infra servers to generate new 
+  # certs and let any pre-existing agents continue to be able to connect.
+  run_task('peadm::check_for_ca', $master_target,
+    'master_replica_host'            => $master_replica_host,
+    'puppetdb_database_host'         => $puppetdb_database_host,
+    'puppetdb_database_replica_host' => $puppetdb_database_replica_host,
+    'compiler_hosts'                 => $compiler_hosts,
+  )
+
   # Create csr_attributes.yaml files for the nodes that need them
   # There is a problem with OID names in csr_attributes.yaml for some
   # installs, e.g. PE 2019.0.1, PUP-9746. Use the raw OIDs for now.

--- a/tasks/check_for_ca.json
+++ b/tasks/check_for_ca.json
@@ -1,0 +1,23 @@
+{
+  "puppet_task_version": 1,
+  "supports_noop": false,
+  "description": "Check the master for restored SSL certs and remove any belonging to infra.",
+  "parameters": {
+    "master_replica_host": {
+      "description": "The Master replica host.",
+      "type": "Optional[String]"
+    },
+    "puppetdb_database_host": {
+      "description": "The PuppetDB host.",
+      "type": "Optional[String]"
+    },
+    "puppetdb_database_replica_host": {
+      "description": "The PuppetDB replica host.",
+      "type": "Optional[String]"
+    },
+    "compiler_hosts": {
+      "description": "The Compiler hosts.",
+      "type": "Optional[Array]"
+    }    
+  }
+}

--- a/tasks/check_for_ca.sh
+++ b/tasks/check_for_ca.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Puppet Task Name: check_for_ca
+#
+# Explected possible inputs:
+#   $PT_master_replica_host
+#   $PT_puppetdb_database_host
+#   $PT_puppetdb_database_replica_host
+#   $PT_compiler_hosts
+#
+
+# A function to check for and remove signed certs for the infra
+function check_for_cert()
+{
+  cert="/etc/puppetlabs/puppet/ssl/ca/signed/${1}.pem"
+  if [ -f $cert ];
+  then
+    echo "Removing existing signed cert for ${1}"
+    /bin/rm -rf $cert
+  fi
+}
+
+
+# Check to see if pe-puppetserver has been installed
+if [ -f '/opt/puppetlabs/puppetserver/server/bin/puppetserver']
+then
+  echo "Puppetserver has been installed, skipping existing CA and cert check."
+else
+  # if pe-puppetserver has not been installed yet then 
+  # we continue to check for a restored CA and certs.
+  if [ -n "${PT_master_replica_host}" ]; then check_for_cert $PT_master_replica_host; fi
+  if [ -n "${PT_puppetdb_database_host}" ]; then check_for_cert $PT_puppetdb_database_host; fi
+  if [ -n "${PT_puppetdb_database_replica_host}" ]; then check_for_cert $PT_puppetdb_database_replica_host; fi
+
+  # Beause the compiler array is expected to be json formatted, 
+  # we need to do some conversion work.
+  if [ -n "${PT_compiler_hosts}" ];
+  then
+    read -a compiler_array <<< $( /bin/echo $PT_compiler_hosts | /bin/tr \[\]\", ' ' )
+    for i in "${compiler_array[@]}";
+    do 
+      check_for_cert $i
+    done
+  fi
+fi


### PR DESCRIPTION
This adds a task in shell script to check for and remove signed certs for puppet infrastructure.  The use case is for hosts provisioned with a puppet backup of certs pre-installed.  This will preserve the CA and the Master cert.  All other infrastructure certs are removed so peadm can regenerate them.  Non-infrastructure certs are not affected.