### PR TITLE
#106 fix permissions on the key files

### DIFF
--- a/plans/action/install.pp
+++ b/plans/action/install.pp
@@ -247,7 +247,7 @@ plan peadm::action::install (
       $master_replica_target,
     ]),
       path    => '/etc/puppetlabs/puppetserver/ssh/id-control_repo.rsa',
-      mode    => '0400',
+      mode    => '0600',
       content => $r10k_private_key,
     )
   }
@@ -258,7 +258,7 @@ plan peadm::action::install (
       $master_replica_target,
     ]),
       path    => '/etc/puppetlabs/license.key',
-      mode    => '0400',
+      mode    => '0644',
       content => $license_key,
     )
   }


### PR DESCRIPTION
puppet-enterprise-installer sets ownership to pe-puppet and mode to 0600 for the r10k private key, but does not manage the license key
change permissions, so pe-puppet can access license key during catalog compilation