### PR TITLE
Ensure locales are set to en_US.UTF-8 for install

### DIFF
--- a/tasks/pe_install.sh
+++ b/tasks/pe_install.sh
@@ -20,6 +20,10 @@ pedir=$(tar -tf "$PT_tarball" | head -n 1 | xargs dirname)
 
 tar -C "$tgzdir" -xzf "$PT_tarball"
 
+export LANG=en_US.UTF-8
+export LANGUAGE=en_US.UTF-8
+export LC_ALL=en_US.UTF-8
+
 if [ ! -z "$PT_peconf" ]; then
 	/bin/bash "${tgzdir}/${pedir}/puppet-enterprise-installer" -y -c "$PT_peconf"
 else


### PR DESCRIPTION
This prevent the following installation error when the source Bolt host runs a non-US locale:
`failed to call refresh: invalid byte sequence in US-ASCII`