### PR TITLE
Add service module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,7 @@
 fixtures:
   forge_modules:
     ruby_task_helper: "puppetlabs/ruby_task_helper"
+    service: "puppetlabs/service"
   repositories:
     facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
     puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# PEADM module
+
+## Unreleased
+- add service module as a dependency
+
 ## Release 2.1.1
 ### Summary
 

--- a/metadata.json
+++ b/metadata.json
@@ -27,6 +27,10 @@
     {
       "name": "puppet/format",
       "version_requirement": ">= 0.1.0 < 1.0.0"
+    },
+    {
+      "name": "puppetlabs/service",
+      "version_requirement": ">= 1.3.0 < 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
  * The bolt gem does ship with the service module and the upgrade
    plan requires the service module to be present.  If the user is
    using the bolt package, the service module ships with it already
    and so does the official docker image.

  * This adds the service module as a requirement to metadata and
    to fixtures.