### PR TITLE
Add wait function during install

### DIFF
--- a/plans/action/install.pp
+++ b/plans/action/install.pp
@@ -342,6 +342,19 @@ plan peadm::action::install (
   }
 
   run_task('peadm::puppet_runonce', $master_target)
+
+  # The puppetserver might be in the middle of a restart so we check the status by calling
+  # the api and ensuring the puppetserver is taking requests.
+  ctrl::do_until('limit' => 10) || {
+    $pe_status = run_task('peadm::check_status', $master_target, service => 'pe-master')
+    if ($pe_status.first['state'] != 'running') {
+      ctrl::sleep(5)
+      false
+    } else {
+      true
+    }
+  }
+
   run_task('peadm::puppet_runonce', $all_targets - $master_target)
 
   return("Installation of Puppet Enterprise ${arch['architecture']} succeeded.")


### PR DESCRIPTION
  * When the puppetserver has a high CPU usage normal tasks can often
    take longer than anticipated.  If the puppetserver is not
    ready for requests, the puppet runs will fail and the plan fails
    shortly after.

    This calls the check_status task to determine if the puppetserver
    is not only up but taking requests. This will help prevent unwanted
    failures. This code will sleep in 5 second increments up to a total
    of 50 seconds.  If the puppetserver hasn't calmed down by then we
    continue with the plan and let it fail during the puppet run.