### PR TITLE
Add direct download option for PE installers

### DIFF
--- a/documentation/provision.md
+++ b/documentation/provision.md
@@ -103,6 +103,10 @@ The content needed is the PE installation tarball for the target version. The in
 
 Installation content can be downloaded from [https://puppet.com/try-puppet/puppet-enterprise/download/](https://puppet.com/try-puppet/puppet-enterprise/download/).
 
+## Online usage
+
+The peadm::provision plan can be configured to download installation content directly to hosts. To configure online installation, set the `download_mode` parameter of the `peadm::provision` plan to `direct`. The direct mode is often more efficient when PE hosts have a route to the internet.
+
 ## Hostnames and Certificate Names
 
 The various host parameters given to the peadm::provision or peadm::action::install plans will be set as Puppet certificate names. You must use the names here that you want the servers to be identified as by Puppet.

--- a/documentation/upgrade.md
+++ b/documentation/upgrade.md
@@ -40,6 +40,10 @@ The content needed is the PE installation tarball for the target version. The in
 
 Installation content can be downloaded from [https://puppet.com/try-puppet/puppet-enterprise/download/](https://puppet.com/try-puppet/puppet-enterprise/download/).
 
+## Online usage
+
+The peadm::provision plan can be configured to download installation content directly to hosts. To configure online installation, set the `download_mode` parameter of the `peadm::provision` plan to `direct`. The direct mode is often more efficient when PE hosts have a route to the internet.
+
 ## Usage over the Orchestrator transport
 
 The peadm::upgrade plan can be used with the Orchestrator (pcp) transport, provided that the Bolt executor is running as root on the master. To use the Orchestrator transport prepare an inventory file such as the following to set the default transport to be `pcp`, but the master specifically to be `local`.

--- a/plans/provision.pp
+++ b/plans/provision.pp
@@ -32,7 +32,8 @@ plan peadm::provision (
   Optional[String]                  $license_key_content = undef,
 
   # Other
-  Optional[String]                  $stagingdir = undef,
+  Optional[String]                  $stagingdir    = undef,
+  Enum[direct,bolthost]             $download_mode = 'bolthost',
 ) {
 
   $install_result = run_plan('peadm::action::install',
@@ -64,6 +65,7 @@ plan peadm::provision (
 
     # Other
     stagingdir                     => $stagingdir,
+    download_mode                  => $download_mode,
   )
 
   $configure_result = run_plan('peadm::action::configure',


### PR DESCRIPTION
This commit adds a new download_mode parameter to the peadm::provision
and peadm::upgrade plans. The default value for the parameter is
bolthost, which causes PE installation content to be downloaded to the
stagingdir of the workstation running bolt and then uploaded to the
PE hosts. Setting download_mode to direct causes PE installation content
to be downloaded directly to the PE hosts. The direct mode skips uploads,
which offers a significant speed boost when the PE hosts have a route to
the internet and the bolt host is connected by a slow link, such as VPN.