### PR TITLE
PE 2021.0 support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM puppet/pdk:latest
+
+# [Optional] Uncomment this section to install additional packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/puppet
+{
+	"name": "Puppet Development Kit (Community)",
+	"dockerFile": "Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"puppet.puppet-vscode",
+		"rebornix.Ruby"
+	]
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "pdk --version",
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
 .git/
-.modules
-.resource_types
-bolt-debug.log
 .*.sw[op]
 .metadata
 .yardoc
@@ -29,6 +26,8 @@ bolt-debug.log
 .envrc
 /inventory.yaml
 .rerun.json
-.plan_cache.json
 *.tar.gz
-Puppetfile
+.modules/
+.plan_cache.json
+.resource_types/
+bolt-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,6 @@ bolt-debug.log
 .envrc
 /inventory.yaml
 .rerun.json
+.plan_cache.json
 *.tar.gz
 Puppetfile

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,20 +3,21 @@ stages:
   - syntax
   - unit
 
-cache:
-  paths:
-    - vendor/bundle
+default:
+  cache:
+    paths:
+      - vendor/bundle
 
-before_script:
-  - bundle -v
-  - rm Gemfile.lock || true
-  - "# Update system gems if requested. This is useful to temporarily workaround troubles in the test runner"
-  - "# Set `rubygems_version` in the .sync.yml to set a value"
-  - "# Ignore exit code of SIGPIPE'd yes to not fail with shell's pipefail set"
-  - '[ -z "$RUBYGEMS_VERSION" ] || (yes || true) | gem update --system $RUBYGEMS_VERSION'
-  - gem --version
-  - bundle -v
-  - bundle install --without system_tests --path vendor/bundle --jobs $(nproc)
+  before_script: &before_script
+    - bundle -v
+    - rm Gemfile.lock || true
+    - "# Update system gems if requested. This is useful to temporarily workaround troubles in the test runner"
+    - "# Set `rubygems_version` in the .sync.yml to set a value"
+    - "# Ignore exit code of SIGPIPE'd yes to not fail with shell's pipefail set"
+    - '[ -z "$RUBYGEMS_VERSION" ] || (yes || true) | gem update --system $RUBYGEMS_VERSION'
+    - gem --version
+    - bundle -v
+    - bundle install --without system_tests --path vendor/bundle --jobs $(nproc)
 
 syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop-Ruby 2.5.7-Puppet ~> 6:
   stage: syntax
@@ -33,12 +34,4 @@ parallel_spec-Ruby 2.5.7-Puppet ~> 6:
     - bundle exec rake parallel_spec
   variables:
     PUPPET_GEM_VERSION: '~> 6'
-
-parallel_spec-Ruby 2.4.5-Puppet ~> 5:
-  stage: unit
-  image: ruby:2.4.5
-  script:
-    - bundle exec rake parallel_spec
-  variables:
-    PUPPET_GEM_VERSION: '~> 5'
 

--- a/.pdkignore
+++ b/.pdkignore
@@ -32,6 +32,7 @@
 /.gitignore
 /.gitlab-ci.yml
 /.pdkignore
+/.puppet-lint.rc
 /Rakefile
 /rakelib/
 /.rspec
@@ -40,3 +41,4 @@
 /.yardopts
 /spec/
 /.vscode/
+/.sync.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,12 +1,12 @@
 ---
 require:
+- rubocop-performance
 - rubocop-rspec
-- rubocop-i18n
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: '2.1'
+  TargetRubyVersion: '2.4'
   Include:
-  - "./**/*.rb"
+  - "**/*.rb"
   Exclude:
   - bin/*
   - ".vendor/**/*"
@@ -18,16 +18,9 @@ AllCops:
   - "**/Puppetfile"
   - "**/Vagrantfile"
   - "**/Guardfile"
-Metrics/LineLength:
+Layout/LineLength:
   Description: People have wide screens, use them.
   Max: 200
-GetText:
-  Enabled: false
-GetText/DecorateString:
-  Description: We don't want to decorate test output.
-  Exclude:
-  - spec/**/*
-  Enabled: false
 RSpec/BeforeAfterAll:
   Description: Beware of using after(:all) as it may cause state to leak between tests.
     A necessary evil in acceptance testing.
@@ -36,14 +29,13 @@ RSpec/BeforeAfterAll:
 RSpec/HookArgument:
   Description: Prefer explicit :each argument, matching existing module's style
   EnforcedStyle: each
+RSpec/DescribeSymbol:
+  Exclude:
+  - spec/unit/facter/**/*.rb
 Style/BlockDelimiters:
   Description: Prefer braces for chaining. Mostly an aesthetical choice. Better to
     be consistent then.
   EnforcedStyle: braces_for_chaining
-Style/BracesAroundHashParameters:
-  Description: Braces are required by Ruby 2.7. Cop removed from RuboCop v0.80.0.
-    See https://github.com/rubocop-hq/rubocop/pull/7643
-  Enabled: true
 Style/ClassAndModuleChildren:
   Description: Compact style reduces the required amount of indentation.
   EnforcedStyle: compact
@@ -72,7 +64,7 @@ Style/TrailingCommaInArguments:
   Description: Prefer always trailing comma on multiline argument lists. This makes
     diffs, and re-ordering nicer.
   EnforcedStyleForMultiline: comma
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
   Description: Prefer always trailing comma on multiline literals. This makes diffs,
     and re-ordering nicer.
   EnforcedStyleForMultiline: comma
@@ -87,25 +79,169 @@ Style/Documentation:
   - spec/**/*
 Style/WordArray:
   EnforcedStyle: brackets
+Performance/AncestorsInclude:
+  Enabled: true
+Performance/BigDecimalWithNumericArgument:
+  Enabled: true
+Performance/BlockGivenWithExplicitBlock:
+  Enabled: true
+Performance/CaseWhenSplat:
+  Enabled: true
+Performance/ConstantRegexp:
+  Enabled: true
+Performance/MethodObjectAsBlock:
+  Enabled: true
+Performance/RedundantSortBlock:
+  Enabled: true
+Performance/RedundantStringChars:
+  Enabled: true
+Performance/ReverseFirst:
+  Enabled: true
+Performance/SortReverse:
+  Enabled: true
+Performance/Squeeze:
+  Enabled: true
+Performance/StringInclude:
+  Enabled: true
+Performance/Sum:
+  Enabled: true
 Style/CollectionMethods:
   Enabled: true
 Style/MethodCalledOnDoEndBlock:
   Enabled: true
 Style/StringMethods:
   Enabled: true
-GetText/DecorateFunctionMessage:
+Bundler/InsecureProtocolSource:
   Enabled: false
-GetText/DecorateStringFormattingUsingInterpolation:
+Gemspec/DuplicatedAssignment:
   Enabled: false
-GetText/DecorateStringFormattingUsingPercent:
+Gemspec/OrderedDependencies:
+  Enabled: false
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+Gemspec/RubyVersionGlobalsUsage:
+  Enabled: false
+Layout/ArgumentAlignment:
+  Enabled: false
+Layout/BeginEndAlignment:
+  Enabled: false
+Layout/ClosingHeredocIndentation:
+  Enabled: false
+Layout/EmptyComment:
+  Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+Layout/EmptyLinesAroundArguments:
+  Enabled: false
+Layout/EmptyLinesAroundAttributeAccessor:
   Enabled: false
 Layout/EndOfLine:
   Enabled: false
-Layout/IndentHeredoc:
+Layout/FirstArgumentIndentation:
+  Enabled: false
+Layout/HashAlignment:
+  Enabled: false
+Layout/HeredocIndentation:
+  Enabled: false
+Layout/LeadingEmptyLines:
+  Enabled: false
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: false
+Layout/SpaceInsideArrayLiteralBrackets:
+  Enabled: false
+Layout/SpaceInsideReferenceBrackets:
+  Enabled: false
+Lint/BigDecimalNew:
+  Enabled: false
+Lint/BooleanSymbol:
+  Enabled: false
+Lint/ConstantDefinitionInBlock:
+  Enabled: false
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: false
+Lint/DisjunctiveAssignmentInConstructor:
+  Enabled: false
+Lint/DuplicateElsifCondition:
+  Enabled: false
+Lint/DuplicateRequire:
+  Enabled: false
+Lint/DuplicateRescueException:
+  Enabled: false
+Lint/EmptyConditionalBody:
+  Enabled: false
+Lint/EmptyFile:
+  Enabled: false
+Lint/ErbNewArguments:
+  Enabled: false
+Lint/FloatComparison:
+  Enabled: false
+Lint/HashCompareByIdentity:
+  Enabled: false
+Lint/IdentityComparison:
+  Enabled: false
+Lint/InterpolationCheck:
+  Enabled: false
+Lint/MissingCopEnableDirective:
+  Enabled: false
+Lint/MixedRegexpCaptureTypes:
+  Enabled: false
+Lint/NestedPercentLiteral:
+  Enabled: false
+Lint/NonDeterministicRequireOrder:
+  Enabled: false
+Lint/OrderedMagicComments:
+  Enabled: false
+Lint/OutOfRangeRegexpRef:
+  Enabled: false
+Lint/RaiseException:
+  Enabled: false
+Lint/RedundantCopEnableDirective:
+  Enabled: false
+Lint/RedundantRequireStatement:
+  Enabled: false
+Lint/RedundantSafeNavigation:
+  Enabled: false
+Lint/RedundantWithIndex:
+  Enabled: false
+Lint/RedundantWithObject:
+  Enabled: false
+Lint/RegexpAsCondition:
+  Enabled: false
+Lint/ReturnInVoidContext:
+  Enabled: false
+Lint/SafeNavigationConsistency:
+  Enabled: false
+Lint/SafeNavigationWithEmpty:
+  Enabled: false
+Lint/SelfAssignment:
+  Enabled: false
+Lint/SendWithMixinArgument:
+  Enabled: false
+Lint/ShadowedArgument:
+  Enabled: false
+Lint/StructNewOverride:
+  Enabled: false
+Lint/ToJSON:
+  Enabled: false
+Lint/TopLevelReturnWithArgument:
+  Enabled: false
+Lint/TrailingCommaInAttributeDeclaration:
+  Enabled: false
+Lint/UnreachableLoop:
+  Enabled: false
+Lint/UriEscapeUnescape:
+  Enabled: false
+Lint/UriRegexp:
+  Enabled: false
+Lint/UselessMethodDefinition:
+  Enabled: false
+Lint/UselessTimes:
   Enabled: false
 Metrics/AbcSize:
   Enabled: false
 Metrics/BlockLength:
+  Enabled: false
+Metrics/BlockNesting:
   Enabled: false
 Metrics/ClassLength:
   Enabled: false
@@ -119,19 +255,265 @@ Metrics/ParameterLists:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
+Migration/DepartmentName:
+  Enabled: false
+Naming/AccessorMethodName:
+  Enabled: false
+Naming/BlockParameterName:
+  Enabled: false
+Naming/HeredocDelimiterCase:
+  Enabled: false
+Naming/HeredocDelimiterNaming:
+  Enabled: false
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+Naming/MethodParameterName:
+  Enabled: false
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
+Naming/VariableNumber:
+  Enabled: false
+Performance/BindCall:
+  Enabled: false
+Performance/DeletePrefix:
+  Enabled: false
+Performance/DeleteSuffix:
+  Enabled: false
+Performance/InefficientHashSearch:
+  Enabled: false
+Performance/UnfreezeString:
+  Enabled: false
+Performance/UriDefaultParser:
+  Enabled: false
+RSpec/Be:
+  Enabled: false
+RSpec/Capybara/CurrentPathExpectation:
+  Enabled: false
+RSpec/Capybara/FeatureMethods:
+  Enabled: false
+RSpec/Capybara/VisibilityMatcher:
+  Enabled: false
+RSpec/ContextMethod:
+  Enabled: false
+RSpec/ContextWording:
+  Enabled: false
 RSpec/DescribeClass:
+  Enabled: false
+RSpec/EmptyHook:
+  Enabled: false
+RSpec/EmptyLineAfterExample:
+  Enabled: false
+RSpec/EmptyLineAfterExampleGroup:
+  Enabled: false
+RSpec/EmptyLineAfterHook:
   Enabled: false
 RSpec/ExampleLength:
   Enabled: false
-RSpec/MessageExpectation:
+RSpec/ExampleWithoutDescription:
+  Enabled: false
+RSpec/ExpectChange:
+  Enabled: false
+RSpec/ExpectInHook:
+  Enabled: false
+RSpec/FactoryBot/AttributeDefinedStatically:
+  Enabled: false
+RSpec/FactoryBot/CreateList:
+  Enabled: false
+RSpec/FactoryBot/FactoryClassName:
+  Enabled: false
+RSpec/HooksBeforeExamples:
+  Enabled: false
+RSpec/ImplicitBlockExpectation:
+  Enabled: false
+RSpec/ImplicitSubject:
+  Enabled: false
+RSpec/LeakyConstantDeclaration:
+  Enabled: false
+RSpec/LetBeforeExamples:
+  Enabled: false
+RSpec/MissingExampleGroupArgument:
   Enabled: false
 RSpec/MultipleExpectations:
   Enabled: false
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+RSpec/MultipleSubjects:
+  Enabled: false
 RSpec/NestedGroups:
+  Enabled: false
+RSpec/PredicateMatcher:
+  Enabled: false
+RSpec/ReceiveCounts:
+  Enabled: false
+RSpec/ReceiveNever:
+  Enabled: false
+RSpec/RepeatedExampleGroupBody:
+  Enabled: false
+RSpec/RepeatedExampleGroupDescription:
+  Enabled: false
+RSpec/RepeatedIncludeExample:
+  Enabled: false
+RSpec/ReturnFromStub:
+  Enabled: false
+RSpec/SharedExamples:
+  Enabled: false
+RSpec/StubbedMock:
+  Enabled: false
+RSpec/UnspecifiedException:
+  Enabled: false
+RSpec/VariableDefinition:
+  Enabled: false
+RSpec/VoidExpect:
+  Enabled: false
+RSpec/Yield:
+  Enabled: false
+Security/Open:
+  Enabled: false
+Style/AccessModifierDeclarations:
+  Enabled: false
+Style/AccessorGrouping:
   Enabled: false
 Style/AsciiComments:
   Enabled: false
+Style/BisectedAttrAccessor:
+  Enabled: false
+Style/CaseLikeIf:
+  Enabled: false
+Style/ClassEqualityComparison:
+  Enabled: false
+Style/ColonMethodDefinition:
+  Enabled: false
+Style/CombinableLoops:
+  Enabled: false
+Style/CommentedKeyword:
+  Enabled: false
+Style/Dir:
+  Enabled: false
+Style/DoubleCopDisableDirective:
+  Enabled: false
+Style/EmptyBlockParameter:
+  Enabled: false
+Style/EmptyLambdaParameter:
+  Enabled: false
+Style/Encoding:
+  Enabled: false
+Style/EvalWithLocation:
+  Enabled: false
+Style/ExpandPathArguments:
+  Enabled: false
+Style/ExplicitBlockArgument:
+  Enabled: false
+Style/ExponentialNotation:
+  Enabled: false
+Style/FloatDivision:
+  Enabled: false
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/GlobalStdStream:
+  Enabled: false
+Style/HashAsLastArrayItem:
+  Enabled: false
+Style/HashLikeCase:
+  Enabled: false
+Style/HashTransformKeys:
+  Enabled: false
+Style/HashTransformValues:
+  Enabled: false
 Style/IfUnlessModifier:
   Enabled: false
+Style/KeywordParametersOrder:
+  Enabled: false
+Style/MinMax:
+  Enabled: false
+Style/MixinUsage:
+  Enabled: false
+Style/MultilineWhenThen:
+  Enabled: false
+Style/NegatedUnless:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/OptionalBooleanParameter:
+  Enabled: false
+Style/OrAssignment:
+  Enabled: false
+Style/RandomWithOffset:
+  Enabled: false
+Style/RedundantAssignment:
+  Enabled: false
+Style/RedundantCondition:
+  Enabled: false
+Style/RedundantConditional:
+  Enabled: false
+Style/RedundantFetchBlock:
+  Enabled: false
+Style/RedundantFileExtensionInRequire:
+  Enabled: false
+Style/RedundantRegexpCharacterClass:
+  Enabled: false
+Style/RedundantRegexpEscape:
+  Enabled: false
+Style/RedundantSelfAssignment:
+  Enabled: false
+Style/RedundantSort:
+  Enabled: false
+Style/RescueStandardError:
+  Enabled: false
+Style/SingleArgumentDig:
+  Enabled: false
+Style/SlicingWithRange:
+  Enabled: false
+Style/SoleNestedConditional:
+  Enabled: false
+Style/StderrPuts:
+  Enabled: false
+Style/StringConcatenation:
+  Enabled: false
+Style/Strip:
+  Enabled: false
 Style/SymbolProc:
+  Enabled: false
+Style/TrailingBodyOnClass:
+  Enabled: false
+Style/TrailingBodyOnMethodDefinition:
+  Enabled: false
+Style/TrailingBodyOnModule:
+  Enabled: false
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+Style/TrailingMethodEndStatement:
+  Enabled: false
+Style/UnpackFirst:
+  Enabled: false
+Lint/DuplicateBranch:
+  Enabled: false
+Lint/DuplicateRegexpCharacterClassElement:
+  Enabled: false
+Lint/EmptyBlock:
+  Enabled: false
+Lint/EmptyClass:
+  Enabled: false
+Lint/NoReturnInBeginEndBlocks:
+  Enabled: false
+Lint/ToEnumArguments:
+  Enabled: false
+Lint/UnexpectedBlockArity:
+  Enabled: false
+Lint/UnmodifiedReduceAccumulator:
+  Enabled: false
+Performance/CollectionLiteralInLoop:
+  Enabled: false
+Style/ArgumentsForwarding:
+  Enabled: false
+Style/CollectionCompact:
+  Enabled: false
+Style/DocumentDynamicEvalDefinition:
+  Enabled: false
+Style/NegatedIfElseCondition:
+  Enabled: false
+Style/NilLambda:
+  Enabled: false
+Style/RedundantArgument:
+  Enabled: false
+Style/SwapValues:
   Enabled: false

--- a/.sync.yml
+++ b/.sync.yml
@@ -20,3 +20,7 @@ spec/spec_helper.rb:
   paths:
     - '.rerun.json'
     - '*.tar.gz'
+    - '.modules/'
+    - '.plan_cache.json'
+    - '.resource_types/'
+    - 'bolt-debug.log'

--- a/.sync.yml
+++ b/.sync.yml
@@ -4,6 +4,8 @@ Gemfile:
     ':development':
       - gem: 'puppet-debugger'
         version: '>= 0.18.0'
+      - gem: 'bolt'
+        version: '>= 2.42.0'
   optional:
     ':development':
       - gem: 'github_changelog_generator'

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,6 @@ jobs:
       env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop syntax lint metadata_lint"
       stage: static
     -
-      env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
-      rvm: 2.4.5
-      stage: spec
-    -
       env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
       rvm: 2.5.7
       stage: spec
@@ -43,7 +39,7 @@ jobs:
       stage: deploy
 branches:
   only:
-    - master
+    - main
     - /^v\d/
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 
 ### Improvements
 
+- Support PE 2021.0
 - Handle exit code 11 from replica upgrade task gracefully. Code 11 means "PuppetDB sync in progress but not yet complete".
 - Further remediate the bug fixed in 2.4.2, by ensuring that all peadm-managed node groups preserve existing data or class parameters not explicitly being managed. This is accomplished by requiring a new version of WhatsARanjit-node\_manager, v0.7.4.
+- Switch dependency enumeration from in-project Puppetfile to bolt-project.yaml modules setting
 
 ## 2.4.5
 ### Summary

--- a/Gemfile
+++ b/Gemfile
@@ -17,19 +17,19 @@ ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
 minor_version = ruby_version_segments[0..1].join('.')
 
 group :development do
-  gem "fast_gettext", '1.1.0',                                   require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
-  gem "fast_gettext",                                            require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
-  gem "json_pure", '<= 2.0.1',                                   require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
-  gem "json", '= 1.8.1',                                         require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
   gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "rb-readline", '= 0.5.5',                                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-posix-default-r#{minor_version}", '~> 0.4', require: false, platforms: [:ruby]
-  gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.4',     require: false, platforms: [:ruby]
-  gem "puppet-module-win-default-r#{minor_version}", '~> 0.4',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-win-dev-r#{minor_version}", '~> 0.4',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "json", '= 2.3.0',                                         require: false if Gem::Requirement.create(['>= 2.7.0', '< 2.8.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "puppet-module-posix-default-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
+  gem "puppet-module-posix-dev-r#{minor_version}", '~> 1.0',     require: false, platforms: [:ruby]
+  gem "puppet-module-win-default-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-debugger", '>= 0.18.0',                            require: false
   gem "github_changelog_generator",                              require: false, git: 'https://github.com/skywinder/github-changelog-generator', ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')
+end
+group :system_tests do
+  gem "puppet-module-posix-system-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
+  gem "puppet-module-win-system-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :development do
   gem "puppet-module-win-default-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-debugger", '>= 0.18.0',                            require: false
+  gem "bolt", '>= 2.42.0',                                       require: false
   gem "github_changelog_generator",                              require: false, git: 'https://github.com/skywinder/github-changelog-generator', ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')
 end
 group :system_tests do

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ The normal usage pattern for peadm is as follows.
 
 ### Requirements
 
-* Puppet Enterprise 2019.8.1 or newer (tested with PE 2019.8.1)
-* Bolt 2.27.0 or newer (tested with Bolt 2.27.0)
+* Puppet Enterprise 2019.8.1 or newer (tested with PE 2021.0)
+* Bolt 2.27.0 or newer (tested with Bolt 3.0.1)
 * EL 7, EL 8, Ubuntu 18.04, or Ubuntu 20.04
 * Classifier Data enabled. This PE feature is enabled by default on new installs, but can be disabled by users if they remove the relevant configuration from their global hiera.yaml file. See the [PE docs](https://puppet.com/docs/pe/latest/config_console.html#task-5039) for more information.
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'bundler'
 require 'puppet_litmus/rake_tasks' if Bundler.rubygems.find_name('puppet_litmus').any?
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'
@@ -53,7 +54,7 @@ if Bundler.rubygems.find_name('github_changelog_generator').any?
     config.header = "# Change log\n\nAll notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org)."
     config.add_pr_wo_labels = true
     config.issues = false
-    config.merge_prefix = "### UNCATEGORIZED PRS; GO LABEL THEM"
+    config.merge_prefix = "### UNCATEGORIZED PRS; LABEL THEM ON GITHUB"
     config.configure_sections = {
       "Changed" => {
         "prefix" => "### Changed",
@@ -61,11 +62,11 @@ if Bundler.rubygems.find_name('github_changelog_generator').any?
       },
       "Added" => {
         "prefix" => "### Added",
-        "labels" => ["feature", "enhancement"],
+        "labels" => ["enhancement", "feature"],
       },
       "Fixed" => {
         "prefix" => "### Fixed",
-        "labels" => ["bugfix"],
+        "labels" => ["bug", "documentation", "bugfix"],
       },
     }
   end
@@ -73,16 +74,15 @@ else
   desc 'Generate a Changelog from GitHub'
   task :changelog do
     raise <<EOM
-The changelog tasks depends on unreleased features of the github_changelog_generator gem.
+The changelog tasks depends on recent features of the github_changelog_generator gem.
 Please manually add it to your .sync.yml for now, and run `pdk update`:
 ---
 Gemfile:
   optional:
     ':development':
       - gem: 'github_changelog_generator'
-        git: 'https://github.com/skywinder/github-changelog-generator'
-        ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')"
+        version: '~> 1.15'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"
 EOM
   end
 end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 version: 1.1.x.{build}
 branches:
   only:
-    - master
+    - main
     - release
 skip_commits:
   message: /^\(?doc\)?.*/
@@ -16,16 +16,8 @@ init:
 environment:
   matrix:
     -
-      RUBY_VERSION: 24-x64
+      RUBY_VERSION: 25-x64
       CHECK: syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
-    -
-      PUPPET_GEM_VERSION: ~> 5.0
-      RUBY_VERSION: 24
-      CHECK: parallel_spec
-    -
-      PUPPET_GEM_VERSION: ~> 5.0
-      RUBY_VERSION: 24-x64
-      CHECK: parallel_spec
     -
       PUPPET_GEM_VERSION: ~> 6.0
       RUBY_VERSION: 25

--- a/functions/check_bolt_version.pp
+++ b/functions/check_bolt_version.pp
@@ -2,16 +2,16 @@
 # Fails the calling plan if false, does nothing if true.
 # Accepts a parameter for the $supported_bolt_version for unit testing purposes
 function peadm::check_bolt_version(
-  $supported_bolt_version = '>= 2.42.0 < 3.0.0'
+  $supported_bolt_version = '>= 2.42.0 < 4.0.0'
 ) {
   $supported = (peadm::bolt_version() =~ SemVerRange($supported_bolt_version))
 
   unless $supported {
     fail(@("REASON"/L))
       This version of puppetlabs-peadm requires Bolt version ${supported_bolt_version}.
-      
+
       You are using Bolt version ${peadm::bolt_version()}.
-      
+
       Please make sure you have a compatible Bolt version and try again.
 
       | REASON

--- a/functions/validate_version.pp
+++ b/functions/validate_version.pp
@@ -3,7 +3,7 @@
 function peadm::validate_version(
   String $version,
 ) >> Boolean {
-  $supported = ($version =~ SemVerRange('>= 2019.7.0 <= 2019.9.0'))
+  $supported = ($version =~ SemVerRange('>= 2019.7.0 <= 2021.0.0'))
 
   unless $supported {
     fail(@("REASON"/L))
@@ -12,7 +12,7 @@ function peadm::validate_version(
       For PE versions older than 2019.7, please use version 1.x of the \
       puppetlabs-peadm module.
 
-      For PE versions newer than 2019.8, check to see if a new version of peadm \
+      For PE versions newer than 2021.0, check to see if a new version of peadm \
       exists which supports that version of PE.
 
       | REASON

--- a/lib/puppet/functions/peadm/bolt_version.rb
+++ b/lib/puppet/functions/peadm/bolt_version.rb
@@ -5,4 +5,3 @@ Puppet::Functions.create_function(:'peadm::bolt_version') do
     Bolt::VERSION
   end
 end
-

--- a/metadata.json
+++ b/metadata.json
@@ -62,7 +62,7 @@
       "version_requirement": ">= 6.0.2 < 7.0.0"
     }
   ],
-  "pdk-version": "1.18.1",
-  "template-url": "https://github.com/puppetlabs/pdk-templates.git#1.18.0",
-  "template-ref": "tags/1.18.0-0-g095317c"
+  "pdk-version": "2.0.0",
+  "template-url": "https://github.com/puppetlabs/pdk-templates.git#2.0.0",
+  "template-ref": "tags/2.0.0-0-ge838f1d"
 }

--- a/spec/functions/bolt_version_spec.rb
+++ b/spec/functions/bolt_version_spec.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'bolt'
 
 describe 'peadm::bolt_version' do
-
   it 'should_return_bolt_version' do
-    is_expected.to run.and_return(Bolt::VERSION)
+    stub_const('Bolt::VERSION', '2.45.0')
+    is_expected.to run.and_return('2.45.0')
   end
-
 end

--- a/spec/functions/validate_version_spec.rb
+++ b/spec/functions/validate_version_spec.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'peadm::validate_version' do
   context 'invalid PE versions' do
     it 'rejects PE versions that are too new' do
-      is_expected.to run.with_params('2021.1.0').and_raise_error(Puppet::ParseError, /This\ version\ of\ the/)
+      is_expected.to run.with_params('2021.1.0').and_raise_error(Puppet::ParseError, %r{This\ version\ of\ the})
     end
 
     it 'rejects PE versions that are too old' do
-      is_expected.to run.with_params('2018.1.9').and_raise_error(Puppet::ParseError, /This\ version\ of\ the/)
+      is_expected.to run.with_params('2018.1.9').and_raise_error(Puppet::ParseError, %r{This\ version\ of\ the})
     end
   end
 

--- a/spec/functions/validate_version_spec.rb
+++ b/spec/functions/validate_version_spec.rb
@@ -2,27 +2,27 @@
 require 'spec_helper'
 
 describe 'peadm::validate_version' do
-  it '2020.3.0' do
-    is_expected.to run.with_params('2020.3.0').and_raise_error(Puppet::ParseError, /This\ version\ of\ the/)
+  context 'invalid PE versions' do
+    it 'rejects PE versions that are too new' do
+      is_expected.to run.with_params('2021.1.0').and_raise_error(Puppet::ParseError, /This\ version\ of\ the/)
+    end
+
+    it 'rejects PE versions that are too old' do
+      is_expected.to run.with_params('2018.1.9').and_raise_error(Puppet::ParseError, /This\ version\ of\ the/)
+    end
   end
 
-  it '2019.9.0' do
-    is_expected.to run.with_params('2019.9.0').and_return(true)
-  end
+  context 'valid PE versions' do
+    it 'accepts the minimum supported version' do
+      is_expected.to run.with_params('2019.7.0').and_return(true)
+    end
 
-  it '2019.8.4' do
-    is_expected.to run.with_params('2019.8.4').and_return(true)
-  end
+    it 'accepts the newest supported version number' do
+      is_expected.to run.with_params('2021.0.0').and_return(true)
+    end
 
-  it '2019.8.0' do
-    is_expected.to run.with_params('2019.8.0').and_return(true)
-  end
-
-  it '2019.7.1' do
-    is_expected.to run.with_params('2019.7.1').and_return(true)
-  end
-
-  it '2018.1' do
-    is_expected.to run.with_params('2018.1').and_raise_error(Puppet::ParseError, /This\ version\ of\ the/)
+    it 'accepts a version in the middle' do
+      is_expected.to run.with_params('2019.8.4').and_return(true)
+    end
   end
 end

--- a/spec/plans/status_spec.rb
+++ b/spec/plans/status_spec.rb
@@ -1,9 +1,19 @@
 # frozen_string_literal: true
 
+# rubocop:disable RSpec/BeforeAfterAll
+
 require 'spec_helper'
 # https://github.com/puppetlabs/bolt/blob/master/lib/bolt_spec/plans.rb
 
-describe 'peadm::status', if: Gem::Version.new(Puppet.version) >= Gem::Version.new('6.0.0') do
+describe 'peadm::status' do
+  # Include the BoltSpec library functions
+  include BoltSpec::Plans
+
+  # Configure Puppet and Bolt before running any tests
+  before(:all) do
+    BoltSpec::Plans.init
+  end
+
   let(:infrastatus) do
     data = JSON.parse(File.read(File.expand_path(File.join(fixtures, 'infrastatus.json'))))
     { 'output' => data }

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,38 +1,14 @@
 # frozen_string_literal: true
 
-require 'puppet'
+# Load the BoltSpec library
+require 'bolt_spec/plans'
+
+# Include the BoltSpec library functions
+include BoltSpec::Plans
+
+# Configure Puppet and Bolt for testing
+BoltSpec::Plans.init
 
 # This environment variable can be read by Ruby Bolt tasks to prevent unwanted
 # auto-execution, enabling easy unit testing.
-ENV["RSPEC_UNIT_TEST_MODE"] ||= "TRUE"
-
-if Gem::Version.new(Puppet.version) >= Gem::Version.new('6.0.0')
-  begin
-    require 'bolt_spec/plans'
-    BoltSpec::Plans.init
-
-    # Seems to be needed to make `run_plan` available inside examples:
-    RSpec.configure { |c| c.include BoltSpec::Plans }
-  rescue LoadError => e
-    warn e.message
-    warn '=== bolt tests will not run; ensure bolt gem is installed (requires Puppet 6+)'
-  end
-end
-
-# Bolt has some hidden puppet modules inside the bolt codebase that need to be added here
-# for proper testing and availablity with other tooling.  The code below will
-# locate the bolt gem dir and create fixtures for each of the bolt modules.
-
-spec = Gem::Specification.latest_specs.find { |s| s.name.eql?('bolt') }
-if spec
-  bolt_modules = File.join(spec.full_gem_path, 'bolt-modules')
-  Dir.glob(File.join(bolt_modules, '*')).each do |dir|
-    mod_name = File.basename(dir)
-    mod_path = File.expand_path(File.join(__dir__, 'fixtures', 'modules', mod_name))
-    FileUtils.ln_sf(dir, mod_path) unless File.exist?(mod_path)
-  end
-
-  RSpec.configure do |c|
-    c.basemodulepath = bolt_modules
-  end
-end
+ENV['RSPEC_UNIT_TEST_MODE'] ||= 'TRUE'

--- a/spec/unit/task/puppet_infra_upgrade_spec.rb
+++ b/spec/unit/task/puppet_infra_upgrade_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require_relative '../../../tasks/puppet_infra_upgrade'
 
-describe PEAdm::Task::PuppetInfraUpgrade do
+describe PuppetInfraUpgrade do
   context 'replica' do
     let(:upgrade) do
       described_class.new('type' => 'replica',
@@ -10,8 +10,8 @@ describe PEAdm::Task::PuppetInfraUpgrade do
     end
 
     it 'Returns when the command exits with an expected code' do
-      status_dbl_0 = double('Status', :exitstatus => 0)
-      status_dbl_11 = double('Status', :exitstatus => 11)
+      status_dbl_0 = instance_double(Process::Status, exitstatus: 0)
+      status_dbl_11 = instance_double(Process::Status, exitstatus: 11)
       allow(STDOUT).to receive(:puts)
       allow(upgrade).to receive(:wait_until_connected)
 
@@ -23,7 +23,7 @@ describe PEAdm::Task::PuppetInfraUpgrade do
     end
 
     it 'Exits non-zero when the command exits with an unexpected code' do
-      status_dbl_1 = double('Status', :exitstatus => 1)
+      status_dbl_1 = instance_double('Process::Status', exitstatus: 1)
       allow(STDOUT).to receive(:puts)
       allow(upgrade).to receive(:wait_until_connected)
       allow(Open3).to receive(:capture2e).and_return(['hello world', status_dbl_1])
@@ -33,11 +33,12 @@ describe PEAdm::Task::PuppetInfraUpgrade do
     end
   end
 
-  context 'compiler' do
-    let(:upgrade) do
-      described_class.new('type' => 'compiler',
-                          'targets' => ['replica.example.com'],
-                          'wait_until_connected_timeout' => 120)
-    end
-  end
+  # TESTS NOT IMPLEMENTED
+  # context 'compiler' do
+  #   let(:upgrade) do
+  #     described_class.new('type' => 'compiler',
+  #                         'targets' => ['compiler.example.com'],
+  #                         'wait_until_connected_timeout' => 120)
+  #   end
+  # end
 end

--- a/tasks/puppet_infra_upgrade.rb
+++ b/tasks/puppet_infra_upgrade.rb
@@ -8,86 +8,83 @@ require 'open3'
 require 'timeout'
 require 'etc'
 
-class PEAdm
-  class Task
-    class PuppetInfraUpgrade
-      def initialize(params)
-        @type       = params['type']
-        @targets    = params['targets']
-        @timeout    = params['wait_until_connected_timeout']
-        @token_file = params['token_file']
-      end
+# Class to run and execute the `puppet infra upgrade` command as a task.
+class PuppetInfraUpgrade
+  def initialize(params)
+    @type       = params['type']
+    @targets    = params['targets']
+    @timeout    = params['wait_until_connected_timeout']
+    @token_file = params['token_file']
+  end
 
-      def execute!
-        exit 0 if @targets.empty?
-        token_file = @token_file || File.join(Etc.getpwuid.dir, '.puppetlabs', 'token')
+  def execute!
+    exit 0 if @targets.empty?
+    token_file = @token_file || File.join(Etc.getpwuid.dir, '.puppetlabs', 'token')
 
-        cmd = ['/opt/puppetlabs/bin/puppet-infrastructure', '--render-as', 'json', 'upgrade']
-        cmd << '--token-file' << token_file unless @token_file.nil?
-        cmd << @type << @targets.join(',')
+    cmd = ['/opt/puppetlabs/bin/puppet-infrastructure', '--render-as', 'json', 'upgrade']
+    cmd << '--token-file' << token_file unless @token_file.nil?
+    cmd << @type << @targets.join(',')
 
-        wait_until_connected(nodes: @targets, token_file: token_file, timeout: @timeout)
+    wait_until_connected(nodes: @targets, token_file: token_file, timeout: @timeout)
 
-        stdouterr, status = Open3.capture2e(*cmd)
-        STDOUT.puts stdouterr
+    stdouterr, status = Open3.capture2e(*cmd)
+    STDOUT.puts stdouterr
 
-        # Exit code 11 indicates PuppetDB sync in progress, just not yet
-        # finished. We consider that success.
-        if [0, 11].include?(status.exitstatus)
-          return
-        else
-          exit status.exitstatus
+    # Exit code 11 indicates PuppetDB sync in progress, just not yet
+    # finished. We consider that success.
+    if [0, 11].include?(status.exitstatus)
+      nil
+    else
+      exit status.exitstatus
+    end
+  end
+
+  def inventory_uri
+    @inventory_uri ||= URI.parse('https://localhost:8143/orchestrator/v1/inventory')
+  end
+
+  def request_object(nodes:, token_file:)
+    token = File.read(token_file)
+    body = {
+      'nodes' => nodes,
+    }.to_json
+
+    request = Net::HTTP::Post.new(inventory_uri.request_uri)
+    request['Content-Type'] = 'application/json'
+    request['X-Authentication'] = token
+    request.body = body
+
+    request
+  end
+
+  def http_object
+    http = Net::HTTP.new(inventory_uri.host, inventory_uri.port)
+    http.use_ssl = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+    http
+  end
+
+  def wait_until_connected(nodes:, token_file:, timeout: 120)
+    http = http_object
+    request = request_object(nodes: nodes, token_file: token_file)
+    inventory = {}
+    Timeout.timeout(timeout) do
+      loop do
+        response = http.request(request)
+        unless response.is_a? Net::HTTPSuccess
+          raise "Unexpected result from orchestrator: #{response.class}\n#{response}"
         end
-      end
-
-      def inventory_uri
-        @inventory_uri ||= URI.parse('https://localhost:8143/orchestrator/v1/inventory')
-      end
-
-      def request_object(nodes:, token_file:)
-        token = File.read(token_file)
-        body = {
-          'nodes' => nodes,
-        }.to_json
-
-        request = Net::HTTP::Post.new(inventory_uri.request_uri)
-        request['Content-Type'] = 'application/json'
-        request['X-Authentication'] = token
-        request.body = body
-
-        request
-      end
-
-      def http_object
-        http = Net::HTTP.new(inventory_uri.host, inventory_uri.port)
-        http.use_ssl = true
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-
-        http
-      end
-
-      def wait_until_connected(nodes:, token_file:, timeout: 120)
-        http = http_object
-        request = request_object(nodes: nodes, token_file: token_file)
-        inventory = {}
-        Timeout.timeout(timeout) do
-          loop do
-            response = http.request(request)
-            unless response.is_a? Net::HTTPSuccess
-              raise "Unexpected result from orchestrator: #{response.class}\n#{response}"
-            end
-            inventory = JSON.parse(response.body)
-            break if inventory['items'].all? { |item| item['connected'] }
-            sleep(1)
-          end
-        end
-      rescue Timeout::Error
-        raise 'Timed out waiting for nodes to be connected to orchestrator: ' +
-              inventory['items'].reject { |item| item['connected'] }
-                                .map { |item| item['name'] }
-                                .to_s
+        inventory = JSON.parse(response.body)
+        break if inventory['items'].all? { |item| item['connected'] }
+        sleep(1)
       end
     end
+  rescue Timeout::Error
+    raise 'Timed out waiting for nodes to be connected to orchestrator: ' +
+          inventory['items'].reject { |item| item['connected'] }
+                            .map { |item| item['name'] }
+                            .to_s
   end
 end
 
@@ -95,6 +92,6 @@ end
 # environment flag is used to disable auto-execution and enable Ruby unit
 # testing of this task.
 unless ENV['RSPEC_UNIT_TEST_MODE']
-  upgrade = PEAdm::Task::PuppetInfraUpgrade.new(JSON.parse(STDIN.read))
+  upgrade = PuppetInfraUpgrade.new(JSON.parse(STDIN.read))
   upgrade.execute!
 end


### PR DESCRIPTION
Tested using peadm and Bolt 3.0.1 to deploy a new 2021 stack, as well as upgrade a 2019.8.5 stack to 2021.0. This PR modifies the version validation functions to indicate support for PE 2021.0, Bolt 3.x, and updates the PDK template to 2.0.0.