### PR TITLE
Add check status tasks

### DIFF
--- a/tasks/check_status.json
+++ b/tasks/check_status.json
@@ -1,0 +1,13 @@
+{
+  "description": "Get the status of a Puppet Service in JSON format",
+  "parameters": {
+    "service": {
+      "type": "Enum[all, ca, code-manager-service, file-sync-client-service,file-sync-storage-service, jruby-metrics, master,pe-jruby-metrics, pe-master, pe-puppet-profiler,puppet-profiler, status-service]",
+      "description": "What service to check. For example: 'all, status-service, pe-master, master, pe-jruby-metrics code-manager-service'"
+    }
+  },
+  "input_method": "environment",
+  "implementations": [
+    {"name": "check_status.sh"}
+  ]
+}

--- a/tasks/check_status.sh
+++ b/tasks/check_status.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# For more information about what this task can return see the API
+# https://puppet.com/docs/puppetserver/latest/status-api/v1/services.html
+# Note: if you pass in a service name you will get only the status of that 
+#       service.
+# This task is meant to be run on the puppetserver which is why localhost
+# is used as the hostname.
+service=$PT_service
+if [[ $service == 'all' ]]; then
+  out=$(curl https://localhost:8140/status/v1/services -k -s)
+else
+  out=$(curl -k -s https://localhost:8140/status/v1/services/${service})
+fi
+
+code=$?
+echo $out
+exit $code


### PR DESCRIPTION
  * It can be useful to get the status of a service or all the services
    remotely from a information only purpose.  Additionally, this task
    can also help plans figure out when a specific puppet service is
    running correctly.  This greatly helps out when trying to determine
    if a puppetserver is taking requests and not just running.

  * This task uses the puppetserver status API endpoint
    https://puppet.com/docs/puppetserver/latest/status-api/v1/services.html