### PR TITLE
Fix installer exit handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # PEADM module
 
+## Unreleased
+### Summary
+
+Unreleased
+
+### Changes
+
+- Improve error handling during early installation of PE
+
 ## 2.5.0
 ### Summary
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Unreleased
 ### Changes
 
 - Improve error handling during early installation of PE
+- Implement concurrency in peadm::action::install to increase speed of installation process
 
 ## 2.5.0
 ### Summary

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The normal usage pattern for peadm is as follows.
 ### Requirements
 
 * Puppet Enterprise 2019.8.1 or newer (tested with PE 2021.0)
-* Bolt 2.27.0 or newer (tested with Bolt 3.5)
+* Bolt 2.42.0 or newer (tested with Bolt 3.5.0)
 * EL 7, EL 8, Ubuntu 18.04, or Ubuntu 20.04
 * Classifier Data enabled. This PE feature is enabled by default on new installs, but can be disabled by users if they remove the relevant configuration from their global hiera.yaml file. See the [PE docs](https://puppet.com/docs/pe/latest/config_console.html#task-5039) for more information.
 

--- a/plans/action/install.pp
+++ b/plans/action/install.pp
@@ -235,21 +235,15 @@ plan peadm::action::install (
     }
   }
 
-  # Get the master installation up and running. The installer will
-  # "fail" because PuppetDB can't start, if puppetdb_database_target
-  # is set. That's expected.
-  $shortcircuit_puppetdb = !($puppetdb_database_target.empty)
-  without_default_logging() || {
-    out::message("Starting: task peadm::pe_install on ${master_target[0].name}")
-    run_task('peadm::pe_install', $master_target,
-      _catch_errors         => $shortcircuit_puppetdb,
-      tarball               => $upload_tarball_path,
-      peconf                => '/tmp/pe.conf',
-      puppet_service_ensure => 'stopped',
-      shortcircuit_puppetdb => $shortcircuit_puppetdb,
-    )
-    out::message("Finished: task peadm::pe_install on ${master_target[0].name}")
-  }
+  # Get the master installation up and running. The installer will "fail"
+  # because PuppetDB can't start, if puppetdb_database_target is set. That's
+  # expected, and handled by the task's install_extra_large parameter.
+  run_task('peadm::pe_install', $master_target,
+    tarball               => $upload_tarball_path,
+    peconf                => '/tmp/pe.conf',
+    puppet_service_ensure => 'stopped',
+    install_extra_large   => ($arch['architecture'] == 'extra-large'),
+  )
 
   parallelize($master_targets) |$target| {
     if $r10k_private_key {

--- a/plans/action/install.pp
+++ b/plans/action/install.pp
@@ -349,10 +349,6 @@ plan peadm::action::install (
     # Ensure certificate requests have been submitted, then run Puppet
     unless ($target in $database_targets) {
       run_task('peadm::submit_csr', $target)
-      # TODO: come up with an intelligent way to validate that the expected CSRs
-      # have been submitted and are available for signing, prior to signing them.
-      # For now, waiting a short period of time is necessary to avoid a small race.
-      ctrl::sleep(5)
       run_task('peadm::sign_csr', $master_target, { 'certnames' => [$target.name] } )
       run_task('peadm::puppet_runonce', $target)
     }

--- a/plans/action/install.pp
+++ b/plans/action/install.pp
@@ -32,7 +32,7 @@ plan peadm::action::install (
 
   # Common Configuration
   String               $console_password,
-  String               $version       = '2019.7.0',
+  String               $version       = '2019.8.5',
   Array[String]        $dns_alt_names = [ ],
   Hash                 $pe_conf_data  = { },
 

--- a/plans/provision.pp
+++ b/plans/provision.pp
@@ -28,7 +28,7 @@ plan peadm::provision (
 
   # Common Configuration
   String                            $console_password,
-  String                            $version                          = '2019.8.1',
+  String                            $version                          = '2019.8.5',
   Optional[Array[String]]           $dns_alt_names                    = undef,
   Optional[String]                  $compiler_pool_address            = undef,
   Optional[String]                  $internal_compiler_a_pool_address = undef,

--- a/spec/docker/extra-large-ha/params.json
+++ b/spec/docker/extra-large-ha/params.json
@@ -6,6 +6,6 @@
   "compiler_hosts": ["pe-xl-compiler-0.puppet.vm"],
   "console_password": "puppetlabs",
   "dns_alt_names": [ "puppet", "pe-xl-core-0.puppet.vm", "puppet-xl.vm" ],
-  "version": "2019.8.0",
+  "version": "2019.8.5",
   "compiler_pool_address": "puppet-xl.vm"
 }

--- a/spec/docker/extra-large-ha/upgrade_params.json
+++ b/spec/docker/extra-large-ha/upgrade_params.json
@@ -4,5 +4,5 @@
     "puppetdb_database_replica_host": "pe-xl-db-1.puppet.vm",
     "master_replica_host": "pe-xl-core-1.puppet.vm",
     "compiler_hosts": ["pe-xl-compiler-0.puppet.vm"],
-    "version": "2019.8.0"
+    "version": "2019.8.5"
 }

--- a/spec/docker/extra-large/params.json
+++ b/spec/docker/extra-large/params.json
@@ -4,5 +4,5 @@
   "compiler_hosts": ["pe-xl-compiler-0.puppet.vm"],
   "console_password": "puppetlabs",
   "dns_alt_names": [ "puppet", "pe-xl-core-0.puppet.vm" ],
-  "version": "2019.8.0"
+  "version": "2019.8.5"
 }

--- a/spec/docker/extra-large/upgrade_params.json
+++ b/spec/docker/extra-large/upgrade_params.json
@@ -2,5 +2,5 @@
     "master_host": "pe-xl-core-0.puppet.vm",
     "puppetdb_database_host": "pe-xl-db-0.puppet.vm",
     "compiler_hosts": ["pe-xl-compiler-0.puppet.vm"],
-    "version": "2019.8.0"
+    "version": "2019.8.5"
 }

--- a/spec/docker/large-ha/params.json
+++ b/spec/docker/large-ha/params.json
@@ -4,5 +4,5 @@
   "compiler_hosts": ["pe-lg-compiler-0.puppet.vm"],
   "console_password": "puppetlabs",
   "dns_alt_names": [ "puppet", "pe-lg.puppet.vm" ],
-  "version": "2019.8.0"
+  "version": "2019.8.5"
 }

--- a/spec/docker/large-ha/upgrade_params.json
+++ b/spec/docker/large-ha/upgrade_params.json
@@ -2,6 +2,6 @@
     "master_host": "pe-lg.puppet.vm",
     "master_replica_host": "pe-lg-replica.puppet.vm",
     "compiler_hosts": ["pe-lg-compiler-0.puppet.vm"],
-    "version": "2019.8.0"
+    "version": "2019.8.5"
 }
   

--- a/spec/docker/large/params.json
+++ b/spec/docker/large/params.json
@@ -3,5 +3,5 @@
   "compiler_hosts": ["pe-lg-compiler-0.puppet.vm"],
   "console_password": "puppetlabs",
   "dns_alt_names": [ "puppet", "pe-lg.puppet.vm" ],
-  "version": "2019.8.0"
+  "version": "2019.8.5"
 }

--- a/spec/docker/large/upgrade_params.json
+++ b/spec/docker/large/upgrade_params.json
@@ -1,6 +1,6 @@
 {
     "master_host": "pe-lg.puppet.vm",
     "compiler_hosts": ["pe-lg-compiler-0.puppet.vm"],
-    "version": "2019.8.0"
+    "version": "2019.8.5"
 }
   

--- a/spec/docker/standard-ha/params.json
+++ b/spec/docker/standard-ha/params.json
@@ -3,5 +3,5 @@
   "master_replica_host": "pe-std-replica.puppet.vm",
   "console_password": "puppetlabs",
   "dns_alt_names": [ "puppet", "pe-std.puppet.vm" ],
-  "version": "2019.8.0"
+  "version": "2019.8.5"
 }

--- a/spec/docker/standard-ha/upgrade_params.json
+++ b/spec/docker/standard-ha/upgrade_params.json
@@ -1,6 +1,6 @@
 {
     "master_host": "pe-std.puppet.vm",
     "master_replica_host": "pe-std-replica.puppet.vm",
-    "version": "2019.8.0"
+    "version": "2019.8.5"
 }
   

--- a/spec/docker/standard/params.json
+++ b/spec/docker/standard/params.json
@@ -2,6 +2,6 @@
   "master_host": "pe-std.puppet.vm",
   "console_password": "puppetlabs",
   "dns_alt_names": [ "puppet", "pe-std.puppet.vm" ],
-  "version": "2019.8.0",
+  "version": "2019.8.5",
   "r10k_remote": "https://gitlab.com/nwops/control-repo.git"
 }

--- a/spec/docker/standard/upgrade_params.json
+++ b/spec/docker/standard/upgrade_params.json
@@ -1,5 +1,5 @@
 {
     "master_host": "pe-std.puppet.vm",
-    "version": "2019.8.0"
+    "version": "2019.8.5"
 }
   

--- a/tasks/pe_install.json
+++ b/tasks/pe_install.json
@@ -9,9 +9,9 @@
       "type": "Optional[String]",
       "description": "The path to the pe.conf file"
     },
-    "shortcircuit_puppetdb": {
+    "install_extra_large": {
       "type": "Optional[Boolean]",
-      "description": "If true, during install, configure PuppetDB to short-circuit its startup"
+      "description": "If true, optimize task for known manual issues with extra-large installs. Do not use for upgrades"
     },
     "puppet_service_ensure": {
       "type": "Optional[Enum['stopped']]",


### PR DESCRIPTION
This PR cleans up exit code handling when dealing with the fact that puppet-enterprise-installer exits 1 during extra-large installs, due to PuppetDB not being able to start yet.