### PR TITLE
Fix incorrect task name in install plan

### DIFF
--- a/plans/action/install.pp
+++ b/plans/action/install.pp
@@ -183,22 +183,22 @@ plan peadm::action::install (
   # if a csr_attributes.yaml file is already present, the values we need are
   # merged with the existing values.
 
-  run_plan('peadm::util::insert_csr_extensions', $master_target,
-    extensions => {
+  run_plan('peadm::util::insert_csr_extension_requests', $master_target,
+    extension_requests => {
       peadm::oid('peadm_role')               => 'puppet/master',
       peadm::oid('peadm_availability_group') => 'A',
     },
   )
 
-  run_plan('peadm::util::insert_csr_extensions', $puppetdb_database_target,
-    extensions => {
+  run_plan('peadm::util::insert_csr_extension_requests', $puppetdb_database_target,
+    extension_requests => {
       peadm::oid('peadm_role')               => 'puppet/puppetdb-database',
       peadm::oid('peadm_availability_group') => 'A',
     },
   )
 
-  run_plan('peadm::util::insert_csr_extensions', $puppetdb_database_replica_target,
-    extensions => {
+  run_plan('peadm::util::insert_csr_extension_requests', $puppetdb_database_replica_target,
+    extension_requests => {
       peadm::oid('peadm_role')               => 'puppet/puppetdb-database',
       peadm::oid('peadm_availability_group') => 'B',
     },


### PR DESCRIPTION
  * previously the install plan fails because the
    insert_csr_extension was recently renamed and not updated.

    Additionally, the parameter name changed and was also updated
    in this commit which is required to complete the install.

Please verify the install.sh task usage is correct because I don't understand how it should be used.

