### PR TITLE
SOLARCH-376 language and terminology updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ As a services-led tool, Puppet Enterprise customers who are advised to start usi
 The normal usage pattern for peadm is as follows.
 
 1. Users set up a Bolt host from which they can run peadm plans. The Bolt host can be any machine that has ssh access to all of the PE nodes.
-2. Users run the `peadm::provision` plan to bootstrap a new PE deployment. Depending on the architecture chosen, peadm may create some node groups in the classifier to set parameters on the built-in `puppet_enterprise` module, tuning it for large or extra large architectures.
-3. Users use and operate their PE deployment as normal. The peadm module is not used again until the next upgrade.
+2. Users run the `peadm::provision` plan to bootstrap a new PE cluster. Depending on the architecture chosen, peadm may create some node groups in the classifier to set parameters on the built-in `puppet_enterprise` module, tuning it for large or extra large architectures.
+3. Users use and operate their PE cluster as normal. The peadm module is not used again until the next upgrade.
 4. When it is time to upgrade, users run the `peadm::upgrade` plan from their Bolt host to accelerate and aid in the upgrade process.
 
 ### What peadm affects
@@ -44,8 +44,8 @@ The normal usage pattern for peadm is as follows.
 
 ### What peadm does not affect
 
-* The peadm module is not required to exist or be present outside of the point(s) in time it is used to create a new PE deployment, or upgrade an existing deployment. No new Puppet classes or other persistent content not provided out-of-box by PE itself is applied to PE infrastructure nodes by the peadm module.
-* Having used the peadm module to provision or to upgrade a PE deployment is not known to affect or curtail the ability to use any normal, documented PE procedures, e.g. failover to a replica, or manual upgrade of a deployment.
+* The peadm module is not required to exist or be present outside of the point(s) in time it is used to create a new PE cluster, or upgrade an existing cluster. No new Puppet classes or other persistent content not provided out-of-box by PE itself is applied to PE infrastructure nodes by the peadm module.
+* Having used the peadm module to provision or to upgrade a PE cluster is not known to affect or curtail the ability to use any normal, documented PE procedures, e.g. failover to a replica, or manual upgrade of a cluster.
 
 ### Requirements
 

--- a/documentation/classification.md
+++ b/documentation/classification.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This reference implementation uses four non-default node classification groups to implement the Extra Large HA architecture. Intentionally, classification of default, out-of-box node groups is not modified. This allows normal commands such as `puppet infrastructure enable replica` to behave more or less exactly as they would in Standard or Large architecture deployments.
+This reference implementation uses four non-default node classification groups to implement the Extra Large DR architecture. Intentionally, classification of default, out-of-box node groups is not modified. This allows normal commands such as `puppet infrastructure enable replica` to behave more or less exactly as they would in Standard or Large architecture deployments.
 
 This image shows a fully expanded view of the PE Infrastructure node group, highlighting the new additions made to support the Extra Large architecture.
 

--- a/documentation/classification.md
+++ b/documentation/classification.md
@@ -12,37 +12,37 @@ This image shows a fully expanded view of the PE Infrastructure node group, high
 
 The new groups are:
 
-* PE Master A
-* PE Master B
+* PE Primary A
+* PE Primary B
 * PE Compiler Group A
 * PE Compiler Group B
 
 The configuration applied in each group looks as follows:
 
-### PE Master A
+### PE Primary A
 
-![PE Master A group](images/pe-master-a.png)
+![PE Primary A group](images/pe-master-a.png)
 
-Notes for PE Master A:
+Notes for PE Primary A:
 
-* The (initial) Master is the only member of this node group
+* The (initial) Primary is the only member of this node group
 * Sets as data two parameters
     * `puppet_enterprise::profile::master_replica::database_host_puppetdb`
     * `puppet_enterprise::profile::puppetdb::database_host`
 * Sets both parameters to the name of the PuppetDB PostgreSQL node paired with this master
-* Uses a different PuppetDB PostgreSQL node than PE Master B
+* Uses a different PuppetDB PostgreSQL node than PE Primary B
 
-### PE Master B
-![PE Master B group](images/pe-master-b.png)
+### PE Primary B
+![PE Primary B group](images/pe-master-b.png)
 
-Notes for PE Master B:
+Notes for PE Primary B:
 
-* The (initial) Master Replica is the only member of this node group
+* The (initial) Primary Replica is the only member of this node group
 * Sets as data two parameters
     * `puppet_enterprise::profile::master_replica::database_host_puppetdb`
     * `puppet_enterprise::profile::puppetdb::database_host`
 * Sets both parameters to the name of the PuppetDB PostgreSQL node paired with this master
-* Uses a different PuppetDB PostgreSQL node than PE Master A
+* Uses a different PuppetDB PostgreSQL node than PE Primary A
 
 ### PE Compiler Group A
 ![PE Compiler Group A group](images/pe-compiler-group-a.png)
@@ -54,7 +54,7 @@ Notes for PE Compiler Group A:
 * Sets the `puppet_enterprise::profile::puppetdb::database_host` parameter
     * Should be set to `"pdb-pg-a"`, where "pdb-pg-a" is the name of the PuppetDB PostgreSQL database host paired with the (initial) Master
 * Modifies the `puppet_enterprise::profile::master::puppetdb_host` parameter
-    * Should be set to `[${clientcert}, "master-b"]`, where "master-b" is the name of the (initial) Master Replica.
+    * Should be set to `[${clientcert}, "master-b"]`, where "master-b" is the name of the (initial) Primary Replica.
     * If you have a load balancer for the compilers in PE Compiler Group B port 8081, you should use that load balancer address instead of "master-b"
 * Modifies the `puppet_enterprise::profile::master::puppetdb_port` parameter
     * Should be set to `[8081]`
@@ -67,9 +67,9 @@ Notes for PE Compiler Group B:
 * The other half of the compilers (those not in the PE Compiler Group A node group) are members of this group
 * Applies the `puppet_enterprise::profile::puppetdb` class
 * Sets the `puppet_enterprise::profile::puppetdb::database_host` parameter
-    * Should be set to `"pdb-pg-b"`, where "pdb-pg-b" is the name of the PuppetDB PostgreSQL database host paired with the (initial) Master Replica
+    * Should be set to `"pdb-pg-b"`, where "pdb-pg-b" is the name of the PuppetDB PostgreSQL database host paired with the (initial) Primary Replica
 * Modifies the `puppet_enterprise::profile::master::puppetdb_host` parameter
-    * Should be set to `[${clientcert}, "master-a"]`, where "master-a" is the name of the PuppetDB PostgreSQL node paired with the (initial) Master Replica.
+    * Should be set to `[${clientcert}, "master-a"]`, where "master-a" is the name of the PuppetDB PostgreSQL node paired with the (initial) Primary Replica.
     * If you have a load balancer for the compilers in PE Compiler Group A port 8081, you should use that load balancer address instead of "master-a"
 * Modifies the `puppet_enterprise::profile::master::puppetdb_port` parameter
     * Should be set to `[8081]`

--- a/documentation/classification.md
+++ b/documentation/classification.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This reference implementation uses four non-default node classification groups to implement the Extra Large DR architecture. Intentionally, classification of default, out-of-box node groups is not modified. This allows normal commands such as `puppet infrastructure enable replica` to behave more or less exactly as they would in Standard or Large architecture deployments.
+This reference implementation uses four non-default node classification groups to implement the Extra Large DR architecture. Intentionally, classification of default, out-of-box node groups is not modified. This allows normal commands such as `puppet infrastructure enable replica` to behave more or less exactly as they would in Standard or Large architecture clusters.
 
 This image shows a fully expanded view of the PE Infrastructure node group, highlighting the new additions made to support the Extra Large architecture.
 

--- a/documentation/classification.md
+++ b/documentation/classification.md
@@ -29,7 +29,7 @@ Notes for PE Primary A:
 * Sets as data two parameters
     * `puppet_enterprise::profile::master_replica::database_host_puppetdb`
     * `puppet_enterprise::profile::puppetdb::database_host`
-* Sets both parameters to the name of the PuppetDB PostgreSQL node paired with this master
+* Sets both parameters to the name of the PuppetDB PostgreSQL node paired with this primary
 * Uses a different PuppetDB PostgreSQL node than PE Primary B
 
 ### PE Primary B
@@ -52,10 +52,10 @@ Notes for PE Compiler Group A:
 * Half of the compilers are members of this group
 * Applies the `puppet_enterprise::profile::puppetdb` class
 * Sets the `puppet_enterprise::profile::puppetdb::database_host` parameter
-    * Should be set to `"pdb-pg-a"`, where "pdb-pg-a" is the name of the PuppetDB PostgreSQL database host paired with the (initial) Master
+    * Should be set to `"pdb-pg-a"`, where "pdb-pg-a" is the name of the PuppetDB PostgreSQL database host paired with the (initial) Primary
 * Modifies the `puppet_enterprise::profile::master::puppetdb_host` parameter
-    * Should be set to `[${clientcert}, "master-b"]`, where "master-b" is the name of the (initial) Primary Replica.
-    * If you have a load balancer for the compilers in PE Compiler Group B port 8081, you should use that load balancer address instead of "master-b"
+    * Should be set to `[${clientcert}, "primary-b"]`, where "primary-b" is the name of the (initial) Primary Replica.
+    * If you have a load balancer for the compilers in PE Compiler Group B port 8081, you should use that load balancer address instead of "primary-b"
 * Modifies the `puppet_enterprise::profile::master::puppetdb_port` parameter
     * Should be set to `[8081]`
 
@@ -69,7 +69,7 @@ Notes for PE Compiler Group B:
 * Sets the `puppet_enterprise::profile::puppetdb::database_host` parameter
     * Should be set to `"pdb-pg-b"`, where "pdb-pg-b" is the name of the PuppetDB PostgreSQL database host paired with the (initial) Primary Replica
 * Modifies the `puppet_enterprise::profile::master::puppetdb_host` parameter
-    * Should be set to `[${clientcert}, "master-a"]`, where "master-a" is the name of the PuppetDB PostgreSQL node paired with the (initial) Primary Replica.
-    * If you have a load balancer for the compilers in PE Compiler Group A port 8081, you should use that load balancer address instead of "master-a"
+    * Should be set to `[${clientcert}, "primary-a"]`, where "primary-a" is the name of the PuppetDB PostgreSQL node paired with the (initial) Primary Replica.
+    * If you have a load balancer for the compilers in PE Compiler Group A port 8081, you should use that load balancer address instead of "primary-a"
 * Modifies the `puppet_enterprise::profile::master::puppetdb_port` parameter
     * Should be set to `[8081]`

--- a/documentation/convert.md
+++ b/documentation/convert.md
@@ -9,7 +9,7 @@ Prepare to run the plan against all servers in the PE infrastructure, using a pa
 ```json
 {
   "primary_host": "pe-xl-core-0.lab1.puppet.vm",
-  "master_replica_host": "pe-xl-core-1.lab1.puppet.vm",
+  "primary_replica_host": "pe-xl-core-1.lab1.puppet.vm",
   "compiler_hosts": [
     "pe-xl-compiler-0.lab1.puppet.vm",
     "pe-xl-compiler-1.lab1.puppet.vm"

--- a/documentation/convert.md
+++ b/documentation/convert.md
@@ -8,7 +8,7 @@ Prepare to run the plan against all servers in the PE infrastructure, using a pa
 
 ```json
 {
-  "master_host": "pe-xl-core-0.lab1.puppet.vm",
+  "primary_host": "pe-xl-core-0.lab1.puppet.vm",
   "master_replica_host": "pe-xl-core-1.lab1.puppet.vm",
   "compiler_hosts": [
     "pe-xl-compiler-0.lab1.puppet.vm",

--- a/documentation/docker_examples.md
+++ b/documentation/docker_examples.md
@@ -1,5 +1,5 @@
 ## Docker Based Examples
-This module provides docker compose files for the various architectures for experimentation purposes. This gives you the ability to stand up an entire PE stack in order to learn how this module and HA works. If you have docker and docker-compose you can start up a full Puppet architecture with a single command.  Please note that Puppet does not support PE on containers in production.  
+This module provides docker compose files for the various architectures for experimentation purposes. This gives you the ability to stand up an entire PE stack in order to learn how this module and DR works. If you have docker and docker-compose you can start up a full Puppet architecture with a single command.  Please note that Puppet does not support PE on containers in production.  
 
 In order to decouple Bolt from a dev system, a special bolt container is created that will run all the bolt commands.  This is
 required to achieve maximum portability.  Should you want to run bolt commands against the PE stack you must
@@ -10,9 +10,10 @@ Example: `docker-compose run --entrypoint=/bin/bash bolt`
 ### Requirements
 To run the container based examples you will need the following requirements:
 
-2. Docker
-3. Docker compose
-4. 16GB memory, 24GB+ for XL and XL-HA architectures
+1. Docker
+2. Docker compose
+3. realpath (brew install coureutils on mac)
+4. 16GB memory, 24GB+ for XL and XL-DR architectures
 5. CPU with many cores (Tested with Core i7 6700)
 
 ### Starting the example

--- a/documentation/pre_post_checks.md
+++ b/documentation/pre_post_checks.md
@@ -38,7 +38,7 @@ Note that if you are using Litmus against a host once the agent is installed (no
 groups:
 - name: peserver
   nodes:
-  - master.puppet.example.net
+  - primary.puppet.example.net
   features: ['puppet-agent']
   config:
     transport: ssh
@@ -60,7 +60,7 @@ groups:
       private-key: "~/.ssh/example.pem"
 - name: ha
   nodes:
-  - ha-master.puppet.example.net
+  - ha-primary.puppet.example.net
   features: ['puppet-agent']  
   config:
     transport: ssh

--- a/documentation/provision.md
+++ b/documentation/provision.md
@@ -89,7 +89,7 @@ Example params.json Bolt parameters file (shown: Extra Large with HA):
 {
   "primary_host": "pe-xl-core-0.lab1.puppet.vm",
   "puppetdb_database_host": "pe-xl-core-1.lab1.puppet.vm",
-  "master_replica_host": "pe-xl-core-2.lab1.puppet.vm",
+  "primary_replica_host": "pe-xl-core-2.lab1.puppet.vm",
   "puppetdb_database_replica_host": "pe-xl-core-3.lab1.puppet.vm",
   "compiler_hosts": [
     "pe-xl-compiler-0.lab1.puppet.vm",
@@ -147,7 +147,7 @@ A parameters JSON file can then reference the target names, which will become th
 ```json
 {
   "primary_host": "pe-xl-core-0.lab1.puppet.vm",
-  "master_replica_host": "pe-xl-core-1.lab1.puppet.vm",
+  "primary_replica_host": "pe-xl-core-1.lab1.puppet.vm",
 
   "console_password": "puppetlabs",
   "dns_alt_names": [ "puppet", "puppet.lab1.puppet.vm" ],

--- a/documentation/provision.md
+++ b/documentation/provision.md
@@ -6,27 +6,27 @@ The peadm provisioning plan creates base reference implementation. Once a base s
 
 ## Reference Architectures
 
-When provisioning a new PE stack using peadm, there are several different host parameters which can be specified. At a minimum, you must always specify the master parameter. Depending on which architecture you are deploying, other host parameters may be needed as well. The following is a list of the architectures peadm can provision and the required parameters.
+When provisioning a new PE stack using peadm, there are several different host parameters which can be specified. At a minimum, you must always specify the primary parameter. Depending on which architecture you are deploying, other host parameters may be needed as well. The following is a list of the architectures peadm can provision and the required parameters.
 
 * Standard
-    - master
+    - primary
 * Standard with HA
-    - master
-    - master-replica
+    - primary
+    - primary-replica
 * Large
-    - master
+    - primary
     - compilers
 * Large with HA
-    - master
-    - master-replica
+    - primary
+    - primary-replica
     - compilers
 * Extra Large
-    - master
+    - primary
     - pdb-database
     - compilers (optional)
 * Extra Large with HA
-    - master
-    - master-replica
+    - primary
+    - primary-replica
     - pdb-database
     - pdb-database-replica
     - compilers (optional)
@@ -38,7 +38,7 @@ Supplying a combination of host parameters which does not match one of the suppo
 ### Bolt 3 usage
 We will name the bolt project `large_ha_peadm` in this example but the project name can be anything.  
 
-1. Install Bolt on a jumphost. This can be the master, or any other system. (via package)
+1. Install Bolt on a jumphost. This can be the primary, or any other system. (via package)
 2. Run `mkdir large_ha_peadm && cd large_ha_peadm && bolt project init large_ha_peadm --modules puppetlabs-peadm`        
 4. Create an inventory file with connection information. Example included below.
 5. Create a parameters file. Example included below.
@@ -47,7 +47,7 @@ We will name the bolt project `large_ha_peadm` in this example but the project n
           
 ### Bolt 2 usage
 
-1. Install Bolt on a jumphost. This can be the master, or any other system.
+1. Install Bolt on a jumphost. This can be the primary, or any other system.
 2. Download or git clone the peadm module and put it somewhere on the jumphost. e.g. ~/modules/peadm.
 3. Download or git clone the module dependencies, and put them somewhere on the jumphost. e.g. ~/modules/stdlib, ~/modules/node\_manager, etc.
 4. Create an inventory file with connection information. Example included below.
@@ -165,5 +165,5 @@ Besides getting Puppet Enterprise installed, the key configuration supporting La
 * [classification.md](classification.md)
 * [peadm::setup::node\_manager class](../manifests/setup/node_manager.pp)
 
-The reference implementation uses trusted facts to put nodes in the right groups. Because the important puppet\_enterprise::\* class parameters and data are specified in the console, it should also be safe to have a pe.conf present on both the master, and the master replica nodes.
+The reference implementation uses trusted facts to put nodes in the right groups. Because the important puppet\_enterprise::\* class parameters and data are specified in the console, it should also be safe to have a pe.conf present on both the primary, and the primary replica nodes.
 

--- a/documentation/provision.md
+++ b/documentation/provision.md
@@ -87,7 +87,7 @@ Example params.json Bolt parameters file (shown: Extra Large with HA):
 
 ```json
 {
-  "master_host": "pe-xl-core-0.lab1.puppet.vm",
+  "primary_host": "pe-xl-core-0.lab1.puppet.vm",
   "puppetdb_database_host": "pe-xl-core-1.lab1.puppet.vm",
   "master_replica_host": "pe-xl-core-2.lab1.puppet.vm",
   "puppetdb_database_replica_host": "pe-xl-core-3.lab1.puppet.vm",
@@ -146,7 +146,7 @@ A parameters JSON file can then reference the target names, which will become th
 
 ```json
 {
-  "master_host": "pe-xl-core-0.lab1.puppet.vm",
+  "primary_host": "pe-xl-core-0.lab1.puppet.vm",
   "master_replica_host": "pe-xl-core-1.lab1.puppet.vm",
 
   "console_password": "puppetlabs",

--- a/documentation/provision.md
+++ b/documentation/provision.md
@@ -10,13 +10,13 @@ When provisioning a new PE stack using peadm, there are several different host p
 
 * Standard
     - primary
-* Standard with HA
+* Standard with DR
     - primary
     - primary-replica
 * Large
     - primary
     - compilers
-* Large with HA
+* Large with DR
     - primary
     - primary-replica
     - compilers
@@ -24,7 +24,7 @@ When provisioning a new PE stack using peadm, there are several different host p
     - primary
     - pdb-database
     - compilers (optional)
-* Extra Large with HA
+* Extra Large with DR
     - primary
     - primary-replica
     - pdb-database
@@ -83,7 +83,7 @@ groups:
         uri: 10.234.14.131
 ```
 
-Example params.json Bolt parameters file (shown: Extra Large with HA):
+Example params.json Bolt parameters file (shown: Extra Large with DR):
 
 ```json
 {

--- a/documentation/recovery.md
+++ b/documentation/recovery.md
@@ -26,7 +26,7 @@ This procedure uses the following placeholder references.
         curl -k https://<primary-server-fqdn>:8140/packages/current/install.bash \
           | bash -s -- \
               main:certname=<replacement-replica-fqdn> \
-              extension_requests:1.3.6.1.4.1.34380.1.1.9812=puppet/master \
+              extension_requests:1.3.6.1.4.1.34380.1.1.9812=puppet/primary \
               extension_requests:1.3.6.1.4.1.34380.1.1.9813=<replacement-avail-group-letter>
 
         puppet agent -t

--- a/documentation/upgrade.md
+++ b/documentation/upgrade.md
@@ -11,7 +11,7 @@ The following is an example parameters file for upgrading an Extra Large archite
 ```json
 {
   "version": "2019.2.2",
-  "master_host": "pe-master-09a40c-0.us-west1-a.c.reidmv-peadm.internal",
+  "primary_host": "pe-master-09a40c-0.us-west1-a.c.reidmv-peadm.internal",
   "puppetdb_database_host": "pe-psql-09a40c-0.us-west1-a.c.reidmv-peadm.internal",
   "master_replica_host": "pe-master-09a40c-1.us-west1-b.c.reidmv-peadm.internal",
   "puppetdb_database_replica_host": "pe-psql-09a40c-1.us-west1-b.c.reidmv-peadm.internal",

--- a/documentation/upgrade.md
+++ b/documentation/upgrade.md
@@ -13,7 +13,7 @@ The following is an example parameters file for upgrading an Extra Large archite
   "version": "2019.2.2",
   "primary_host": "pe-master-09a40c-0.us-west1-a.c.reidmv-peadm.internal",
   "puppetdb_database_host": "pe-psql-09a40c-0.us-west1-a.c.reidmv-peadm.internal",
-  "master_replica_host": "pe-master-09a40c-1.us-west1-b.c.reidmv-peadm.internal",
+  "primary_replica_host": "pe-master-09a40c-1.us-west1-b.c.reidmv-peadm.internal",
   "puppetdb_database_replica_host": "pe-psql-09a40c-1.us-west1-b.c.reidmv-peadm.internal",
   "compiler_hosts": [
     "pe-compiler-09a40c-0.us-west1-a.c.reidmv-peadm.internal",

--- a/documentation/upgrade.md
+++ b/documentation/upgrade.md
@@ -97,7 +97,7 @@ Note: it is assumed that the Puppet primary is in cluster A when the upgrade sta
 
 * Stop the `puppet` service on all PE infrastructure nodes to prevent normal automatic runs from interfering with the upgrade process
 
-**Phase 2: upgrade HA cluster A**
+**Phase 2: upgrade DR cluster A**
 
 1. Shut down the `pe-puppetdb` service on the compilers in cluster A
 2. If different from the primary, run the `install-puppet-enterprise` script for the new PE version on the PuppetDB PostgreSQL node for cluster A
@@ -106,7 +106,7 @@ Note: it is assumed that the Puppet primary is in cluster A when the upgrade sta
 5. If different from the primary, Run `puppet agent -t` on the PuppetDB PostgreSQL node for cluster A
 6. Perform the compiler upgrade using `puppet infra upgrade compiler` for the compilers in cluster A
 
-**Phase 3: upgrade HA cluster B**
+**Phase 3: upgrade DR cluster B**
 
 1. Shut down the `pe-puppetdb` service on the compilers in cluster B
 2. If different from the primary (replica), run the `install-puppet-enterprise` script for the new PE version on the PuppetDB PostgreSQL node for cluster B

--- a/examples/provision/extra-large-ha.json
+++ b/examples/provision/extra-large-ha.json
@@ -1,7 +1,7 @@
 {
   "version": "2019.4.0",
   "console_password": "puppetlabs",
-  "master_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
+  "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
   "master_replica_host": "pe-master-1830cd-1.us-west1-b.c.reidmv-peadm.internal",
   "puppetdb_database_host": "pe-psql-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
   "puppetdb_database_replica_host": "pe-psql-1830cd-1.us-west1-b.c.reidmv-peadm.internal",

--- a/examples/provision/extra-large-ha.json
+++ b/examples/provision/extra-large-ha.json
@@ -2,7 +2,7 @@
   "version": "2019.4.0",
   "console_password": "puppetlabs",
   "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
-  "master_replica_host": "pe-master-1830cd-1.us-west1-b.c.reidmv-peadm.internal",
+  "primary_replica_host": "pe-master-1830cd-1.us-west1-b.c.reidmv-peadm.internal",
   "puppetdb_database_host": "pe-psql-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
   "puppetdb_database_replica_host": "pe-psql-1830cd-1.us-west1-b.c.reidmv-peadm.internal",
   "compiler_pool_address": "puppet.pe-compiler-lb-1830cd.il4.us-west1.lb.reidmv-peadm.internal",

--- a/examples/provision/extra-large.json
+++ b/examples/provision/extra-large.json
@@ -1,7 +1,7 @@
 {
   "version": "2019.2.4",
   "console_password": "puppetlabs",
-  "master_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
+  "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
 
   "puppetdb_database_host": "pe-psql-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
 

--- a/examples/provision/large-ha.json
+++ b/examples/provision/large-ha.json
@@ -2,7 +2,7 @@
   "version": "2019.4.0",
   "console_password": "puppetlabs",
   "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
-  "master_replica_host": "pe-master-1830cd-1.us-west1-b.c.reidmv-peadm.internal",
+  "primary_replica_host": "pe-master-1830cd-1.us-west1-b.c.reidmv-peadm.internal",
 
 
   "compiler_pool_address": "puppet.pe-compiler-lb-1830cd.il4.us-west1.lb.reidmv-peadm.internal",

--- a/examples/provision/large-ha.json
+++ b/examples/provision/large-ha.json
@@ -1,7 +1,7 @@
 {
   "version": "2019.4.0",
   "console_password": "puppetlabs",
-  "master_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
+  "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
   "master_replica_host": "pe-master-1830cd-1.us-west1-b.c.reidmv-peadm.internal",
 
 

--- a/examples/provision/large.json
+++ b/examples/provision/large.json
@@ -1,7 +1,7 @@
 {
   "version": "2019.4.0",
   "console_password": "puppetlabs",
-  "master_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
+  "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
 
 
 

--- a/examples/provision/minimal.json
+++ b/examples/provision/minimal.json
@@ -1,5 +1,5 @@
 {
   "version": "2019.4.0",
   "console_password": "puppetlabs",
-  "master_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal"
+  "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal"
 }

--- a/examples/provision/standard-ha.json
+++ b/examples/provision/standard-ha.json
@@ -2,7 +2,7 @@
   "version": "2019.4.0",
   "console_password": "puppetlabs",
   "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
-  "master_replica_host": "pe-master-1830cd-1.us-west1-b.c.reidmv-peadm.internal",
+  "primary_replica_host": "pe-master-1830cd-1.us-west1-b.c.reidmv-peadm.internal",
 
 
   "compiler_pool_address": "puppet.pe-compiler-lb-1830cd.il4.us-west1.lb.reidmv-peadm.internal",

--- a/examples/provision/standard-ha.json
+++ b/examples/provision/standard-ha.json
@@ -1,7 +1,7 @@
 {
   "version": "2019.4.0",
   "console_password": "puppetlabs",
-  "master_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
+  "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
   "master_replica_host": "pe-master-1830cd-1.us-west1-b.c.reidmv-peadm.internal",
 
 

--- a/examples/provision/standard.json
+++ b/examples/provision/standard.json
@@ -1,7 +1,7 @@
 {
   "version": "2019.4.0",
   "console_password": "puppetlabs",
-  "master_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
+  "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
 
 
 

--- a/functions/validate_architecture.pp
+++ b/functions/validate_architecture.pp
@@ -32,9 +32,9 @@ function peadm::validate_architecture (
     default: {                     # Invalid
       out::message(inline_epp(@(HEREDOC)))
         Invalid architecture! Recieved:
-          - master
+          - primary
         <% if $primary_replica_host { -%>
-          - master-replica
+          - primary-replica
         <% } -%>
         <% if $puppetdb_database_host { -%>
           - pdb-database
@@ -48,24 +48,24 @@ function peadm::validate_architecture (
 
         Supported architectures include:
           Standard
-            - master
+            - primary
           Standard with HA
-            - master
-            - master-replica
+            - primary
+            - primary-replica
           Large
-            - master
+            - primary
             - compilers
           Large with HA
-            - master
-            - master-replica
+            - primary
+            - primary-replica
             - compilers
           Extra Large
-            - master
+            - primary
             - pdb-database
             - compilers (optional)
           Extra Large with HA
-            - master
-            - master-replica
+            - primary
+            - primary-replica
             - pdb-database
             - pdb-database-replica
             - compilers (optional)

--- a/functions/validate_architecture.pp
+++ b/functions/validate_architecture.pp
@@ -1,13 +1,13 @@
 function peadm::validate_architecture (
   TargetSpec                 $primary_host,
-  Variant[TargetSpec, Undef] $master_replica_host = undef,
+  Variant[TargetSpec, Undef] $primary_replica_host = undef,
   Variant[TargetSpec, Undef] $puppetdb_database_host = undef,
   Variant[TargetSpec, Undef] $puppetdb_database_replica_host = undef,
   Variant[TargetSpec, Undef] $compiler_hosts = undef,
 )  >> Hash {
   $result = case [
     !!($primary_host),
-    !!($master_replica_host),
+    !!($primary_replica_host),
     !!($puppetdb_database_host),
     !!($puppetdb_database_replica_host),
   ] {
@@ -33,7 +33,7 @@ function peadm::validate_architecture (
       out::message(inline_epp(@(HEREDOC)))
         Invalid architecture! Recieved:
           - master
-        <% if $master_replica_host { -%>
+        <% if $primary_replica_host { -%>
           - master-replica
         <% } -%>
         <% if $puppetdb_database_host { -%>

--- a/functions/validate_architecture.pp
+++ b/functions/validate_architecture.pp
@@ -11,23 +11,23 @@ function peadm::validate_architecture (
     !!($puppetdb_database_host),
     !!($puppetdb_database_replica_host),
   ] {
-    [true, false, false, false]: { # Standard or Large, no HA
-      ({ 'high-availability' => false, 'architecture' => $compiler_hosts ? {
+    [true, false, false, false]: { # Standard or Large, no DR
+      ({ 'disaster-recovery' => false, 'architecture' => $compiler_hosts ? {
         undef   => 'standard',
         default => 'large',
       }})
     }
-    [true, true, false, false]: {  # Standard or Large, HA
-      ({ 'high-availability' => true, 'architecture' => $compiler_hosts ? {
+    [true, true, false, false]: {  # Standard or Large, DR
+      ({ 'disaster-recovery' => true, 'architecture' => $compiler_hosts ? {
         undef   => 'standard',
         default => 'large',
       }})
     }
-    [true, false, true, false]: {  # Extra Large, no HA
-      ({ 'high-availability' => false, 'architecture' => 'extra-large' })
+    [true, false, true, false]: {  # Extra Large, no DR
+      ({ 'disaster-recovery' => false, 'architecture' => 'extra-large' })
     }
-    [true, true, true, true]: {    # Extra Large, HA
-      ({ 'high-availability' => true,  'architecture' => 'extra-large' })
+    [true, true, true, true]: {    # Extra Large, DR
+      ({ 'disaster-recovery' => true,  'architecture' => 'extra-large' })
     }
     default: {                     # Invalid
       out::message(inline_epp(@(HEREDOC)))
@@ -49,13 +49,13 @@ function peadm::validate_architecture (
         Supported architectures include:
           Standard
             - primary
-          Standard with HA
+          Standard with DR
             - primary
             - primary-replica
           Large
             - primary
             - compilers
-          Large with HA
+          Large with DR
             - primary
             - primary-replica
             - compilers
@@ -63,7 +63,7 @@ function peadm::validate_architecture (
             - primary
             - pdb-database
             - compilers (optional)
-          Extra Large with HA
+          Extra Large with DR
             - primary
             - primary-replica
             - pdb-database

--- a/functions/validate_architecture.pp
+++ b/functions/validate_architecture.pp
@@ -1,12 +1,12 @@
 function peadm::validate_architecture (
-  TargetSpec                 $master_host,
+  TargetSpec                 $primary_host,
   Variant[TargetSpec, Undef] $master_replica_host = undef,
   Variant[TargetSpec, Undef] $puppetdb_database_host = undef,
   Variant[TargetSpec, Undef] $puppetdb_database_replica_host = undef,
   Variant[TargetSpec, Undef] $compiler_hosts = undef,
 )  >> Hash {
   $result = case [
-    !!($master_host),
+    !!($primary_host),
     !!($master_replica_host),
     !!($puppetdb_database_host),
     !!($puppetdb_database_replica_host),

--- a/manifests/setup/node_manager.pp
+++ b/manifests/setup/node_manager.pp
@@ -14,11 +14,11 @@
 #   service. Typically this is a load balancer.
 # @param internal_compiler_a_pool_address
 #   A load balancer address directing traffic to any of the "A" pool
-#   compilers. This is used for DR/HA configuration in large and extra large
+#   compilers. This is used for DR configuration in large and extra large
 #   architectures.
 # @param internal_compiler_b_pool_address
 #   A load balancer address directing traffic to any of the "B" pool
-#   compilers. This is used for DR/HA configuration in large and extra large
+#   compilers. This is used for DR configuration in large and extra large
 #   architectures.
 #
 class peadm::setup::node_manager (
@@ -110,7 +110,7 @@ class peadm::setup::node_manager (
     },
   }
 
-  # Configure the A pool for compilers. There are up to two pools for HA, each
+  # Configure the A pool for compilers. There are up to two pools for DR, each
   # having an affinity for one "availability zone" or the other.
   node_group { 'PE Compiler Group A':
     ensure  => 'present',
@@ -140,7 +140,7 @@ class peadm::setup::node_manager (
   # supplied
   if $primary_replica_host {
     # We need to ensure this group provides the peadm_replica variable.
-    node_group { 'PE HA Replica':
+    node_group { 'PE DR Replica':
       ensure    => 'present',
       parent    => 'PE Infrastructure',
       classes   => {

--- a/manifests/setup/node_manager.pp
+++ b/manifests/setup/node_manager.pp
@@ -26,12 +26,12 @@ class peadm::setup::node_manager (
   String[1] $primary_host,
 
   # High Availability
-  Optional[String[1]] $master_replica_host            = undef,
+  Optional[String[1]] $primary_replica_host            = undef,
 
   # Common
   Optional[String[1]] $compiler_pool_address            = undef,
   Optional[String[1]] $internal_compiler_a_pool_address = $primary_host,
-  Optional[String[1]] $internal_compiler_b_pool_address = $master_replica_host,
+  Optional[String[1]] $internal_compiler_b_pool_address = $primary_replica_host,
 
   # For the next two parameters, the default values are appropriate when
   # deploying Standard or Large architectures. These values only need to be
@@ -41,7 +41,7 @@ class peadm::setup::node_manager (
   String[1]           $puppetdb_database_host         = $primary_host,
 
   # Specify when using Extra Large AND High Availability
-  Optional[String[1]] $puppetdb_database_replica_host = $master_replica_host,
+  Optional[String[1]] $puppetdb_database_replica_host = $primary_replica_host,
 ) {
 
   # Preserve existing user data and classes values. We only need to make sure
@@ -138,7 +138,7 @@ class peadm::setup::node_manager (
 
   # Create the replica and B groups if a replica master and database host are
   # supplied
-  if $master_replica_host {
+  if $primary_replica_host {
     # We need to ensure this group provides the peadm_replica variable.
     node_group { 'PE HA Replica':
       ensure    => 'present',

--- a/manifests/setup/node_manager.pp
+++ b/manifests/setup/node_manager.pp
@@ -97,7 +97,7 @@ class peadm::setup::node_manager (
     ensure => present,
     parent => 'PE Infrastructure',
     rule   => ['and',
-      ['=', ['trusted', 'extensions', peadm::oid('peadm_role')], 'puppet/master'],
+      ['=', ['trusted', 'extensions', peadm::oid('peadm_role')], 'puppet/primary'],
       ['=', ['trusted', 'extensions', peadm::oid('peadm_availability_group')], 'A'],
     ],
     data   => {
@@ -153,7 +153,7 @@ class peadm::setup::node_manager (
       ensure => present,
       parent => 'PE Infrastructure',
       rule   => ['and',
-        ['=', ['trusted', 'extensions', peadm::oid('peadm_role')], 'puppet/master'],
+        ['=', ['trusted', 'extensions', peadm::oid('peadm_role')], 'puppet/primary'],
         ['=', ['trusted', 'extensions', peadm::oid('peadm_availability_group')], 'B'],
       ],
       data   => {

--- a/manifests/setup/node_manager.pp
+++ b/manifests/setup/node_manager.pp
@@ -149,7 +149,7 @@ class peadm::setup::node_manager (
       variables => { 'peadm_replica' => true },
     }
 
-    node_group { 'PE Primary ter B':
+    node_group { 'PE Primary B':
       ensure => present,
       parent => 'PE Infrastructure',
       rule   => ['and',

--- a/manifests/setup/node_manager.pp
+++ b/manifests/setup/node_manager.pp
@@ -23,14 +23,14 @@
 #
 class peadm::setup::node_manager (
   # Standard
-  String[1] $master_host,
+  String[1] $primary_host,
 
   # High Availability
   Optional[String[1]] $master_replica_host            = undef,
 
   # Common
   Optional[String[1]] $compiler_pool_address            = undef,
-  Optional[String[1]] $internal_compiler_a_pool_address = $master_host,
+  Optional[String[1]] $internal_compiler_a_pool_address = $primary_host,
   Optional[String[1]] $internal_compiler_b_pool_address = $master_replica_host,
 
   # For the next two parameters, the default values are appropriate when
@@ -38,7 +38,7 @@ class peadm::setup::node_manager (
   # specified differently when deploying an Extra Large architecture.
 
   # Specify when using Extra Large
-  String[1]           $puppetdb_database_host         = $master_host,
+  String[1]           $puppetdb_database_host         = $primary_host,
 
   # Specify when using Extra Large AND High Availability
   Optional[String[1]] $puppetdb_database_replica_host = $master_replica_host,
@@ -78,7 +78,7 @@ class peadm::setup::node_manager (
     variables => { 'pe_master' => true },
     rule      => ['or',
       ['and', ['=', ['trusted', 'extensions', 'pp_auth_role'], 'pe_compiler']],
-      ['=', 'name', $master_host],
+      ['=', 'name', $primary_host],
     ],
   }
 
@@ -87,7 +87,7 @@ class peadm::setup::node_manager (
   node_group { 'PE Database':
     rule => ['or',
       ['and', ['=', ['trusted', 'extensions', peadm::oid('peadm_role')], 'puppet/puppetdb-database']],
-      ['=', 'name', $master_host],
+      ['=', 'name', $primary_host],
     ]
   }
 

--- a/manifests/setup/node_manager.pp
+++ b/manifests/setup/node_manager.pp
@@ -1,8 +1,8 @@
-# This profile is not intended to be continously enforced on PE masters.
+# This profile is not intended to be continously enforced on PE primaries.
 # Rather, it describes state to enforce as a boostrap action, preparing the
 # Puppet Enterprise console with a sane default environment configuration.
 #
-# This class will be applied during master bootstrap using e.g.
+# This class will be applied during primary bootstrap using e.g.
 #
 #     puppet apply \
 #       --exec 'class { "peadm::setup::node_manager":
@@ -72,7 +72,7 @@ class peadm::setup::node_manager (
     default => { 'pe_repo' => { 'compile_master_pool_address' => $compiler_pool_address } },
   }
 
-  node_group { 'PE Master':
+  node_group { 'PE Primary':
     parent    => 'PE Infrastructure',
     data      => $compiler_pool_address_data,
     variables => { 'pe_master' => true },
@@ -92,8 +92,8 @@ class peadm::setup::node_manager (
   }
 
   # Create data-only groups to store PuppetDB PostgreSQL database configuration
-  # information specific to the master and master replica nodes.
-  node_group { 'PE Master A':
+  # information specific to the primary and primary replica nodes.
+  node_group { 'PE Primary A':
     ensure => present,
     parent => 'PE Infrastructure',
     rule   => ['and',
@@ -136,7 +136,7 @@ class peadm::setup::node_manager (
     },
   }
 
-  # Create the replica and B groups if a replica master and database host are
+  # Create the replica and B groups if a replica primary and database host are
   # supplied
   if $primary_replica_host {
     # We need to ensure this group provides the peadm_replica variable.
@@ -149,7 +149,7 @@ class peadm::setup::node_manager (
       variables => { 'peadm_replica' => true },
     }
 
-    node_group { 'PE Master B':
+    node_group { 'PE Primary ter B':
       ensure => present,
       parent => 'PE Infrastructure',
       rule   => ['and',

--- a/manifests/setup/node_manager_yaml.pp
+++ b/manifests/setup/node_manager_yaml.pp
@@ -1,5 +1,5 @@
 class peadm::setup::node_manager_yaml (
-  String $master_host,
+  String $primary_host
 ) {
 
   # Necessary to give the sandboxed Puppet executor the configuration
@@ -9,7 +9,7 @@ class peadm::setup::node_manager_yaml (
     mode    => '0644',
     path    => Deferred('peadm::node_manager_yaml_location'),
     content => epp('peadm/node_manager.yaml.epp', {
-      server => $master_host,
+      server => $primary_host,
     }),
   }
 

--- a/plans/action/configure.pp
+++ b/plans/action/configure.pp
@@ -15,7 +15,7 @@
 plan peadm::action::configure (
   # Standard
   Peadm::SingleTargetSpec           $primary_host,
-  Optional[Peadm::SingleTargetSpec] $master_replica_host = undef,
+  Optional[Peadm::SingleTargetSpec] $primary_replica_host = undef,
 
   # Large
   Optional[TargetSpec]              $compiler_hosts = undef,
@@ -38,7 +38,7 @@ plan peadm::action::configure (
 
   # Convert inputs into targets.
   $master_target                    = peadm::get_targets($primary_host, 1)
-  $master_replica_target            = peadm::get_targets($master_replica_host, 1)
+  $master_replica_target            = peadm::get_targets($primary_replica_host, 1)
   $puppetdb_database_replica_target = peadm::get_targets($puppetdb_database_replica_host, 1)
   $compiler_targets                 = peadm::get_targets($compiler_hosts)
   $puppetdb_database_target         = peadm::get_targets($puppetdb_database_host, 1)
@@ -46,7 +46,7 @@ plan peadm::action::configure (
   # Ensure input valid for a supported architecture
   $arch = peadm::validate_architecture(
     $primary_host,
-    $master_replica_host,
+    $primary_replica_host,
     $puppetdb_database_host,
     $puppetdb_database_replica_host,
     $compiler_hosts,
@@ -79,7 +79,7 @@ plan peadm::action::configure (
 
     class { 'peadm::setup::node_manager':
       primary_host                     => $master_target.peadm::target_name(),
-      master_replica_host              => $master_replica_target.peadm::target_name(),
+      primary_replica_host             => $master_replica_target.peadm::target_name(),
       puppetdb_database_host           => $puppetdb_database_target.peadm::target_name(),
       puppetdb_database_replica_host   => $puppetdb_database_replica_target.peadm::target_name(),
       compiler_pool_address            => $compiler_pool_address,

--- a/plans/action/configure.pp
+++ b/plans/action/configure.pp
@@ -1,15 +1,15 @@
-# @summary Configure first-time classification and HA setup
+# @summary Configure first-time classification and DR setup
 #
 # @param compiler_pool_address 
 #   The service address used by agents to connect to compilers, or the Puppet
 #   service. Typically this is a load balancer.
 # @param internal_compiler_a_pool_address
 #   A load balancer address directing traffic to any of the "A" pool
-#   compilers. This is used for DR/HA configuration in large and extra large
+#   compilers. This is used for DR configuration in large and extra large
 #   architectures.
 # @param internal_compiler_b_pool_address
 #   A load balancer address directing traffic to any of the "B" pool
-#   compilers. This is used for DR/HA configuration in large and extra large
+#   compilers. This is used for DR configuration in large and extra large
 #   architectures.
 #
 plan peadm::action::configure (
@@ -89,7 +89,7 @@ plan peadm::action::configure (
     }
   }
 
-  if $arch['high-availability'] {
+  if $arch['disaster-recovery'] {
     # Run the PE Replica Provision
     run_task('peadm::provision_replica', $primary_target,
       master_replica => $primary_replica_target.peadm::target_name(),

--- a/plans/action/configure.pp
+++ b/plans/action/configure.pp
@@ -37,8 +37,8 @@ plan peadm::action::configure (
   # TODO: get and validate PE version
 
   # Convert inputs into targets.
-  $master_target                    = peadm::get_targets($primary_host, 1)
-  $master_replica_target            = peadm::get_targets($primary_replica_host, 1)
+  $primary_target                   = peadm::get_targets($primary_host, 1)
+  $primary_replica_target           = peadm::get_targets($primary_replica_host, 1)
   $puppetdb_database_replica_target = peadm::get_targets($puppetdb_database_replica_host, 1)
   $compiler_targets                 = peadm::get_targets($compiler_hosts)
   $puppetdb_database_target         = peadm::get_targets($puppetdb_database_host, 1)
@@ -55,12 +55,12 @@ plan peadm::action::configure (
   # Define the global hiera.yaml file on the Master; and syncronize to any Replica and Compilers.
   # This enables Data in the Classifier/Console, which is used/required by this architecture.
   # Necessary, for example, when promoting the Replica due to PE-18400 (and others).
-  $global_hiera_yaml = run_task('peadm::read_file', $master_target,
+  $global_hiera_yaml = run_task('peadm::read_file', $primary_target,
     path => '/etc/puppetlabs/puppet/hiera.yaml',
   ).first['content']
 
   run_task('peadm::mkdir_p_file', peadm::flatten_compact([
-    $master_replica_target,
+    $primary_replica_target,
     $compiler_targets,
   ]),
     path    => '/etc/puppetlabs/puppet/hiera.yaml',
@@ -72,14 +72,14 @@ plan peadm::action::configure (
 
   # Set up the console node groups to configure the various hosts in their roles
 
-  apply($master_target) {
+  apply($primary_target) {
     class { 'peadm::setup::node_manager_yaml':
-      primary_host => $master_target.peadm::target_name(),
+      primary_host => $primary_target.peadm::target_name(),
     }
 
     class { 'peadm::setup::node_manager':
-      primary_host                     => $master_target.peadm::target_name(),
-      primary_replica_host             => $master_replica_target.peadm::target_name(),
+      primary_host                     => $primary_target.peadm::target_name(),
+      primary_replica_host             => $primary_replica_target.peadm::target_name(),
       puppetdb_database_host           => $puppetdb_database_target.peadm::target_name(),
       puppetdb_database_replica_host   => $puppetdb_database_replica_target.peadm::target_name(),
       compiler_pool_address            => $compiler_pool_address,
@@ -91,8 +91,8 @@ plan peadm::action::configure (
 
   if $arch['high-availability'] {
     # Run the PE Replica Provision
-    run_task('peadm::provision_replica', $master_target,
-      master_replica => $master_replica_target.peadm::target_name(),
+    run_task('peadm::provision_replica', $primary_target,
+      master_replica => $primary_replica_target.peadm::target_name(),
       token_file     => $token_file,
 
       # Race condition, where the provision command checks PuppetDB status and
@@ -104,24 +104,24 @@ plan peadm::action::configure (
 
   # Run Puppet everywhere to pick up last remaining config tweaks
   run_task('peadm::puppet_runonce', peadm::flatten_compact([
-    $master_target,
+    $primary_target,
     $puppetdb_database_target,
     $compiler_targets,
-    $master_replica_target,
+    $primary_replica_target,
     $puppetdb_database_replica_target,
   ]))
 
   # Deploy an environment if a deploy environment is specified
   if $deploy_environment {
-    run_task('peadm::code_manager', $master_target,
+    run_task('peadm::code_manager', $primary_target,
       action => "deploy ${deploy_environment}",
     )
   }
 
   # Ensure Puppet agent service is running now that configuration is complete
   run_command('systemctl start puppet', peadm::flatten_compact([
-    $master_target,
-    $master_replica_target,
+    $primary_target,
+    $primary_replica_target,
     $puppetdb_database_target,
     $puppetdb_database_replica_target,
     $compiler_targets,

--- a/plans/action/configure.pp
+++ b/plans/action/configure.pp
@@ -14,7 +14,7 @@
 #
 plan peadm::action::configure (
   # Standard
-  Peadm::SingleTargetSpec           $master_host,
+  Peadm::SingleTargetSpec           $primary_host,
   Optional[Peadm::SingleTargetSpec] $master_replica_host = undef,
 
   # Large
@@ -25,7 +25,7 @@ plan peadm::action::configure (
   Optional[Peadm::SingleTargetSpec] $puppetdb_database_replica_host = undef,
 
   # Common Configuration
-  String           $compiler_pool_address = $master_host,
+  String           $compiler_pool_address = $primary_host,
   Optional[String] $internal_compiler_a_pool_address = undef,
   Optional[String] $internal_compiler_b_pool_address = undef,
   Optional[String] $token_file = undef,
@@ -37,7 +37,7 @@ plan peadm::action::configure (
   # TODO: get and validate PE version
 
   # Convert inputs into targets.
-  $master_target                    = peadm::get_targets($master_host, 1)
+  $master_target                    = peadm::get_targets($primary_host, 1)
   $master_replica_target            = peadm::get_targets($master_replica_host, 1)
   $puppetdb_database_replica_target = peadm::get_targets($puppetdb_database_replica_host, 1)
   $compiler_targets                 = peadm::get_targets($compiler_hosts)
@@ -45,7 +45,7 @@ plan peadm::action::configure (
 
   # Ensure input valid for a supported architecture
   $arch = peadm::validate_architecture(
-    $master_host,
+    $primary_host,
     $master_replica_host,
     $puppetdb_database_host,
     $puppetdb_database_replica_host,
@@ -74,11 +74,11 @@ plan peadm::action::configure (
 
   apply($master_target) {
     class { 'peadm::setup::node_manager_yaml':
-      master_host => $master_target.peadm::target_name(),
+      primary_host => $master_target.peadm::target_name(),
     }
 
     class { 'peadm::setup::node_manager':
-      master_host                      => $master_target.peadm::target_name(),
+      primary_host                     => $master_target.peadm::target_name(),
       master_replica_host              => $master_replica_target.peadm::target_name(),
       puppetdb_database_host           => $puppetdb_database_target.peadm::target_name(),
       puppetdb_database_replica_host   => $puppetdb_database_replica_target.peadm::target_name(),

--- a/plans/action/install.pp
+++ b/plans/action/install.pp
@@ -172,7 +172,7 @@ plan peadm::action::install (
   # Upload the pe.conf files to the hosts that need them, and ensure correctly
   # configured certnames. Right now for these hosts we need to do that by
   # staging a puppet.conf file.
-  parallelize(['master', 'puppetdb_database', 'puppetdb_database_replica']) |$var| {
+  parallelize(['primary', 'puppetdb_database', 'puppetdb_database_replica']) |$var| {
     $target  = getvar("${var}_target", [])
     $pe_conf = getvar("${var}_pe_conf")
 

--- a/plans/action/install.pp
+++ b/plans/action/install.pp
@@ -144,7 +144,7 @@ plan peadm::action::install (
     ).map |$t| { $t.peadm::target_name() },
   }
 
-  $master_pe_conf = peadm::generate_pe_conf({
+  $primary_pe_conf = peadm::generate_pe_conf({
     'console_admin_password'                                          => $console_password,
     'puppet_enterprise::puppet_master_host'                           => $primary_target.peadm::target_name(),
     'pe_install::puppet_master_dnsaltnames'                           => $dns_alt_names,

--- a/plans/action/install.pp
+++ b/plans/action/install.pp
@@ -6,13 +6,13 @@
 #
 # @param r10k_private_key_file
 #   The private key to use for r10k. If this is a local file it will be copied
-#   over to the masters at /etc/puppetlabs/puppetserver/ssh/id-control_repo.rsa
-#   If the file does not exist the value will simply be supplied to the masters
+#   over to the primary at /etc/puppetlabs/puppetserver/ssh/id-control_repo.rsa
+#   If the file does not exist the value will simply be supplied to the primary
 #
 # @param license_key_file
 #   The license key to use with Puppet Enterprise.  If this is a local file it
 #   will be copied over to the MoM at /etc/puppetlabs/license.key
-#   If the file does not exist the value will simply be supplied to the masters
+#   If the file does not exist the value will simply be supplied to the primaries
 #
 # @param pe_conf_data
 #   Config data to plane into pe.conf when generated on all hosts, this can be

--- a/plans/action/install.pp
+++ b/plans/action/install.pp
@@ -52,7 +52,7 @@ plan peadm::action::install (
   peadm::validate_version($version)
 
   # Convert inputs into targets.
-  $master_target                    = peadm::get_targets($primary_host, 1)
+  $primary_target                   = peadm::get_targets($primary_host, 1)
   $master_replica_target            = peadm::get_targets($primary_replica_host, 1)
   $puppetdb_database_target         = peadm::get_targets($puppetdb_database_host, 1)
   $puppetdb_database_replica_target = peadm::get_targets($puppetdb_database_replica_host, 1)
@@ -68,15 +68,15 @@ plan peadm::action::install (
   )
 
   $all_targets = peadm::flatten_compact([
-    $master_target,
+    $primary_target,
     $puppetdb_database_target,
     $master_replica_target,
     $puppetdb_database_replica_target,
     $compiler_targets,
   ])
 
-  $master_targets = peadm::flatten_compact([
-    $master_target,
+  $primary_targets = peadm::flatten_compact([
+    $primary_target,
     $master_replica_target,
   ])
 
@@ -86,7 +86,7 @@ plan peadm::action::install (
   ])
 
   $pe_installer_targets = peadm::flatten_compact([
-    $master_target,
+    $primary_target,
     $puppetdb_database_target,
     $puppetdb_database_replica_target,
   ])
@@ -140,13 +140,13 @@ plan peadm::action::install (
   # puppet and are present in PuppetDB, it is not necessary anymore.
   $puppetdb_database_temp_config = {
     'puppet_enterprise::profile::database::puppetdb_hosts' => (
-      $compiler_targets + $master_target + $master_replica_target
+      $compiler_targets + $primary_target + $master_replica_target
     ).map |$t| { $t.peadm::target_name() },
   }
 
   $master_pe_conf = peadm::generate_pe_conf({
     'console_admin_password'                                          => $console_password,
-    'puppet_enterprise::puppet_master_host'                           => $master_target.peadm::target_name(),
+    'puppet_enterprise::puppet_master_host'                           => $primary_target.peadm::target_name(),
     'pe_install::puppet_master_dnsaltnames'                           => $dns_alt_names,
     'puppet_enterprise::puppetdb_database_host'                       => $puppetdb_database_target.peadm::target_name(),
     'puppet_enterprise::profile::master::code_manager_auto_configure' => true,
@@ -159,13 +159,13 @@ plan peadm::action::install (
 
   $puppetdb_database_pe_conf = peadm::generate_pe_conf({
     'console_admin_password'                => 'not used',
-    'puppet_enterprise::puppet_master_host' => $master_target.peadm::target_name(),
+    'puppet_enterprise::puppet_master_host' => $primary_target.peadm::target_name(),
     'puppet_enterprise::database_host'      => $puppetdb_database_target.peadm::target_name(),
   } + $puppetdb_database_temp_config + $pe_conf_data)
 
   $puppetdb_database_replica_pe_conf = peadm::generate_pe_conf({
     'console_admin_password'                => 'not used',
-    'puppet_enterprise::puppet_master_host' => $master_target.peadm::target_name(),
+    'puppet_enterprise::puppet_master_host' => $primary_target.peadm::target_name(),
     'puppet_enterprise::database_host'      => $puppetdb_database_replica_target.peadm::target_name(),
   } + $puppetdb_database_temp_config + $pe_conf_data)
 
@@ -209,7 +209,7 @@ plan peadm::action::install (
   # if a csr_attributes.yaml file is already present, the values we need are
   # merged with the existing values.
   parallelize($pe_installer_targets) |$target| {
-    if ($target in $master_target) {
+    if ($target in $primary_target) {
       run_plan('peadm::util::insert_csr_extension_requests', $target,
         extension_requests => {
           peadm::oid('peadm_role')               => 'puppet/master',
@@ -238,14 +238,14 @@ plan peadm::action::install (
   # Get the master installation up and running. The installer will "fail"
   # because PuppetDB can't start, if puppetdb_database_target is set. That's
   # expected, and handled by the task's install_extra_large parameter.
-  run_task('peadm::pe_install', $master_target,
+  run_task('peadm::pe_install', $primary_target,
     tarball               => $upload_tarball_path,
     peconf                => '/tmp/pe.conf',
     puppet_service_ensure => 'stopped',
     install_extra_large   => ($arch['architecture'] == 'extra-large'),
   )
 
-  parallelize($master_targets) |$target| {
+  parallelize($primary_targets) |$target| {
     if $r10k_private_key {
       run_task('peadm::mkdir_p_file', $target,
         path    => '/etc/puppetlabs/puppetserver/ssh/id-control_repo.rsa',
@@ -265,7 +265,7 @@ plan peadm::action::install (
 
   # Configure autosigning for the puppetdb database hosts 'cause they need it
   $autosign_conf = $database_targets.reduce('') |$memo,$target| { "${target.name}\n${memo}" }
-  run_task('peadm::mkdir_p_file', $master_target,
+  run_task('peadm::mkdir_p_file', $primary_target,
     path    => '/etc/puppetlabs/puppet/autosign.conf',
     owner   => 'pe-puppet',
     group   => 'pe-puppet',
@@ -282,9 +282,9 @@ plan peadm::action::install (
 
   # Now that the main PuppetDB database node is ready, finish priming the
   # master. Explicitly stop puppetdb first to avoid any systemd interference.
-  run_command('systemctl stop pe-puppetdb', $master_target)
-  run_command('systemctl start pe-puppetdb', $master_target)
-  run_task('peadm::rbac_token', $master_target,
+  run_command('systemctl stop pe-puppetdb', $primary_target)
+  run_command('systemctl start pe-puppetdb', $primary_target)
+  run_task('peadm::rbac_token', $primary_target,
     password => $console_password,
   )
 
@@ -293,7 +293,7 @@ plan peadm::action::install (
   # replication. A production environment must exist when committed to avoid
   # corrupting the PE console. Create the site.pp file specifically to avoid
   # breaking the `puppet infra configure` command.
-  run_task('peadm::mkdir_p_file', $master_target,
+  run_task('peadm::mkdir_p_file', $primary_target,
     path    => '/etc/puppetlabs/code-staging/environments/production/manifests/site.pp',
     chown_r => '/etc/puppetlabs/code-staging/environments',
     owner   => 'pe-puppet',
@@ -302,7 +302,7 @@ plan peadm::action::install (
     content => "# Empty manifest\n",
   )
 
-  run_task('peadm::code_manager', $master_target,
+  run_task('peadm::code_manager', $primary_target,
     action => 'file-sync commit',
   )
 
@@ -320,7 +320,7 @@ plan peadm::action::install (
     # Everything else needs an agent installed and cert signed
     elsif ($target in $compiler_a_targets) {
       run_task('peadm::agent_install', $target,
-        server        => $master_target.peadm::target_name(),
+        server        => $primary_target.peadm::target_name(),
         install_flags => $common_install_flags + [
           "extension_requests:${peadm::oid('pp_auth_role')}=pe_compiler",
           "extension_requests:${peadm::oid('peadm_availability_group')}=A",
@@ -329,7 +329,7 @@ plan peadm::action::install (
     }
     elsif ($target in $compiler_b_targets) {
       run_task('peadm::agent_install', $target,
-        server        => $master_target.peadm::target_name(),
+        server        => $primary_target.peadm::target_name(),
         install_flags => $common_install_flags + [
           "extension_requests:${peadm::oid('pp_auth_role')}=pe_compiler",
           "extension_requests:${peadm::oid('peadm_availability_group')}=B",
@@ -338,7 +338,7 @@ plan peadm::action::install (
     }
     elsif ($target in $master_replica_target) {
       run_task('peadm::agent_install', $target,
-        server        => $master_target.peadm::target_name(),
+        server        => $primary_target.peadm::target_name(),
         install_flags => $common_install_flags + [
           "extension_requests:${peadm::oid('peadm_role')}=puppet/master",
           "extension_requests:${peadm::oid('peadm_availability_group')}=B",
@@ -349,7 +349,7 @@ plan peadm::action::install (
     # Ensure certificate requests have been submitted, then run Puppet
     unless ($target in $database_targets) {
       run_task('peadm::submit_csr', $target)
-      run_task('peadm::sign_csr', $master_target, { 'certnames' => [$target.name] } )
+      run_task('peadm::sign_csr', $primary_target, { 'certnames' => [$target.name] } )
       run_task('peadm::puppet_runonce', $target)
     }
   }
@@ -358,9 +358,9 @@ plan peadm::action::install (
   # so we check the status by calling the api and ensuring the puppetserver is
   # taking requests before proceeding. It takes two runs to fully finish
   # configuration.
-  run_task('peadm::puppet_runonce', $master_target)
-  peadm::wait_until_service_ready('pe-master', $master_target)
-  run_task('peadm::puppet_runonce', $master_target)
+  run_task('peadm::puppet_runonce', $primary_target)
+  peadm::wait_until_service_ready('pe-master', $primary_target)
+  run_task('peadm::puppet_runonce', $primary_target)
 
   # Cleanup temp bootstrapping config
   parallelize(['master', 'puppetdb_database', 'puppetdb_database_replica']) |$var| {

--- a/plans/action/install.pp
+++ b/plans/action/install.pp
@@ -20,7 +20,7 @@
 #
 plan peadm::action::install (
   # Standard
-  Peadm::SingleTargetSpec           $master_host,
+  Peadm::SingleTargetSpec           $primary_host,
   Optional[Peadm::SingleTargetSpec] $master_replica_host = undef,
 
   # Large
@@ -52,7 +52,7 @@ plan peadm::action::install (
   peadm::validate_version($version)
 
   # Convert inputs into targets.
-  $master_target                    = peadm::get_targets($master_host, 1)
+  $master_target                    = peadm::get_targets($primary_host, 1)
   $master_replica_target            = peadm::get_targets($master_replica_host, 1)
   $puppetdb_database_target         = peadm::get_targets($puppetdb_database_host, 1)
   $puppetdb_database_replica_target = peadm::get_targets($puppetdb_database_replica_host, 1)
@@ -60,7 +60,7 @@ plan peadm::action::install (
 
   # Ensure input valid for a supported architecture
   $arch = peadm::validate_architecture(
-    $master_host,
+    $primary_host,
     $master_replica_host,
     $puppetdb_database_host,
     $puppetdb_database_replica_host,

--- a/plans/action/install.pp
+++ b/plans/action/install.pp
@@ -53,7 +53,7 @@ plan peadm::action::install (
 
   # Convert inputs into targets.
   $primary_target                   = peadm::get_targets($primary_host, 1)
-  $master_replica_target            = peadm::get_targets($primary_replica_host, 1)
+  $primary_replica_target           = peadm::get_targets($primary_replica_host, 1)
   $puppetdb_database_target         = peadm::get_targets($puppetdb_database_host, 1)
   $puppetdb_database_replica_target = peadm::get_targets($puppetdb_database_replica_host, 1)
   $compiler_targets                 = peadm::get_targets($compiler_hosts)
@@ -70,14 +70,14 @@ plan peadm::action::install (
   $all_targets = peadm::flatten_compact([
     $primary_target,
     $puppetdb_database_target,
-    $master_replica_target,
+    $primary_replica_target,
     $puppetdb_database_replica_target,
     $compiler_targets,
   ])
 
   $primary_targets = peadm::flatten_compact([
     $primary_target,
-    $master_replica_target,
+    $primary_replica_target,
   ])
 
   $database_targets = peadm::flatten_compact([
@@ -93,7 +93,7 @@ plan peadm::action::install (
 
   $agent_installer_targets = peadm::flatten_compact([
     $compiler_targets,
-    $master_replica_target,
+    $primary_replica_target,
   ])
 
   # Clusters A and B are used to divide PuppetDB availability for compilers
@@ -140,7 +140,7 @@ plan peadm::action::install (
   # puppet and are present in PuppetDB, it is not necessary anymore.
   $puppetdb_database_temp_config = {
     'puppet_enterprise::profile::database::puppetdb_hosts' => (
-      $compiler_targets + $primary_target + $master_replica_target
+      $compiler_targets + $primary_target + $primary_replica_target
     ).map |$t| { $t.peadm::target_name() },
   }
 
@@ -336,7 +336,7 @@ plan peadm::action::install (
         ],
       )
     }
-    elsif ($target in $master_replica_target) {
+    elsif ($target in $primary_replica_target) {
       run_task('peadm::agent_install', $target,
         server        => $primary_target.peadm::target_name(),
         install_flags => $common_install_flags + [

--- a/plans/action/install.pp
+++ b/plans/action/install.pp
@@ -212,7 +212,7 @@ plan peadm::action::install (
     if ($target in $primary_target) {
       run_plan('peadm::util::insert_csr_extension_requests', $target,
         extension_requests => {
-          peadm::oid('peadm_role')               => 'puppet/master',
+          peadm::oid('peadm_role')               => 'puppet/primary',
           peadm::oid('peadm_availability_group') => 'A'
         }
       )
@@ -340,7 +340,7 @@ plan peadm::action::install (
       run_task('peadm::agent_install', $target,
         server        => $primary_target.peadm::target_name(),
         install_flags => $common_install_flags + [
-          "extension_requests:${peadm::oid('peadm_role')}=puppet/master",
+          "extension_requests:${peadm::oid('peadm_role')}=puppet/primary",
           "extension_requests:${peadm::oid('peadm_availability_group')}=B",
         ],
       )

--- a/plans/action/install.pp
+++ b/plans/action/install.pp
@@ -21,7 +21,7 @@
 plan peadm::action::install (
   # Standard
   Peadm::SingleTargetSpec           $primary_host,
-  Optional[Peadm::SingleTargetSpec] $master_replica_host = undef,
+  Optional[Peadm::SingleTargetSpec] $primary_replica_host = undef,
 
   # Large
   Optional[TargetSpec]              $compiler_hosts      = undef,
@@ -53,7 +53,7 @@ plan peadm::action::install (
 
   # Convert inputs into targets.
   $master_target                    = peadm::get_targets($primary_host, 1)
-  $master_replica_target            = peadm::get_targets($master_replica_host, 1)
+  $master_replica_target            = peadm::get_targets($primary_replica_host, 1)
   $puppetdb_database_target         = peadm::get_targets($puppetdb_database_host, 1)
   $puppetdb_database_replica_target = peadm::get_targets($puppetdb_database_replica_host, 1)
   $compiler_targets                 = peadm::get_targets($compiler_hosts)
@@ -61,7 +61,7 @@ plan peadm::action::install (
   # Ensure input valid for a supported architecture
   $arch = peadm::validate_architecture(
     $primary_host,
-    $master_replica_host,
+    $primary_replica_host,
     $puppetdb_database_host,
     $puppetdb_database_replica_host,
     $compiler_hosts,

--- a/plans/action/install.pp
+++ b/plans/action/install.pp
@@ -97,7 +97,7 @@ plan peadm::action::install (
   ])
 
   # Clusters A and B are used to divide PuppetDB availability for compilers
-  if $arch['high-availability'] {
+  if $arch['disaster-recovery'] {
     $compiler_a_targets = $compiler_targets.filter |$index,$target| { $index % 2 == 0 }
     $compiler_b_targets = $compiler_targets.filter |$index,$target| { $index % 2 != 0 }
   }

--- a/plans/convert.pp
+++ b/plans/convert.pp
@@ -1,7 +1,7 @@
 plan peadm::convert (
   # Standard
   Peadm::SingleTargetSpec           $primary_host,
-  Optional[Peadm::SingleTargetSpec] $master_replica_host = undef,
+  Optional[Peadm::SingleTargetSpec] $primary_replica_host = undef,
 
   # Large
   Optional[TargetSpec]              $compiler_hosts = undef,
@@ -32,7 +32,7 @@ plan peadm::convert (
 
   # Convert inputs into targets.
   $master_target                    = peadm::get_targets($primary_host, 1)
-  $master_replica_target            = peadm::get_targets($master_replica_host, 1)
+  $master_replica_target            = peadm::get_targets($primary_replica_host, 1)
   $puppetdb_database_replica_target = peadm::get_targets($puppetdb_database_replica_host, 1)
   $compiler_targets                 = peadm::get_targets($compiler_hosts)
   $puppetdb_database_target         = peadm::get_targets($puppetdb_database_host, 1)
@@ -48,7 +48,7 @@ plan peadm::convert (
   # Ensure input valid for a supported architecture
   $arch = peadm::validate_architecture(
     $primary_host,
-    $master_replica_host,
+    $primary_replica_host,
     $puppetdb_database_host,
     $puppetdb_database_replica_host,
     $compiler_hosts,
@@ -209,7 +209,7 @@ plan peadm::convert (
 
         class { 'peadm::setup::node_manager':
           primary_host                     => $master_target.peadm::target_name(),
-          master_replica_host              => $master_replica_target.peadm::target_name(),
+          primary_replica_host             => $master_replica_target.peadm::target_name(),
           puppetdb_database_host           => $puppetdb_database_target.peadm::target_name(),
           puppetdb_database_replica_host   => $puppetdb_database_replica_target.peadm::target_name(),
           compiler_pool_address            => $compiler_pool_address,

--- a/plans/convert.pp
+++ b/plans/convert.pp
@@ -87,7 +87,7 @@ plan peadm::convert (
   # Clusters A and B are used to divide PuppetDB availability for compilers. If
   # the compilers given already have peadm_availability_group facts designating
   # them A or B, use that. Otherwise, divide them by modulus of 2.
-  if $arch['high-availability'] {
+  if $arch['disaster-recovery'] {
     $compiler_a_targets = $compiler_targets.filter |$index,$target| {
       $exts = $cert_extensions[$target.peadm::target_name()]
       if ($exts[peadm::oid('peadm_availability_group')] in ['A', 'B']) {

--- a/plans/convert.pp
+++ b/plans/convert.pp
@@ -68,7 +68,7 @@ plan peadm::convert (
     path => '/opt/puppetlabs/server/pe_version',
   )[0][content].chomp
 
-  # Figure out if this PE deployment has been configured with peadm or pe_xl
+  # Figure out if this PE cluster has been configured with peadm or pe_xl
   # before
   $previously_configured_by_peadm = $all_targets.any |$target| {
     $exts = $cert_extensions[$target.peadm::target_name()]
@@ -77,7 +77,7 @@ plan peadm::convert (
 
   if (!$previously_configured_by_peadm and ($pe_version =~ SemVerRange('< 2019.7.0'))) {
     fail_plan(@("EOL"/L))
-      PE deployment cannot be converted! PE deployment must be a deployment \
+      PE cluster cannot be converted! PE cluster must be a deployment \
       created by pe_xl, by an older version of peadm, or be PE version \
       2019.7.0 or newer. Detected PE version ${pe_version}, and did not detect \
       signs that the deployment was previously created by peadm/pe_xl.

--- a/plans/convert.pp
+++ b/plans/convert.pp
@@ -230,7 +230,7 @@ plan peadm::convert (
 
   peadm::plan_step('finalize') || {
     # Run Puppet on all targets to ensure catalogs and exported resources fully
-    # up-to-date. Run on master first in case puppet server restarts, 'cause
+    # up-to-date. Run on primary first in case puppet server restarts, 'cause
     # that would cause the runs to fail on all the rest.
     run_task('peadm::puppet_runonce', $primary_target)
     run_task('peadm::puppet_runonce', $all_targets - $primary_target)

--- a/plans/convert.pp
+++ b/plans/convert.pp
@@ -132,7 +132,7 @@ plan peadm::convert (
     run_plan('peadm::util::add_cert_extensions', $primary_target,
       primary_host => $primary_target,
       extensions  => {
-        peadm::oid('peadm_role')               => 'puppet/master',
+        peadm::oid('peadm_role')               => 'puppet/primary',
         peadm::oid('peadm_availability_group') => 'A',
       },
     )
@@ -150,7 +150,7 @@ plan peadm::convert (
     run_plan('peadm::util::add_cert_extensions', $primary_replica_target,
       primary_host => $primary_target,
       extensions  => {
-        peadm::oid('peadm_role')               => 'puppet/master',
+        peadm::oid('peadm_role')               => 'puppet/primary',
         peadm::oid('peadm_availability_group') => 'B',
       },
     )

--- a/plans/misc/divert_code_manager.pp
+++ b/plans/misc/divert_code_manager.pp
@@ -11,7 +11,7 @@
 # This is a stop-gap at best. This should not be attempted without advisement.
 #
 plan peadm::misc::divert_code_manager (
-  $master_host,
+  $primary_host,
 ) {
 
   notice(@(HEREDOC))
@@ -21,7 +21,7 @@ plan peadm::misc::divert_code_manager (
     This will allow /etc/puppetlabs/code to be managed manually
     | HEREDOC
 
-  run_task('peadm::divert_code_manager', $master_host)
+  run_task('peadm::divert_code_manager', $primary_host)
 
   notice(@(HEREDOC))
     Remember to enforce this configuration in your Puppet code with a Collector Override. E.g.

--- a/plans/misc/divert_code_manager.pp
+++ b/plans/misc/divert_code_manager.pp
@@ -1,9 +1,9 @@
 # @summary This plan exists to account for a scenario where a PE XL
 # architecture is in use, but code manager is not.
 #
-# The PE HA solution technically requires code manager be enabled and running.
+# The PE DR solution technically requires code manager be enabled and running.
 # However, in unusual circumstances, it may not be possible for a customer to
-# actually use code manager. This plan allows HA to be used by leaving
+# actually use code manager. This plan allows DR to be used by leaving
 # file-sync turned on, but directing file-sync to deploy code to a
 # non-standard, unused directory. This leaves the Puppet codedir available for
 # management via an alternative means.

--- a/plans/provision.pp
+++ b/plans/provision.pp
@@ -17,7 +17,7 @@
 plan peadm::provision (
   # Standard
   Peadm::SingleTargetSpec           $primary_host,
-  Optional[Peadm::SingleTargetSpec] $master_replica_host = undef,
+  Optional[Peadm::SingleTargetSpec] $primary_replica_host = undef,
 
   # Large
   Optional[TargetSpec]              $compiler_hosts = undef,
@@ -56,7 +56,7 @@ plan peadm::provision (
   $install_result = run_plan('peadm::action::install',
     # Standard
     primary_host                    => $primary_host,
-    master_replica_host            => $master_replica_host,
+    primary_replica_host            => $primary_replica_host,
 
     # Large
     compiler_hosts                 => $compiler_hosts,
@@ -88,7 +88,7 @@ plan peadm::provision (
   $configure_result = run_plan('peadm::action::configure',
     # Standard
     primary_host                      => $primary_host,
-    master_replica_host              => $master_replica_host,
+    primary_replica_host              => $primary_replica_host,
 
     # Large
     compiler_hosts                   => $compiler_hosts,

--- a/plans/provision.pp
+++ b/plans/provision.pp
@@ -7,11 +7,11 @@
 #   service. Typically this is a load balancer.
 # @param internal_compiler_a_pool_address
 #   A load balancer address directing traffic to any of the "A" pool
-#   compilers. This is used for DR/HA configuration in large and extra large
+#   compilers. This is used for DR configuration in large and extra large
 #   architectures.
 # @param internal_compiler_b_pool_address
 #   A load balancer address directing traffic to any of the "B" pool
-#   compilers. This is used for DR/HA configuration in large and extra large
+#   compilers. This is used for DR configuration in large and extra large
 #   architectures.
 #
 plan peadm::provision (

--- a/plans/provision.pp
+++ b/plans/provision.pp
@@ -16,7 +16,7 @@
 #
 plan peadm::provision (
   # Standard
-  Peadm::SingleTargetSpec           $master_host,
+  Peadm::SingleTargetSpec           $primary_host,
   Optional[Peadm::SingleTargetSpec] $master_replica_host = undef,
 
   # Large
@@ -55,7 +55,7 @@ plan peadm::provision (
 
   $install_result = run_plan('peadm::action::install',
     # Standard
-    master_host                    => $master_host,
+    primary_host                    => $primary_host,
     master_replica_host            => $master_replica_host,
 
     # Large
@@ -87,7 +87,7 @@ plan peadm::provision (
 
   $configure_result = run_plan('peadm::action::configure',
     # Standard
-    master_host                      => $master_host,
+    primary_host                      => $primary_host,
     master_replica_host              => $master_replica_host,
 
     # Large

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -14,7 +14,7 @@
 #
 plan peadm::upgrade (
   # Standard
-  Peadm::SingleTargetSpec           $master_host,
+  Peadm::SingleTargetSpec           $primary_host,
   Optional[Peadm::SingleTargetSpec] $master_replica_host = undef,
 
   # Large
@@ -49,7 +49,7 @@ plan peadm::upgrade (
 
   # Ensure input valid for a supported architecture
   $arch = peadm::validate_architecture(
-    $master_host,
+    $primary_host,
     $master_replica_host,
     $puppetdb_database_host,
     $puppetdb_database_replica_host,
@@ -57,7 +57,7 @@ plan peadm::upgrade (
   )
 
   # Convert inputs into targets.
-  $master_target                    = peadm::get_targets($master_host, 1)
+  $master_target                    = peadm::get_targets($primary_host, 1)
   $master_replica_target            = peadm::get_targets($master_replica_host, 1)
   $puppetdb_database_target         = peadm::get_targets($puppetdb_database_host, 1)
   $puppetdb_database_replica_target = peadm::get_targets($puppetdb_database_replica_host, 1)
@@ -217,7 +217,7 @@ plan peadm::upgrade (
 
     # If necessary, add missing cert extensions to compilers
     run_plan('peadm::util::add_cert_extensions', $convert_targets,
-      master_host => $master_target,
+      primary_host => $master_target,
       extensions  => {
         'pp_auth_role' => 'pe_compiler',
       },
@@ -228,11 +228,11 @@ plan peadm::upgrade (
     # successfully classify and update
     apply($master_target) {
       class { 'peadm::setup::node_manager_yaml':
-        master_host => $master_target.peadm::target_name(),
+        primary_host => $master_target.peadm::target_name(),
       }
 
       class { 'peadm::setup::node_manager':
-        master_host                      => $master_target.peadm::target_name(),
+        primary_host                     => $master_target.peadm::target_name(),
         master_replica_host              => $master_replica_target.peadm::target_name(),
         puppetdb_database_host           => $puppetdb_database_target.peadm::target_name(),
         puppetdb_database_replica_host   => $puppetdb_database_replica_target.peadm::target_name(),

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -5,11 +5,11 @@
 #   service. Typically this is a load balancer.
 # @param internal_compiler_a_pool_address
 #   A load balancer address directing traffic to any of the "A" pool
-#   compilers. This is used for DR/HA configuration in large and extra large
+#   compilers. This is used for DR configuration in large and extra large
 #   architectures.
 # @param internal_compiler_b_pool_address
 #   A load balancer address directing traffic to any of the "B" pool
-#   compilers. This is used for DR/HA configuration in large and extra large
+#   compilers. This is used for DR configuration in large and extra large
 #   architectures.
 #
 plan peadm::upgrade (
@@ -104,7 +104,7 @@ plan peadm::upgrade (
       | HEREDOC
   }
 
-  # Determine which compilers are associated with which HA group
+  # Determine which compilers are associated with which DR group
   $compiler_m1_targets = $compiler_targets.filter |$target| {
     ($cert_extensions[$target.name][peadm::oid('peadm_availability_group')]
       == $cert_extensions[$primary_target[0].name][peadm::oid('peadm_availability_group')])
@@ -279,7 +279,7 @@ plan peadm::upgrade (
     # doesn't deal well with the PuppetDB database being on a separate node.
     # So, move it aside before running the upgrade.
     $pdbapps = '/opt/puppetlabs/server/apps/puppetdb/cli/apps'
-    $workaround_delete_reports = $arch['high-availability'] and $version =~ SemVerRange('>= 2019.8')
+    $workaround_delete_reports = $arch['disaster-recovery'] and $version =~ SemVerRange('>= 2019.8')
     if $workaround_delete_reports {
       run_command(@("COMMAND"/$), $primary_replica_target)
         if [ -e ${pdbapps}/delete-reports -a ! -h ${pdbapps}/delete-reports ]

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -15,7 +15,7 @@
 plan peadm::upgrade (
   # Standard
   Peadm::SingleTargetSpec           $primary_host,
-  Optional[Peadm::SingleTargetSpec] $master_replica_host = undef,
+  Optional[Peadm::SingleTargetSpec] $primary_replica_host = undef,
 
   # Large
   Optional[TargetSpec]              $compiler_hosts      = undef,
@@ -50,7 +50,7 @@ plan peadm::upgrade (
   # Ensure input valid for a supported architecture
   $arch = peadm::validate_architecture(
     $primary_host,
-    $master_replica_host,
+    $primary_replica_host,
     $puppetdb_database_host,
     $puppetdb_database_replica_host,
     $compiler_hosts,
@@ -58,7 +58,7 @@ plan peadm::upgrade (
 
   # Convert inputs into targets.
   $master_target                    = peadm::get_targets($primary_host, 1)
-  $master_replica_target            = peadm::get_targets($master_replica_host, 1)
+  $master_replica_target            = peadm::get_targets($primary_replica_host, 1)
   $puppetdb_database_target         = peadm::get_targets($puppetdb_database_host, 1)
   $puppetdb_database_replica_target = peadm::get_targets($puppetdb_database_replica_host, 1)
   $compiler_targets                 = peadm::get_targets($compiler_hosts)
@@ -233,7 +233,7 @@ plan peadm::upgrade (
 
       class { 'peadm::setup::node_manager':
         primary_host                     => $master_target.peadm::target_name(),
-        master_replica_host              => $master_replica_target.peadm::target_name(),
+        primary_replica_host             => $master_replica_target.peadm::target_name(),
         puppetdb_database_host           => $puppetdb_database_target.peadm::target_name(),
         puppetdb_database_replica_host   => $puppetdb_database_replica_target.peadm::target_name(),
         compiler_pool_address            => $compiler_pool_address,

--- a/plans/util/add_cert_extensions.pp
+++ b/plans/util/add_cert_extensions.pp
@@ -18,7 +18,7 @@ plan peadm::util::add_cert_extensions (
 
   # The master is treated differently than a standard node, so we need to be
   # able to identify it if it's in the target list
-  $master_certname = run_task('peadm::trusted_facts', $primary_target)[0]['certname']
+  $primary_certname = run_task('peadm::trusted_facts', $primary_target)[0]['certname']
 
   # Get trusted fact information for all targets
   $certdata = run_task('peadm::trusted_facts', $all_targets).reduce({}) |$memo,$result| {
@@ -70,7 +70,7 @@ plan peadm::util::add_cert_extensions (
 
     # Then things get crazy...
 
-    if ($certname != $master_certname) {
+    if ($certname != $primary_certname) {
       # AGENT cert regeneration
       run_task('peadm::ssl_clean', $target, certname => $certname)
       run_task('peadm::submit_csr', $target)

--- a/plans/util/add_cert_extensions.pp
+++ b/plans/util/add_cert_extensions.pp
@@ -1,11 +1,11 @@
 plan peadm::util::add_cert_extensions (
   TargetSpec $targets,
-  TargetSpec $master_host,
+  TargetSpec $primary_host,
   Hash       $extensions,
   Array      $remove = [ ],
 ) {
   $all_targets   = peadm::get_targets($targets)
-  $master_target = peadm::get_targets($master_host, 1)
+  $master_target = peadm::get_targets($primary_host, 1)
 
   # Short-circuit if there are no targets
   if $all_targets.empty { return(0) }

--- a/plans/util/sanitize_pg_pe_conf.pp
+++ b/plans/util/sanitize_pg_pe_conf.pp
@@ -1,12 +1,12 @@
 plan peadm::util::sanitize_pg_pe_conf (
   TargetSpec              $targets,
-  Peadm::SingleTargetSpec $master_host,
+  Peadm::SingleTargetSpec $primary_host,
 ) {
-  $master_target = get_target($master_host)
+  $master_target = get_target($primary_host)
 
   $path = '/etc/puppetlabs/enterprise/conf.d/pe.conf'
   # Ensure the pe.conf file on PostgreSQL nodes has the needed values for
-  # puppet_master_host and database_host
+  # puppet_primary_host and database_host
   run_task('peadm::read_file', $targets,
     path => $path,
   ).map |$result| {

--- a/plans/util/sanitize_pg_pe_conf.pp
+++ b/plans/util/sanitize_pg_pe_conf.pp
@@ -2,7 +2,7 @@ plan peadm::util::sanitize_pg_pe_conf (
   TargetSpec              $targets,
   Peadm::SingleTargetSpec $primary_host,
 ) {
-  $master_target = get_target($primary_host)
+  $primary_target = get_target($primary_host)
 
   $path = '/etc/puppetlabs/enterprise/conf.d/pe.conf'
   # Ensure the pe.conf file on PostgreSQL nodes has the needed values for
@@ -11,7 +11,7 @@ plan peadm::util::sanitize_pg_pe_conf (
     path => $path,
   ).map |$result| {
     $sanitized = $result['content'].loadjson() + {
-      'puppet_enterprise::puppet_master_host' => $master_target.peadm::target_name(),
+      'puppet_enterprise::puppet_master_host' => $primary_target.peadm::target_name(),
       'puppet_enterprise::database_host'      => $result.target.peadm::target_name(),
     }
     # Return the result of file_content_upload. There is only one target

--- a/spec/docker/extra-large-ha/docker-compose.yaml
+++ b/spec/docker/extra-large-ha/docker-compose.yaml
@@ -108,7 +108,7 @@ services:
     image: pe-base
     privileged: true # required for systemd
     labels:
-      com.puppet.role: "master_host"
+      com.puppet.role: "primary_host"
     ports:
       - "22"
       - "8140"

--- a/spec/docker/extra-large-ha/docker-compose.yaml
+++ b/spec/docker/extra-large-ha/docker-compose.yaml
@@ -80,7 +80,7 @@ services:
     image: pe-base
     privileged: true # required for systemd
     labels:
-      com.puppet.role: "master_replica_host"
+      com.puppet.role: "primary_replica_host"
     ports:
       - "22"
       - "8140"

--- a/spec/docker/extra-large-ha/params.json
+++ b/spec/docker/extra-large-ha/params.json
@@ -1,5 +1,5 @@
 {
-  "master_host": "pe-xl-core-0.puppet.vm",
+  "primary_host": "pe-xl-core-0.puppet.vm",
   "puppetdb_database_host": "pe-xl-db-0.puppet.vm",
   "puppetdb_database_replica_host": "pe-xl-db-1.puppet.vm",
   "master_replica_host": "pe-xl-core-1.puppet.vm",

--- a/spec/docker/extra-large-ha/params.json
+++ b/spec/docker/extra-large-ha/params.json
@@ -2,7 +2,7 @@
   "primary_host": "pe-xl-core-0.puppet.vm",
   "puppetdb_database_host": "pe-xl-db-0.puppet.vm",
   "puppetdb_database_replica_host": "pe-xl-db-1.puppet.vm",
-  "master_replica_host": "pe-xl-core-1.puppet.vm",
+  "primary_replica_host": "pe-xl-core-1.puppet.vm",
   "compiler_hosts": ["pe-xl-compiler-0.puppet.vm"],
   "console_password": "puppetlabs",
   "dns_alt_names": [ "puppet", "pe-xl-core-0.puppet.vm", "puppet-xl.vm" ],

--- a/spec/docker/extra-large-ha/upgrade_params.json
+++ b/spec/docker/extra-large-ha/upgrade_params.json
@@ -2,7 +2,7 @@
     "primary_host": "pe-xl-core-0.puppet.vm",
     "puppetdb_database_host": "pe-xl-db-0.puppet.vm",
     "puppetdb_database_replica_host": "pe-xl-db-1.puppet.vm",
-    "master_replica_host": "pe-xl-core-1.puppet.vm",
+    "primary_replica_host": "pe-xl-core-1.puppet.vm",
     "compiler_hosts": ["pe-xl-compiler-0.puppet.vm"],
     "version": "2019.8.5"
 }

--- a/spec/docker/extra-large-ha/upgrade_params.json
+++ b/spec/docker/extra-large-ha/upgrade_params.json
@@ -1,5 +1,5 @@
 {
-    "master_host": "pe-xl-core-0.puppet.vm",
+    "primary_host": "pe-xl-core-0.puppet.vm",
     "puppetdb_database_host": "pe-xl-db-0.puppet.vm",
     "puppetdb_database_replica_host": "pe-xl-db-1.puppet.vm",
     "master_replica_host": "pe-xl-core-1.puppet.vm",

--- a/spec/docker/extra-large/docker-compose.yaml
+++ b/spec/docker/extra-large/docker-compose.yaml
@@ -53,7 +53,7 @@ services:
     image: pe-base
     privileged: true # required for systemd
     labels:
-      com.puppet.role: "master_host"
+      com.puppet.role: "primary_host"
     ports:
       - "22"
       - "8140"

--- a/spec/docker/extra-large/params.json
+++ b/spec/docker/extra-large/params.json
@@ -1,5 +1,5 @@
 {
-  "master_host": "pe-xl-core-0.puppet.vm",
+  "primary_host": "pe-xl-core-0.puppet.vm",
   "puppetdb_database_host": "pe-xl-db-0.puppet.vm",
   "compiler_hosts": ["pe-xl-compiler-0.puppet.vm"],
   "console_password": "puppetlabs",

--- a/spec/docker/extra-large/upgrade_params.json
+++ b/spec/docker/extra-large/upgrade_params.json
@@ -1,5 +1,5 @@
 {
-    "master_host": "pe-xl-core-0.puppet.vm",
+    "primary_host": "pe-xl-core-0.puppet.vm",
     "puppetdb_database_host": "pe-xl-db-0.puppet.vm",
     "compiler_hosts": ["pe-xl-compiler-0.puppet.vm"],
     "version": "2019.8.5"

--- a/spec/docker/large-ha/docker-compose.yaml
+++ b/spec/docker/large-ha/docker-compose.yaml
@@ -32,7 +32,7 @@ services:
         HOST: 'pe-lg-replica.puppet.vm'
     entrypoint: /sbin/init
     labels:
-      com.puppet.role: "master_replica_host"
+      com.puppet.role: "primary_replica_host"
     image: pe-base
     privileged: true # required for systemd
     ports:

--- a/spec/docker/large-ha/docker-compose.yaml
+++ b/spec/docker/large-ha/docker-compose.yaml
@@ -61,7 +61,7 @@ services:
     image: pe-base
     privileged: true # required for systemd
     labels:
-      com.puppet.role: "master_host"
+      com.puppet.role: "primary_host"
     ports:
       - "22"
       - "8140"

--- a/spec/docker/large-ha/params.json
+++ b/spec/docker/large-ha/params.json
@@ -1,5 +1,5 @@
 {
-  "master_host": "pe-lg.puppet.vm",
+  "primary_host": "pe-lg.puppet.vm",
   "master_replica_host": "pe-lg-replica.puppet.vm",
   "compiler_hosts": ["pe-lg-compiler-0.puppet.vm"],
   "console_password": "puppetlabs",

--- a/spec/docker/large-ha/params.json
+++ b/spec/docker/large-ha/params.json
@@ -1,6 +1,6 @@
 {
   "primary_host": "pe-lg.puppet.vm",
-  "master_replica_host": "pe-lg-replica.puppet.vm",
+  "primary_replica_host": "pe-lg-replica.puppet.vm",
   "compiler_hosts": ["pe-lg-compiler-0.puppet.vm"],
   "console_password": "puppetlabs",
   "dns_alt_names": [ "puppet", "pe-lg.puppet.vm" ],

--- a/spec/docker/large-ha/upgrade_params.json
+++ b/spec/docker/large-ha/upgrade_params.json
@@ -1,5 +1,5 @@
 {
-    "master_host": "pe-lg.puppet.vm",
+    "primary_host": "pe-lg.puppet.vm",
     "master_replica_host": "pe-lg-replica.puppet.vm",
     "compiler_hosts": ["pe-lg-compiler-0.puppet.vm"],
     "version": "2019.8.5"

--- a/spec/docker/large-ha/upgrade_params.json
+++ b/spec/docker/large-ha/upgrade_params.json
@@ -1,6 +1,6 @@
 {
     "primary_host": "pe-lg.puppet.vm",
-    "master_replica_host": "pe-lg-replica.puppet.vm",
+    "primary_replica_host": "pe-lg-replica.puppet.vm",
     "compiler_hosts": ["pe-lg-compiler-0.puppet.vm"],
     "version": "2019.8.5"
 }

--- a/spec/docker/large/docker-compose.yaml
+++ b/spec/docker/large/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
     hostname: pe-lg.puppet.vm
     container_name: pe-lg.puppet.vm
     labels:
-      com.puppet.role: "master_host"
+      com.puppet.role: "primary_host"
     stop_signal: SIGRTMIN+3
     tmpfs:
       - /run

--- a/spec/docker/large/params.json
+++ b/spec/docker/large/params.json
@@ -1,5 +1,5 @@
 {
-  "master_host": "pe-lg.puppet.vm",
+  "primary_host": "pe-lg.puppet.vm",
   "compiler_hosts": ["pe-lg-compiler-0.puppet.vm"],
   "console_password": "puppetlabs",
   "dns_alt_names": [ "puppet", "pe-lg.puppet.vm" ],

--- a/spec/docker/large/upgrade_params.json
+++ b/spec/docker/large/upgrade_params.json
@@ -1,5 +1,5 @@
 {
-    "master_host": "pe-lg.puppet.vm",
+    "primary_host": "pe-lg.puppet.vm",
     "compiler_hosts": ["pe-lg-compiler-0.puppet.vm"],
     "version": "2019.8.5"
 }

--- a/spec/docker/standard-ha/docker-compose.yaml
+++ b/spec/docker/standard-ha/docker-compose.yaml
@@ -39,7 +39,7 @@ services:
     image: pe-base
     privileged: true # required for systemd
     labels:
-      com.puppet.role: "master_host"
+      com.puppet.role: "primary_host"
     ports:
       - "22"
       - "8140"

--- a/spec/docker/standard-ha/docker-compose.yaml
+++ b/spec/docker/standard-ha/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
     image: pe-base
     privileged: true # required for systemd
     labels:
-      com.puppet.role: "master_replica_host"
+      com.puppet.role: "primary_replica_host"
     ports:
       - "22"
       - "8140"

--- a/spec/docker/standard-ha/params.json
+++ b/spec/docker/standard-ha/params.json
@@ -1,6 +1,6 @@
 {
   "primary_host": "pe-std.puppet.vm",
-  "master_replica_host": "pe-std-replica.puppet.vm",
+  "primary_replica_host": "pe-std-replica.puppet.vm",
   "console_password": "puppetlabs",
   "dns_alt_names": [ "puppet", "pe-std.puppet.vm" ],
   "version": "2019.8.5"

--- a/spec/docker/standard-ha/params.json
+++ b/spec/docker/standard-ha/params.json
@@ -1,5 +1,5 @@
 {
-  "master_host": "pe-std.puppet.vm",
+  "primary_host": "pe-std.puppet.vm",
   "master_replica_host": "pe-std-replica.puppet.vm",
   "console_password": "puppetlabs",
   "dns_alt_names": [ "puppet", "pe-std.puppet.vm" ],

--- a/spec/docker/standard-ha/upgrade_params.json
+++ b/spec/docker/standard-ha/upgrade_params.json
@@ -1,5 +1,5 @@
 {
-    "master_host": "pe-std.puppet.vm",
+    "primary_host": "pe-std.puppet.vm",
     "master_replica_host": "pe-std-replica.puppet.vm",
     "version": "2019.8.5"
 }

--- a/spec/docker/standard-ha/upgrade_params.json
+++ b/spec/docker/standard-ha/upgrade_params.json
@@ -1,6 +1,6 @@
 {
     "primary_host": "pe-std.puppet.vm",
-    "master_replica_host": "pe-std-replica.puppet.vm",
+    "primary_replica_host": "pe-std-replica.puppet.vm",
     "version": "2019.8.5"
 }
   

--- a/spec/docker/standard/docker-compose.yaml
+++ b/spec/docker/standard/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
     container_name: pe-std.puppet.vm
     stop_signal: SIGRTMIN+3
     labels:
-      com.puppet.role: "master_host"
+      com.puppet.role: "primary_host"
     tmpfs:
       - /run
       - /tmp

--- a/spec/docker/standard/params.json
+++ b/spec/docker/standard/params.json
@@ -1,5 +1,5 @@
 {
-  "master_host": "pe-std.puppet.vm",
+  "primary_host": "pe-std.puppet.vm",
   "console_password": "puppetlabs",
   "dns_alt_names": [ "puppet", "pe-std.puppet.vm" ],
   "version": "2019.8.5",

--- a/spec/docker/standard/upgrade_params.json
+++ b/spec/docker/standard/upgrade_params.json
@@ -1,5 +1,5 @@
 {
-    "master_host": "pe-std.puppet.vm",
+    "primary_host": "pe-std.puppet.vm",
     "version": "2019.8.5"
 }
   

--- a/spec/functions/validate_architecture_spec.rb
+++ b/spec/functions/validate_architecture_spec.rb
@@ -9,7 +9,7 @@ describe 'peadm::validate_architecture' do
   let(:pre_condition) do
     'type TargetSpec = Variant[String[1], Target, Array[TargetSpec]]'
   end
-  let(:master_host) do
+  let(:primary_host) do
     'puppet-std.puppet.vm'
   end
   let(:master_replica_host) do
@@ -26,17 +26,17 @@ describe 'peadm::validate_architecture' do
   end
 
   it {
-    is_expected.to run.with_params(master_host)
+    is_expected.to run.with_params(primary_host)
                       .and_return('high-availability' => false, 'architecture' => 'standard')
   }
   it {
-    is_expected.to run.with_params(master_host, master_replica_host)
+    is_expected.to run.with_params(primary_host, master_replica_host)
                       .and_return('high-availability' => true, 'architecture' => 'standard')
   }
 
   it do
     is_expected.to run.with_params(
-      master_host,
+      primary_host,
       master_replica_host,
       nil,
       nil,
@@ -47,7 +47,7 @@ describe 'peadm::validate_architecture' do
 
   it do
     is_expected.to run.with_params(
-      master_host,
+      primary_host,
       nil,
       nil,
       nil,
@@ -58,7 +58,7 @@ describe 'peadm::validate_architecture' do
 
   it do
     is_expected.to run.with_params(
-      master_host,
+      primary_host,
       master_replica_host,
       puppetdb_database_host,
       puppetdb_database_replica_host,
@@ -69,7 +69,7 @@ describe 'peadm::validate_architecture' do
 
   it do
     is_expected.to run.with_params(
-      master_host,
+      primary_host,
       nil,
       puppetdb_database_host,
       nil,

--- a/spec/functions/validate_architecture_spec.rb
+++ b/spec/functions/validate_architecture_spec.rb
@@ -12,7 +12,7 @@ describe 'peadm::validate_architecture' do
   let(:primary_host) do
     'puppet-std.puppet.vm'
   end
-  let(:master_replica_host) do
+  let(:primary_replica_host) do
     'pup-replica.puppet.vm'
   end
   let(:puppetdb_database_host) do
@@ -30,14 +30,14 @@ describe 'peadm::validate_architecture' do
                       .and_return('high-availability' => false, 'architecture' => 'standard')
   }
   it {
-    is_expected.to run.with_params(primary_host, master_replica_host)
+    is_expected.to run.with_params(primary_host, primary_replica_host)
                       .and_return('high-availability' => true, 'architecture' => 'standard')
   }
 
   it do
     is_expected.to run.with_params(
       primary_host,
-      master_replica_host,
+      primary_replica_host,
       nil,
       nil,
       compiler_hosts,
@@ -59,7 +59,7 @@ describe 'peadm::validate_architecture' do
   it do
     is_expected.to run.with_params(
       primary_host,
-      master_replica_host,
+      primary_replica_host,
       puppetdb_database_host,
       puppetdb_database_replica_host,
       compiler_hosts,

--- a/spec/functions/validate_architecture_spec.rb
+++ b/spec/functions/validate_architecture_spec.rb
@@ -27,11 +27,11 @@ describe 'peadm::validate_architecture' do
 
   it {
     is_expected.to run.with_params(primary_host)
-                      .and_return('high-availability' => false, 'architecture' => 'standard')
+                      .and_return('disaster-recovery' => false, 'architecture' => 'standard')
   }
   it {
     is_expected.to run.with_params(primary_host, primary_replica_host)
-                      .and_return('high-availability' => true, 'architecture' => 'standard')
+                      .and_return('disaster-recovery' => true, 'architecture' => 'standard')
   }
 
   it do
@@ -42,7 +42,7 @@ describe 'peadm::validate_architecture' do
       nil,
       compiler_hosts,
     )
-                      .and_return('high-availability' => true, 'architecture' => 'large')
+                      .and_return('disaster-recovery' => true, 'architecture' => 'large')
   end
 
   it do
@@ -53,7 +53,7 @@ describe 'peadm::validate_architecture' do
       nil,
       compiler_hosts,
     )
-                      .and_return('high-availability' => false, 'architecture' => 'large')
+                      .and_return('disaster-recovery' => false, 'architecture' => 'large')
   end
 
   it do
@@ -64,7 +64,7 @@ describe 'peadm::validate_architecture' do
       puppetdb_database_replica_host,
       compiler_hosts,
     )
-                      .and_return('high-availability' => true, 'architecture' => 'extra-large')
+                      .and_return('disaster-recovery' => true, 'architecture' => 'extra-large')
   end
 
   it do
@@ -75,6 +75,6 @@ describe 'peadm::validate_architecture' do
       nil,
       compiler_hosts,
     )
-                      .and_return('high-availability' => false, 'architecture' => 'extra-large')
+                      .and_return('disaster-recovery' => false, 'architecture' => 'extra-large')
   end
 end

--- a/tasks/provision_replica.json
+++ b/tasks/provision_replica.json
@@ -1,7 +1,7 @@
 {
   "description": "Execute the replica provision puppet command ",
   "parameters": {
-    "master_replica": {
+    "primary_replica": {
       "type": "String",
       "description": "The name of the replica to provision"
     },

--- a/tasks/provision_replica.sh
+++ b/tasks/provision_replica.sh
@@ -14,17 +14,17 @@ fi
 set -e
 
 if [ "$PT_legacy" = "false" ]; then
-  puppet infrastructure provision replica "$PT_master_replica" \
+  puppet infrastructure provision replica "$PT_primary_replica" \
     --yes --token-file "$TOKEN_FILE" \
     --skip-agent-config \
     --topology mono-with-compile \
     --enable
 
 elif [ "$PT_legacy" = "true" ]; then
-  puppet infrastructure provision replica "$PT_master_replica" \
+  puppet infrastructure provision replica "$PT_primary_replica" \
     --token-file "$TOKEN_FILE"
 
-  puppet infrastructure enable replica "$PT_master_replica" \
+  puppet infrastructure enable replica "$PT_primary_replica" \
     --yes --token-file "$TOKEN_FILE" \
     --skip-agent-config \
     --topology mono-with-compile


### PR DESCRIPTION
master_host to primary_host

master_replica_host to primary_replica_host

master_target to primary_target

master_replica_target to primary_replica_target

master_certname to primary_certname

master to primary

HA to DR

high-availability to disaster-recovery

peadm::oid('peadm_role') => 'puppet/master', to peadm::oid('peadm_role') => 'puppet/primary',

Node groups 
PE Master B to PE Primary B
PE Master A to PE Primary A

None of the following puppet settings can be updated as all appear to still be in with no alternative https://github.com/puppetlabs/puppet-enterprise-modules/tree/main/modules/puppet_enterprise/manifests/profile and https://github.com/puppetlabs/puppet-enterprise-modules/tree/main/modules/puppet_enterprise/manifests

puppet_enterprise::profile::master
puppet_enterprise::profile::master::puppetdb
puppet_enterprise::profile::primary_master_replica
puppet_enterprise::profile::master::java_args
puppet_enterprise::puppet_master_host