### PR TITLE
Fix a problem with Peadm::SingleTargetSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Bugfix release
 ### Bugfixes
 
 * Fix an issue in the convert plan incorrectly disallowing conversion of deployments newer than 2019.7.0.
+* Fix a problem with the Peadm::SingleTargetSpec type alias.
 
 ## 2.4.4
 ### Summary

--- a/types/singletargetspec.pp
+++ b/types/singletargetspec.pp
@@ -6,5 +6,5 @@
 type Peadm::SingleTargetSpec = Variant[
   Pattern[/\A[^[:space:],]+\z/],
   Target,
-  Array[Boltlib::SingleTargetSpec, 1, 1]
+  Array[Peadm::SingleTargetSpec, 1, 1]
 ]


### PR DESCRIPTION
For more than a year this type has included in its definition a
reference to Boltlib::SingleTargetSpec. That type doesn't exist; this
should have been a recursive reference to Peadm::SingleTargetSpec this
whole time. Not sure why it ever worked.