### PR TITLE
Make puppet_runonce exit non-zero on resrc failure

### DIFF
--- a/tasks/puppet_runonce.sh
+++ b/tasks/puppet_runonce.sh
@@ -24,4 +24,15 @@ echo
   --no-usecacheonfailure \
   --no-splay \
   --no-use_cached_catalog \
+  --detailed-exitcodes \
   $NOOP_FLAG
+
+# Without --detailed-exitcodes, the `puppet agent` command will return 0 even
+# if there are resource failures. Use --detailed-exitcodes but only exit
+# non-zero if an error occurred. Changes (code 2) are not errors.
+exitcode=$?
+if [ $exitcode -eq 0 -o $exitcode -eq 2 ]; then
+  exit 0
+else
+  exit $exitcode
+fi


### PR DESCRIPTION
If a Puppet agent run is unable to complete cleanly, that should be reported as a problem so the plan(s) can stop or deal with it.