### PR TITLE
Pin master to PE Database group

### DIFF
--- a/manifests/setup/node_manager.pp
+++ b/manifests/setup/node_manager.pp
@@ -75,7 +75,10 @@ class peadm::setup::node_manager (
       parent               => 'PE Infrastructure',
       environment          => 'production',
       override_environment => false,
-      rule                 => ['and', ['=', ['trusted', 'extensions', peadm::oid('peadm_role')], 'puppet/puppetdb-database']],
+      rule                 => ['or',
+        ['and', ['=', ['trusted', 'extensions', peadm::oid('peadm_role')], 'puppet/puppetdb-database']],
+        ['=', 'name', $master_host],
+      ],
       classes              => {
         'puppet_enterprise::profile::database' => { },
       },


### PR DESCRIPTION
It appears that in a default install, the master is pinned to this
group.