### PR TITLE
Reset password during provision

### DIFF
--- a/plans/action/install.pp
+++ b/plans/action/install.pp
@@ -267,6 +267,7 @@ plan peadm::action::install (
   # master. Explicitly stop puppetdb first to avoid any systemd interference.
   run_command('systemctl stop pe-puppetdb', $master_target)
   run_command('systemctl start pe-puppetdb', $master_target)
+  run_command("/opt/puppetlabs/bin/puppet infra console_password --password ${console_password}", $master_target)
   run_task('peadm::rbac_token', $master_target,
     password => $console_password,
   )


### PR DESCRIPTION
I don't think this should be merged.  I am only submitting to start a conversation as to why this is even required when the installer should do the right thing.  Without this patch I was not able to successfully provision due to the password being different than what I supplied.

During the install step the password seems to get manged in the
process of laying down a feeder file to the pe installer.  This
commit is a hack to get around that problem, but ultimately we
should not have to do this as it could cause unwanted password
resets since upgrades might also use the install plan.