### PR TITLE
Fix node group name to match out-of-box

### DIFF
--- a/manifests/setup/node_manager.pp
+++ b/manifests/setup/node_manager.pp
@@ -72,7 +72,10 @@ class peadm::setup::node_manager (
     default => { 'pe_repo' => { 'compile_master_pool_address' => $compiler_pool_address } },
   }
 
-  node_group { 'PE Primary':
+  # We do not call this node group PE Primary because it is modifying a
+  # built-in group, rather than creating a new one. And, as of PE 2021.1, the
+  # name is still PE Master.
+  node_group { 'PE Master':
     parent    => 'PE Infrastructure',
     data      => $compiler_pool_address_data,
     variables => { 'pe_master' => true },


### PR DESCRIPTION
The node group PE Master is using harmful terminology, but it matches
the product-shipped name, so making peadm use a group named PE Primary
would be a larger change for us. Continue to use the out-of-box group
for now.