### PR TITLE
Fail peadm::pe_install task when installer fails

### DIFF
--- a/tasks/pe_install.sh
+++ b/tasks/pe_install.sh
@@ -26,6 +26,9 @@ else
 	/bin/bash "${tgzdir}/${pedir}/puppet-enterprise-installer" -y
 fi
 
+# The exit code of the installer script will be the exit code of the task
+exit_code=$?
+
 if [ "$PT_shortcircuit_puppetdb" = "true" ]; then
 	systemctl stop pe-puppetdb.service
 	rm /etc/systemd/system/pe-puppetdb.service.d/10-shortcircuit.conf
@@ -35,3 +38,6 @@ fi
 if [ "$PT_puppet_service_ensure" = "stopped" ]; then
 	systemctl stop puppet.service
 fi
+
+# Exit with the installer script's exit code
+exit $exit_code


### PR DESCRIPTION
The peadm::pe_install task as written will probably never technically
fail, even when the puppet-enterprise-installer script exits non-zero.

This commit updates the task to exit with whatever exit code the
puppet-enterprise-installer script exited with. Not a perfect fix but a
step in the right direction.

Fixes #71