### PR TITLE
Set certnames to target names

### DIFF
--- a/plans/action/install.pp
+++ b/plans/action/install.pp
@@ -290,31 +290,38 @@ plan peadm::action::install (
     server        => $master_target.peadm::target_name(),
     install_flags => [
       '--puppet-service-ensure', 'stopped',
+      "main:certname=${master_replica_target.peadm::target_name()}",
       "main:dns_alt_names=${dns_alt_names_csv}",
       "extension_requests:${pp_application}=puppet/master",
       "extension_requests:${pp_cluster}=B",
     ],
   )
 
-  run_task('peadm::agent_install', $compiler_a_targets,
-    server        => $master_target.peadm::target_name(),
-    install_flags => [
-      '--puppet-service-ensure', 'stopped',
-      "main:dns_alt_names=${dns_alt_names_csv}",
-      "extension_requests:${pp_application}=puppet/compiler",
-      "extension_requests:${pp_cluster}=A",
-    ],
-  )
+  $compiler_a_targets.each |$target| {
+    run_task('peadm::agent_install', $target,
+      server        => $master_target.peadm::target_name(),
+      install_flags => [
+        '--puppet-service-ensure', 'stopped',
+        "main:certname=${target.peadm::target_name()}",
+        "main:dns_alt_names=${dns_alt_names_csv}",
+        "extension_requests:${pp_application}=puppet/compiler",
+        "extension_requests:${pp_cluster}=A",
+      ],
+    )
+  }
 
-  run_task('peadm::agent_install', $compiler_b_targets,
-    server        => $master_target.peadm::target_name(),
-    install_flags => [
-      '--puppet-service-ensure', 'stopped',
-      "main:dns_alt_names=${dns_alt_names_csv}",
-      "extension_requests:${pp_application}=puppet/compiler",
-      "extension_requests:${pp_cluster}=B",
-    ],
-  )
+  $compiler_b_targets.each |$target| {
+    run_task('peadm::agent_install', $target,
+      server        => $master_target.peadm::target_name(),
+      install_flags => [
+        '--puppet-service-ensure', 'stopped',
+        "main:certname=${target.peadm::target_name()}",
+        "main:dns_alt_names=${dns_alt_names_csv}",
+        "extension_requests:${pp_application}=puppet/compiler",
+        "extension_requests:${pp_cluster}=B",
+      ],
+    )
+  }
 
   # Ensure certificate requests have been submitted
   run_task('peadm::submit_csr', $agent_installer_targets)

--- a/plans/action/install.pp
+++ b/plans/action/install.pp
@@ -115,7 +115,10 @@ plan peadm::action::install (
   # the configured hostname, and that all systems return the same platform
   $precheck_results.each |$result| {
     if $result.target.name != $result['hostname'] {
-      fail_plan("Hostname / DNS name mismatch: target ${result.target.name} reports '${result['hostname']}'")
+      warning(@("HEREDOC"))
+        WARNING: Target name / hostname mismatch: target ${result.target.name} reports ${result['hostname']}
+                 Certificate name will be set to target name. Please ensure target name is correct and resolvable
+        |-HEREDOC
     }
     if $result['platform'] != $platform {
       fail_plan("Platform mismatch: target ${result.target.name} reports '${result['platform']}; expected ${platform}'")

--- a/plans/action/install.pp
+++ b/plans/action/install.pp
@@ -297,30 +297,19 @@ plan peadm::action::install (
     ],
   )
 
-  $compiler_a_targets.each |$target| {
-    run_task('peadm::agent_install', $target,
-      server        => $master_target.peadm::target_name(),
-      install_flags => [
-        '--puppet-service-ensure', 'stopped',
-        "main:certname=${target.peadm::target_name()}",
-        "main:dns_alt_names=${dns_alt_names_csv}",
-        "extension_requests:${pp_application}=puppet/compiler",
-        "extension_requests:${pp_cluster}=A",
-      ],
-    )
-  }
-
-  $compiler_b_targets.each |$target| {
-    run_task('peadm::agent_install', $target,
-      server        => $master_target.peadm::target_name(),
-      install_flags => [
-        '--puppet-service-ensure', 'stopped',
-        "main:certname=${target.peadm::target_name()}",
-        "main:dns_alt_names=${dns_alt_names_csv}",
-        "extension_requests:${pp_application}=puppet/compiler",
-        "extension_requests:${pp_cluster}=B",
-      ],
-    )
+  ['A', 'B'].each |$group| {
+    getvar("compiler_${group.downcase()}_targets").each |$target| {
+      run_task('peadm::agent_install', $target,
+        server        => $master_target.peadm::target_name(),
+        install_flags => [
+          '--puppet-service-ensure', 'stopped',
+          "main:certname=${target.peadm::target_name()}",
+          "main:dns_alt_names=${dns_alt_names_csv}",
+          "extension_requests:${pp_application}=puppet/compiler",
+          "extension_requests:${pp_cluster}=${group}",
+        ],
+      )
+    }
   }
 
   # Ensure certificate requests have been submitted


### PR DESCRIPTION
To support the use case wherein the certname of a system should be set to something besides the hostname (such as when the DNS A records are friendly names, but the system hostname(s) are not), do not leave certname settings up to Puppet's defaults.

Instead, at install time set the certnames of each server in the infrastructure to the target name of the server.

This will require a little bit of creative decision making with regards to the precheck validator, which used to insist that hostname == target name, and would fail if there was a mismatch.