### PR TITLE
Add bolt_version function and use it in plans

### DIFF
--- a/functions/check_bolt_version.pp
+++ b/functions/check_bolt_version.pp
@@ -1,0 +1,19 @@
+# Checks if the current Bolt version matches the SemVerRange defined in $supported_bolt_version
+# Fails the calling plan if false, does nothing if true.
+# Accepts a parameter for the $supported_bolt_version for unit testing purposes
+function peadm::check_bolt_version(
+  $supported_bolt_version = '>= 2.42.0 < 3.0.0'
+) {
+  $supported = (peadm::bolt_version() =~ SemVerRange($supported_bolt_version))
+
+  unless $supported {
+    fail(@("REASON"/L))
+      This version of puppetlabs-peadm requires Bolt version ${supported_bolt_version}.
+      
+      You are using Bolt version ${peadm::bolt_version()}.
+      
+      Please make sure you have a compatible Bolt version and try again.
+
+      | REASON
+  }
+}

--- a/lib/puppet/functions/peadm/bolt_version.rb
+++ b/lib/puppet/functions/peadm/bolt_version.rb
@@ -1,0 +1,8 @@
+require 'bolt'
+
+Puppet::Functions.create_function(:'peadm::bolt_version') do
+  def bolt_version
+    Bolt::VERSION
+  end
+end
+

--- a/plans/convert.pp
+++ b/plans/convert.pp
@@ -26,6 +26,8 @@ plan peadm::convert (
     'convert-node-groups',
     'finalize']] $begin_at_step = undef,
 ) {
+  peadm::check_bolt_version()
+
   # TODO: read and validate convertable PE version
 
   # Convert inputs into targets.

--- a/plans/provision.pp
+++ b/plans/provision.pp
@@ -49,6 +49,8 @@ plan peadm::provision (
   Optional[String]                  $stagingdir    = undef,
   Enum[direct,bolthost]             $download_mode = 'bolthost',
 ) {
+  peadm::check_bolt_version()
+
   peadm::validate_version($version)
 
   $install_result = run_plan('peadm::action::install',

--- a/plans/status.pp
+++ b/plans/status.pp
@@ -14,6 +14,8 @@ plan peadm::status(
   Boolean $summarize = true,
   Boolean $colors = $format ? { json => false, default => true }
 ) {
+  peadm::check_bolt_version()
+
   $results = run_task('peadm::infrastatus', $targets, { format => 'json'})
   # returns the data in a hash 
   $stack_status = $results.reduce({}) | $res, $item | {

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -43,6 +43,8 @@ plan peadm::upgrade (
     'upgrade-replica-compilers',
     'finalize']] $begin_at_step = undef,
 ) {
+  peadm::check_bolt_version()
+
   peadm::validate_version($version)
 
   # Ensure input valid for a supported architecture

--- a/spec/functions/bolt_version_spec.rb
+++ b/spec/functions/bolt_version_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bolt'
+
+describe 'peadm::bolt_version' do
+
+  it 'should_return_bolt_version' do
+    is_expected.to run.and_return(Bolt::VERSION)
+  end
+
+end


### PR DESCRIPTION
- added the function `bolt_version` returning the current Bolt version
- added the function `check_bolt_version` comparing the current Bolt version with the one supported by peadm
- added the call to `check_bolt_version` to all plans