### PR TITLE
Improve error handling of peadm::download task

### DIFF
--- a/tasks/download.sh
+++ b/tasks/download.sh
@@ -8,5 +8,6 @@ filesize=$(stat -c%s "$PT_path" 2>/dev/null)
 if [[ ! -z "$urisize" && ! -z "$filesize" && "$filesize" -eq "$urisize" ]]; then
   exit 0
 else
-  curl -L -o "$PT_path" "$PT_source"
+  printf '%s\n' "Downloading: ${PT_source}" >&2
+  curl -f -L -o "$PT_path" "$PT_source"
 fi


### PR DESCRIPTION
Prior to this commit, the `peadm::download` task would exit with
"success" when S3 returned a "404 Not Found" error page. This
would happen when a PE version was reqeusts that did not support
the OS platforms being provisioned. E.g. requesting an install of
PE 2018.1 on RedHat 8. The provisioning plan would then blow
later when `tar` found an XML document instead of a gzipped archive.

This commit updates the download task to:

  - Print the URL being downloaded to stderr.

  - Pass the `-f` flag to `curl` when downloading tarballs.
    This causes curl to exit with a status of 22 if the
    HTTP response is an error.