### PR TITLE
Adds testing for validate_version

### DIFF
--- a/functions/validate_version.pp
+++ b/functions/validate_version.pp
@@ -1,6 +1,8 @@
+# @return [Boolean] true if the version is supported, raise error otherwise
+# @param [String] the version number to check
 function peadm::validate_version(
   String $version,
-) {
+) >> Boolean {
   $supported = ($version =~ SemVerRange('>= 2019.7.0 <= 2019.9.0'))
 
   unless $supported {
@@ -15,4 +17,5 @@ function peadm::validate_version(
 
       | REASON
   }
+  $supported
 }

--- a/spec/functions/validate_version_spec.rb
+++ b/spec/functions/validate_version_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe 'peadm::validate_version' do
+  it '2020.3.0' do
+    is_expected.to run.with_params('2020.3.0').and_raise_error(Puppet::ParseError, /This\ version\ of\ the/)
+  end
+
+  it '2019.9.0' do
+    is_expected.to run.with_params('2019.9.0').and_return(true)
+  end
+
+  it '2019.8.4' do
+    is_expected.to run.with_params('2019.8.4').and_return(true)
+  end
+
+  it '2019.8.0' do
+    is_expected.to run.with_params('2019.8.0').and_return(true)
+  end
+
+  it '2019.7.1' do
+    is_expected.to run.with_params('2019.7.1').and_return(true)
+  end
+
+  it '2018.1' do
+    is_expected.to run.with_params('2018.1').and_raise_error(Puppet::ParseError, /This\ version\ of\ the/)
+  end
+end


### PR DESCRIPTION
  * Previously there was not any unit tests for
    validate_version function.  Additionally, the function
    was updated to return a Boolean unless the unsupported
    version is identified.  This return value, while not used
    in plans helps with unit testing.