### PR TITLE
Add compiler_pool_{a,b}_address parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 Documentation and README update
 
+### Features
+
+- Added parameters to configure compiler pool addresses for the A and B availability groups. These are used in large and extra large architectures.
+
+### Bugfixes
+
+- Fixed GH-118, wherein a compiler would unnecessarily send duplicate work to an extra configured PuppetDB endpoint.
+
 ### Improvements
 
 - Provide a useful overview of the module in the README so that readers can quickly gain a sense of how the module is used, what it affects, and what it does not affect.

--- a/plans/action/configure.pp
+++ b/plans/action/configure.pp
@@ -1,5 +1,17 @@
 # @summary Configure first-time classification and HA setup
 #
+# @param compiler_pool_address 
+#   The service address used by agents to connect to compilers, or the Puppet
+#   service. Typically this is a load balancer.
+# @param internal_compiler_a_pool_address
+#   A load balancer address directing traffic to any of the "A" pool
+#   compilers. This is used for DR/HA configuration in large and extra large
+#   architectures.
+# @param internal_compiler_b_pool_address
+#   A load balancer address directing traffic to any of the "B" pool
+#   compilers. This is used for DR/HA configuration in large and extra large
+#   architectures.
+#
 plan peadm::action::configure (
   # Standard
   Peadm::SingleTargetSpec           $master_host,
@@ -14,6 +26,8 @@ plan peadm::action::configure (
 
   # Common Configuration
   String           $compiler_pool_address = $master_host,
+  Optional[String] $internal_compiler_a_pool_address = undef,
+  Optional[String] $compiler_pool_b_address = undef,
   Optional[String] $token_file = undef,
   Optional[String] $deploy_environment = undef,
 
@@ -64,12 +78,14 @@ plan peadm::action::configure (
     }
 
     class { 'peadm::setup::node_manager':
-      master_host                    => $master_target.peadm::target_name(),
-      master_replica_host            => $master_replica_target.peadm::target_name(),
-      puppetdb_database_host         => $puppetdb_database_target.peadm::target_name(),
-      puppetdb_database_replica_host => $puppetdb_database_replica_target.peadm::target_name(),
-      compiler_pool_address          => $compiler_pool_address,
-      require                        => Class['peadm::setup::node_manager_yaml'],
+      master_host                      => $master_target.peadm::target_name(),
+      master_replica_host              => $master_replica_target.peadm::target_name(),
+      puppetdb_database_host           => $puppetdb_database_target.peadm::target_name(),
+      puppetdb_database_replica_host   => $puppetdb_database_replica_target.peadm::target_name(),
+      compiler_pool_address            => $compiler_pool_address,
+      internal_compiler_a_pool_address => $internal_compiler_a_pool_address,
+      internal_compiler_b_pool_address => $internal_compiler_b_pool_address,
+      require                          => Class['peadm::setup::node_manager_yaml'],
     }
   }
 

--- a/plans/provision.pp
+++ b/plans/provision.pp
@@ -2,6 +2,18 @@
 #   Puppet Enterprise Extra Large cluster.  This plan accepts all parameters
 #   used by its sub-plans, and invokes them in order.
 #
+# @param compiler_pool_address 
+#   The service address used by agents to connect to compilers, or the Puppet
+#   service. Typically this is a load balancer.
+# @param internal_compiler_a_pool_address
+#   A load balancer address directing traffic to any of the "A" pool
+#   compilers. This is used for DR/HA configuration in large and extra large
+#   architectures.
+# @param internal_compiler_b_pool_address
+#   A load balancer address directing traffic to any of the "B" pool
+#   compilers. This is used for DR/HA configuration in large and extra large
+#   architectures.
+#
 plan peadm::provision (
   # Standard
   Peadm::SingleTargetSpec           $master_host,
@@ -16,10 +28,12 @@ plan peadm::provision (
 
   # Common Configuration
   String                            $console_password,
-  String                            $version               = '2019.7.0',
-  Optional[Array[String]]           $dns_alt_names         = undef,
-  Optional[String]                  $compiler_pool_address = undef,
-  Optional[Hash]                    $pe_conf_data          = { },
+  String                            $version                          = '2019.8.1',
+  Optional[Array[String]]           $dns_alt_names                    = undef,
+  Optional[String]                  $compiler_pool_address            = undef,
+  Optional[String]                  $internal_compiler_a_pool_address = undef,
+  Optional[String]                  $internal_compiler_b_pool_address = undef,
+  Optional[Hash]                    $pe_conf_data                     = { },
 
   # Code Manager
   Optional[String]                  $r10k_remote              = undef,
@@ -71,22 +85,24 @@ plan peadm::provision (
 
   $configure_result = run_plan('peadm::action::configure',
     # Standard
-    master_host                    => $master_host,
-    master_replica_host            => $master_replica_host,
+    master_host                      => $master_host,
+    master_replica_host              => $master_replica_host,
 
     # Large
-    compiler_hosts                 => $compiler_hosts,
+    compiler_hosts                   => $compiler_hosts,
 
     # Extra Large
-    puppetdb_database_host         => $puppetdb_database_host,
-    puppetdb_database_replica_host => $puppetdb_database_replica_host,
+    puppetdb_database_host           => $puppetdb_database_host,
+    puppetdb_database_replica_host   => $puppetdb_database_replica_host,
 
     # Common Configuration
-    compiler_pool_address          => $compiler_pool_address,
-    deploy_environment             => $deploy_environment,
+    compiler_pool_address            => $compiler_pool_address,
+    internal_compiler_a_pool_address => $internal_compiler_a_pool_address,
+    internal_compiler_b_pool_address => $internal_compiler_b_pool_address,
+    deploy_environment               => $deploy_environment,
 
     # Other
-    stagingdir                     => $stagingdir,
+    stagingdir                       => $stagingdir,
   )
 
   # Return a string banner reporting on what was done

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -1,5 +1,17 @@
 # @summary Upgrade an Extra Large stack from one .z to the next
 #
+# @param compiler_pool_address 
+#   The service address used by agents to connect to compilers, or the Puppet
+#   service. Typically this is a load balancer.
+# @param internal_compiler_a_pool_address
+#   A load balancer address directing traffic to any of the "A" pool
+#   compilers. This is used for DR/HA configuration in large and extra large
+#   architectures.
+# @param internal_compiler_b_pool_address
+#   A load balancer address directing traffic to any of the "B" pool
+#   compilers. This is used for DR/HA configuration in large and extra large
+#   architectures.
+#
 plan peadm::upgrade (
   # Standard
   Peadm::SingleTargetSpec           $master_host,
@@ -13,7 +25,10 @@ plan peadm::upgrade (
   Optional[Peadm::SingleTargetSpec] $puppetdb_database_replica_host = undef,
 
   # Common Configuration
-  String $version,
+  String           $version,
+  Optional[String] $compiler_pool_address            = undef,
+  Optional[String] $internal_compiler_a_pool_address = undef,
+  Optional[String] $internal_compiler_b_pool_address = undef,
 
   # Other
   Optional[String]      $token_file    = undef,
@@ -177,11 +192,14 @@ plan peadm::upgrade (
     }
 
     class { 'peadm::setup::node_manager':
-      master_host                    => $master_target.peadm::target_name(),
-      master_replica_host            => $master_replica_target.peadm::target_name(),
-      puppetdb_database_host         => $puppetdb_database_target.peadm::target_name(),
-      puppetdb_database_replica_host => $puppetdb_database_replica_target.peadm::target_name(),
-      require                        => Class['peadm::setup::node_manager_yaml'],
+      master_host                      => $master_target.peadm::target_name(),
+      master_replica_host              => $master_replica_target.peadm::target_name(),
+      puppetdb_database_host           => $puppetdb_database_target.peadm::target_name(),
+      puppetdb_database_replica_host   => $puppetdb_database_replica_target.peadm::target_name(),
+      compiler_pool_address            => $compiler_pool_address,
+      internal_compiler_a_pool_address => $internal_compiler_a_pool_address,
+      internal_compiler_b_pool_address => $internal_compiler_b_pool_address,
+      require                          => Class['peadm::setup::node_manager_yaml'],
     }
   }
 


### PR DESCRIPTION
These are necessary to fully configure large and extra large architectures.