### PR TITLE
Don't re-issue certs if they have required exts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # PEADM module
 
+## Unreleased
+### Summary
+
+Readme updates and further convert plan efficiency improvements
+
+### Features
+
+- In the peadm::convert plan, certificates which already contain requested extensions will not be re-issued. This will accelerate the convert process, or allow re-runs of the convert process to move more quickly.
+
+### Improvements
+
+- The README now provides more detailed information on how customers using the peadm module should go about getting support for it.
+
 ## 2.3.0
 ### Summary
 

--- a/plans/convert.pp
+++ b/plans/convert.pp
@@ -177,9 +177,8 @@ plan peadm::convert (
   peadm::plan_step('convert-compilers-a') || {
     run_plan('peadm::util::add_cert_extensions', $compiler_a_targets,
       master_host => $master_target,
-      remove      => ['1.3.6.1.4.1.34380.1.3.13'], # OID form of pp_auth_role
       extensions  => {
-        'pp_auth_role'                         => 'pe_compiler',
+        peadm::oid('pp_auth_role')             => 'pe_compiler',
         peadm::oid('peadm_availability_group') => 'A',
       },
     )
@@ -188,9 +187,8 @@ plan peadm::convert (
   peadm::plan_step('convert-compilers-b') || {
     run_plan('peadm::util::add_cert_extensions', $compiler_b_targets,
       master_host => $master_target,
-      remove      => ['1.3.6.1.4.1.34380.1.3.13'], # OID form of pp_auth_role
       extensions  => {
-        'pp_auth_role'                         => 'pe_compiler',
+        peadm::oid('pp_auth_role')             => 'pe_compiler',
         peadm::oid('peadm_availability_group') => 'B',
       },
     )
@@ -236,5 +234,5 @@ plan peadm::convert (
     run_task('peadm::puppet_runonce', $all_targets - $master_target)
   }
 
-  return("Conversion to peadm Puppet Enterprise ${arch['architecture']} succeeded.")
+  return("Conversion to peadm Puppet Enterprise ${arch['architecture']} completed.")
 }


### PR DESCRIPTION
Basically, don't do work that isn't necessary. This commit changes how shortname/OID conflicts are handled for the pp_auth_role extension by just standardizing on always specifying OID, for now.