### PR TITLE
Bug fixes to convert

### DIFF
--- a/plans/convert.pp
+++ b/plans/convert.pp
@@ -76,16 +76,26 @@ plan peadm::convert (
   if $arch['high-availability'] {
     $compiler_a_targets = $compiler_targets.filter |$index,$target| {
       $exts = $cert_extensions[$target.peadm::target_name()]
-      $exts[peadm::oid('peadm_availability_group')] in ['A', 'B'] ? {
-        true  => $exts[peadm::oid('peadm_availability_group')] == 'A',
-        false => $index % 2 == 0,
+      if ($exts[peadm::oid('peadm_availability_group')] in ['A', 'B']) {
+        $exts[peadm::oid('peadm_availability_group')] == 'A'
+      }
+      elsif ($exts[peadm::oid('pp_cluster')] in ['A', 'B']) {
+        $exts[peadm::oid('pp_cluster')] == 'A'
+      }
+      else {
+        $index % 2 == 0
       }
     }
     $compiler_b_targets = $compiler_targets.filter |$index,$target| {
       $exts = $cert_extensions[$target.peadm::target_name()]
-      $exts[peadm::oid('peadm_availability_group')] in ['A', 'B'] ? {
-        true  => $exts[peadm::oid('peadm_availability_group')] == 'B',
-        false => $index % 2 != 0,
+      if ($exts[peadm::oid('peadm_availability_group')] in ['A', 'B']) {
+        $exts[peadm::oid('peadm_availability_group')] == 'B'
+      }
+      elsif ($exts[peadm::oid('pp_cluster')] in ['A', 'B']) {
+        $exts[peadm::oid('pp_cluster')] == 'B'
+      }
+      else {
+        $index % 2 != 0
       }
     }
   }

--- a/plans/convert.pp
+++ b/plans/convert.pp
@@ -203,8 +203,10 @@ plan peadm::convert (
   }
 
   # Run Puppet on all targets to ensure catalogs and exported resources fully
-  # up-to-date
-  run_task('peadm::puppet_runonce', $all_targets)
+  # up-to-date. Run on master first in case puppet server restarts, 'cause
+  # that would cause the runs to fail on all the rest.
+  run_task('peadm::puppet_runonce', $master_target)
+  run_task('peadm::puppet_runonce', $all_targets - $master_target)
 
   return("Conversion to peadm Puppet Enterprise ${arch['architecture']} succeeded.")
 }

--- a/plans/util/add_cert_extensions.pp
+++ b/plans/util/add_cert_extensions.pp
@@ -44,18 +44,19 @@ plan peadm::util::add_cert_extensions (
     # This will be the new trusted fact data for this node
     $extension_requests = $certdata[$target]['extensions'] + $extensions
 
-    # Make sure the csr_attributes.yaml file on the node matches
-    run_plan('peadm::util::insert_csr_extension_requests', $target,
-      extension_requests => $extension_requests,
-      merge              => false,
-    )
-
     # Everything starts the same; we always stop the agent and revoke the
     # existing cert. We use `run_command` in case the master is 2019.x but
     # the agent is only 2018.x. In that scenario `run_task(service, ...)`
     # doesn't work.
     $was_running = run_command('systemctl is-active puppet.service', $target, _catch_errors => true)[0].ok
     if ($was_running) { run_command('systemctl stop puppet.service', $target) }
+
+    # Make sure the csr_attributes.yaml file on the node matches
+    run_plan('peadm::util::insert_csr_extension_requests', $target,
+      extension_requests => $extension_requests,
+      merge              => false,
+    )
+
     run_command("${pserver} ca clean --certname ${certname}", $master_target)
 
     # Then things get crazy...


### PR DESCRIPTION
Two things.

1. Stop the puppet agent _before_ writing the csr_attributes.yaml file. This is to avoid a situation where the Puppet agent might delete or alter the file before a cert request is made.
2. Check for either the peadm availability group OID, OR use of the pp_cluster OID to identify nodes in A and B availability groups before falling back to simple even/odd indexing.