### PR TITLE
Set ha_enabled_replicas to an empty array for compilers

### DIFF
--- a/manifests/setup/node_manager.pp
+++ b/manifests/setup/node_manager.pp
@@ -92,7 +92,6 @@ class peadm::setup::node_manager (
   node_group { 'PE Compiler Group A':
     ensure  => 'present',
     parent  => 'PE Compiler',
-    data    => { },
     rule    => ['and',
       ['=', ['trusted', 'extensions', 'pp_auth_role'], 'pe_compiler'],
       ['=', ['trusted', 'extensions', peadm::oid('peadm_availability_group')], 'A'],
@@ -105,6 +104,12 @@ class peadm::setup::node_manager (
         'puppetdb_host' => ['${trusted[\'certname\']}', $master_replica_host].filter |$_| { $_ }, # lint:ignore:single_quote_string_with_variables
         'puppetdb_port' => [8081],
       }
+    },
+    data    => {
+      # Workaround for GH-118
+      'puppet_enterprise::profile::master::puppetdb' => {
+        'ha_enabled_replicas' => [ ],
+      },
     },
   }
 
@@ -144,7 +149,6 @@ class peadm::setup::node_manager (
     node_group { 'PE Compiler Group B':
       ensure  => 'present',
       parent  => 'PE Compiler',
-      data    => { },
       rule    => ['and',
         ['=', ['trusted', 'extensions', 'pp_auth_role'], 'pe_compiler'],
         ['=', ['trusted', 'extensions', peadm::oid('peadm_availability_group')], 'B'],
@@ -157,6 +161,12 @@ class peadm::setup::node_manager (
           'puppetdb_host' => ['${trusted[\'certname\']}', $master_host], # lint:ignore:single_quote_string_with_variables
           'puppetdb_port' => [8081],
         }
+      },
+      data    => {
+        # Workaround for GH-118
+        'puppet_enterprise::profile::master::puppetdb' => {
+          'ha_enabled_replicas' => [ ],
+        },
       },
     }
   }


### PR DESCRIPTION
Set ha_enabled_replicas to an empty array for compilers only. We are already supplying the specific certnames that compilers' PuppetDB terminus configuration should use.

Fixes #118 