### PR TITLE
use 'mono' topology for standard DR infrastructure

### DIFF
--- a/plans/action/configure.pp
+++ b/plans/action/configure.pp
@@ -74,10 +74,16 @@ plan peadm::action::configure (
   }
 
   if $arch['high-availability'] {
+    $topology =  $arch['architecture']? {
+      'standard' => 'mono',
+      default    => 'mono-with-compile',
+    }
+
     # Run the PE Replica Provision
     run_task('peadm::provision_replica', $master_target,
       master_replica => $master_replica_target.peadm::target_name(),
       token_file     => $token_file,
+      topology       => $topology,
 
       # Race condition, where the provision command checks PuppetDB status and
       # probably gets "starting", but fails out because that's not "running".

--- a/tasks/provision_replica.json
+++ b/tasks/provision_replica.json
@@ -5,6 +5,11 @@
       "type": "String",
       "description": "The name of the replica to provision"
     },
+    "topology": {
+      "type": "String",
+      "description": "The topology of PE installation",
+      "default": "mono-with-compile"
+    },
     "token_file": {
       "type": "Optional[String]",
       "description": "The name of the token-file for auth"

--- a/tasks/provision_replica.sh
+++ b/tasks/provision_replica.sh
@@ -10,14 +10,19 @@ else
   export TOKEN_FILE="$PT_token_file"
 fi
 
+if [ "$PT_topology" = "mono" ] ; then
+  AGENT_CONFIG=""
+else
+  AGENT_CONFIG="--skip-agent-config"
+fi
 
 set -e
 
 if [ "$PT_legacy" = "false" ]; then
   puppet infrastructure provision replica "$PT_master_replica" \
     --yes --token-file "$TOKEN_FILE" \
-    --skip-agent-config \
-    --topology mono-with-compile \
+    $AGENT_CONFIG \
+    --topology "$PT_topology" \
     --enable
 
 elif [ "$PT_legacy" = "true" ]; then
@@ -26,8 +31,8 @@ elif [ "$PT_legacy" = "true" ]; then
 
   puppet infrastructure enable replica "$PT_master_replica" \
     --yes --token-file "$TOKEN_FILE" \
-    --skip-agent-config \
-    --topology mono-with-compile
+    $AGENT_CONFIG \
+    --topology "$PT_topology"
 
 else
   exit 1


### PR DESCRIPTION
In standard DR configuration agents need to be configured to use failover capabilities

By the way, I haven't had issues with provisioning and enabling replica in one command, maybe 'legacy' flag can be retired ?
