### PR TITLE
Revert "made print() call Py3 compliant, added checks for Py execs"

### DIFF
--- a/tasks/read_file.json
+++ b/tasks/read_file.json
@@ -7,6 +7,7 @@
     }
   },
   "implementations": [
+    {"name": "read_file.rb", "requirements": ["puppet-agent"], "input_method": "stdin"},
     {"name": "read_file.sh", "requirements": ["shell"], "input_method": "environment"}
   ]
 }

--- a/tasks/read_file.sh
+++ b/tasks/read_file.sh
@@ -1,21 +1,10 @@
 #!/bin/bash
 
 main() {
-       local python_exec=""
-
-        # check if any python exec is available on the remote system. error out if not
-        while :; do
-  	   python_exec=$(command -v python)  && break
-	   python_exec=$(command -v python3) && break
-	   python_exec=$(command -v python2) && break
-	   echo "Error: No Python version 2 or 3 interpreter found."
-	   exit 1
-        done
-
 	if [ -r "$PT_path" ]; then
 		cat <<-EOS
 			{
-				"content": $(${python_exec} -c "import json; print(json.dumps(open('$PT_path','r').read()))")
+				"content": $(python_cmd -c "import json; print json.dumps(open('$PT_path','r').read())")
 			}
 		EOS
 	else
@@ -25,8 +14,17 @@ main() {
 				"error": "File does not exist or is not readable"
 			}
 		EOS
-		exit 1
+	fi
+}
+
+python_cmd() {
+	if command -v python >/dev/null 2>&1; then
+		python "$@"
+	else
+		python3 "$@"
 	fi
 }
 
 main "$@"
+exit_code=$?
+exit $exit_code


### PR DESCRIPTION
The commit that I am reverting causes hard failures in newly deployed infrastructure via https://github.com/puppetlabs/puppetlabs-autope on GCP with CentOS 7. My suspicion is the addition of `exit 1` upon detection that the file did exist, this fails the plan immediately but previously allowed to run to completion.