### PR TITLE
Eliminate convert configure_node_groups param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Documentation and README update
 ### Improvements
 
 - Provide a useful overview of the module in the README so that readers can quickly gain a sense of how the module is used, what it affects, and what it does not affect.
+- Eliminate `configure_node_groups` parameter to peadm::convert. Perform the correct action(s) automatically.
 
 ## Release 2.1.1
 ### Summary

--- a/functions/oid.pp
+++ b/functions/oid.pp
@@ -6,6 +6,7 @@ function peadm::oid (
     'peadm_availability_group': { '1.3.6.1.4.1.34380.1.1.9813' }
     'pp_application': { '1.3.6.1.4.1.34380.1.1.8' }
     'pp_cluster': { '1.3.6.1.4.1.34380.1.1.16' }
+    'pp_role': { '1.3.6.1.4.1.34380.1.1.13' }
     'pp_auth_role': { '1.3.6.1.4.1.34380.1.3.13' }
     default: { fail("No peadm OID for ${short_name}") }
   }

--- a/manifests/setup/convert_pre20197.pp
+++ b/manifests/setup/convert_pre20197.pp
@@ -1,6 +1,6 @@
 # @summary Defines configuration needed for converting PE 2018
 #
-class peadm::setup::convert_pe2018 {
+class peadm::setup::convert_pre20197 {
 
   # This is needed so that compiler certs can be signed. It's included by
   # default in 2019.7 and newer, but isn't present in 2018.1. It would be

--- a/plans/convert.pp
+++ b/plans/convert.pp
@@ -11,11 +11,10 @@ plan peadm::convert (
   Optional[Peadm::SingleTargetSpec] $puppetdb_database_replica_host = undef,
 
   # Common Configuration
-  String                            $compiler_pool_address = $master_host,
-  Array[String]                     $dns_alt_names         = [ ],
-
-  # Options
-  Boolean                           $configure_node_groups = true,
+  String                            $compiler_pool_address            = $master_host,
+  Optional[String]                  $internal_compiler_a_pool_address = undef,
+  Optional[String]                  $internal_compiler_b_pool_address = undef,
+  Array[String]                     $dns_alt_names                    = [ ],
 ) {
   # TODO: read and validate convertable PE version
 
@@ -43,16 +42,32 @@ plan peadm::convert (
     $compiler_hosts,
   )
 
+  # Get trusted fact information for all compilers. Use peadm::target_name() as
+  # the hash key because the apply block below will break trying to parse the
+  # $compiler_extensions variable if it has Target-type hash keys.
+  $cert_extensions = run_task('peadm::trusted_facts', $all_targets).reduce({}) |$memo,$result| {
+    $memo + { $result.target.peadm::target_name() => $result['extensions'] }
+  }
+
   # Know what version of PE the current targets are
   $pe_version = run_task('peadm::read_file', $master_target,
     path => '/opt/puppetlabs/server/pe_version',
   )[0][content].chomp
 
-  # Get trusted fact information for all compilers. Use peadm::target_name() as
-  # the hash key because the apply block below will break trying to parse the
-  # $compiler_extensions variable if it has Target-type hash keys.
-  $compiler_extensions = run_task('peadm::trusted_facts', $compiler_targets).reduce({}) |$memo,$result| {
-    $memo + { $result.target.peadm::target_name() => $result['extensions'] }
+  # Figure out if this PE deployment has been configured with peadm or pe_xl
+  # before
+  $previously_configured_by_peadm = $all_targets.any |$target| {
+    $exts = $cert_extensions[$target.peadm::target_name()]
+    $exts[peadm::oid('peadm_role')] or String($exts[peadm::oid('pp_role')]) =~ /pe_xl|peadm/
+  }
+
+  if (!$previously_configured_by_peadm and (versioncmp($pe_version, '2019.7.0') > 0)) {
+    fail_plan(@("EOL"/L))
+      PE deployment cannot be converted! PE deployment must be a deployment \
+      created by pe_xl, by an older version of peadm, or be PE version \
+      2019.7.0 or newer. Detected PE version ${pe_version}, and did not detect \
+      signs that the deployment was previously created by peadm/pe_xl.
+      | EOL
   }
 
   # Clusters A and B are used to divide PuppetDB availability for compilers. If
@@ -60,14 +75,14 @@ plan peadm::convert (
   # them A or B, use that. Otherwise, divide them by modulus of 2.
   if $arch['high-availability'] {
     $compiler_a_targets = $compiler_targets.filter |$index,$target| {
-      $exts = $compiler_extensions[$target.peadm::target_name()]
+      $exts = $cert_extensions[$target.peadm::target_name()]
       $exts[peadm::oid('peadm_availability_group')] in ['A', 'B'] ? {
         true  => $exts[peadm::oid('peadm_availability_group')] == 'A',
         false => $index % 2 == 0,
       }
     }
     $compiler_b_targets = $compiler_targets.filter |$index,$target| {
-      $exts = $compiler_extensions[$target.peadm::target_name()]
+      $exts = $cert_extensions[$target.peadm::target_name()]
       $exts[peadm::oid('peadm_availability_group')] in ['A', 'B'] ? {
         true  => $exts[peadm::oid('peadm_availability_group')] == 'B',
         false => $index % 2 != 0,
@@ -79,9 +94,10 @@ plan peadm::convert (
     $compiler_b_targets = []
   }
 
-  if $pe_version =~ /^2018/ {
+  # If PE version is older than 2019.7
+  if (versioncmp($pe_version, '2019.7.0') < 0) {
     apply($master_target) {
-      include peadm::setup::convert_pe2018
+      include peadm::setup::convert_pre20197
     }
   }
 
@@ -146,23 +162,34 @@ plan peadm::convert (
     },
   )
 
-  # Create the necessary node groups in the console
-
-  if $configure_node_groups {
+  # Create the necessary node groups in the console, unless the PE version is
+  # too old to support it pre-upgrade. In that circumstance, we trust that
+  # the existing groups are correct enough to function until the upgrade is
+  # performed.
+  if (versioncmp($pe_version, '2019.7.0') >= 0) {
     apply($master_target) {
       class { 'peadm::setup::node_manager_yaml':
         master_host => $master_target.peadm::target_name(),
       }
 
       class { 'peadm::setup::node_manager':
-        master_host                    => $master_target.peadm::target_name(),
-        master_replica_host            => $master_replica_target.peadm::target_name(),
-        puppetdb_database_host         => $puppetdb_database_target.peadm::target_name(),
-        puppetdb_database_replica_host => $puppetdb_database_replica_target.peadm::target_name(),
-        compiler_pool_address          => $compiler_pool_address,
-        require                        => Class['peadm::setup::node_manager_yaml'],
+        master_host                      => $master_target.peadm::target_name(),
+        master_replica_host              => $master_replica_target.peadm::target_name(),
+        puppetdb_database_host           => $puppetdb_database_target.peadm::target_name(),
+        puppetdb_database_replica_host   => $puppetdb_database_replica_target.peadm::target_name(),
+        compiler_pool_address            => $compiler_pool_address,
+        internal_compiler_a_pool_address => $internal_compiler_a_pool_address,
+        internal_compiler_b_pool_address => $internal_compiler_b_pool_address,
+        require                          => Class['peadm::setup::node_manager_yaml'],
       }
     }
+  }
+  else {
+    out::message(@("EOL"/L))
+      NOTICE: Node groups not created/updated as part of convert because PE \
+      version is too old to support them. Node groups will be updated when \
+      the peadm::upgrade plan is run.
+      | EOL
   }
 
   # Run Puppet on all targets to ensure catalogs and exported resources fully


### PR DESCRIPTION
Previously, the user would need to specify the `configure_node_groups`
parameter when running the convert plan. In some circumstances failing
to pass the right value would break the convert operation.

This commit adds computed default values for this parameter so that the
user does not need to pass it.