### PR TITLE
Make cert tasks more idempotent

### DIFF
--- a/tasks/submit_csr.rb
+++ b/tasks/submit_csr.rb
@@ -3,6 +3,12 @@
 require 'json'
 require 'open3'
 
+def already_signed?
+  cmd = ['/opt/puppetlabs/bin/puppet', 'ssl', 'verify']
+  _, status = Open3.capture2(*cmd)
+  status.success?
+end
+
 def main
   majver = `/opt/puppetlabs/bin/puppet --version`
            .chomp
@@ -22,6 +28,7 @@ def main
            '--dns-alt-names', conf['dns_alt_names'],
            conf['certname']]
   else
+    exit 0 if already_signed?
     cmd = ['/opt/puppetlabs/bin/puppet', 'ssl', 'submit_request']
   end
 


### PR DESCRIPTION
  * previously if the sign or request cert tasks were
    run twice, the tasks would fail.  This adds idempotency
    to the sign_csr and submit_csr tasks for puppet 6+ only.