### PR TITLE
Support latest PE release

### DIFF
--- a/.github/workflows/test-add-replica.yaml
+++ b/.github/workflows/test-add-replica.yaml
@@ -33,6 +33,7 @@ jobs:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true
       BUILDEVENT_FILE: '../buildevents.txt'
+      LANG: 'en_US.UTF-8'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-install-matrix.yaml
+++ b/.github/workflows/test-install-matrix.yaml
@@ -28,6 +28,7 @@ jobs:
           - extra-large-with-dr
         version:
           - 2019.8.7
+          - 2021.2.0
         image:
           - centos-7
 

--- a/.github/workflows/test-install-matrix.yaml
+++ b/.github/workflows/test-install-matrix.yaml
@@ -19,6 +19,7 @@ jobs:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true
       BUILDEVENT_FILE: '../buildevents.txt'
+      LANG: 'en_US.UTF-8'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -33,6 +33,7 @@ jobs:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true
       BUILDEVENT_FILE: '../buildevents.txt'
+      LANG: 'en_US.UTF-8'
     strategy:
       fail-fast: false
       matrix:

--- a/functions/assert_supported_pe_version.pp
+++ b/functions/assert_supported_pe_version.pp
@@ -3,16 +3,18 @@
 function peadm::assert_supported_pe_version (
   String $version,
 ) >> Struct[{'supported' => Boolean}] {
-  $supported = ($version =~ SemVerRange('>= 2019.7.0 <= 2021.0.0'))
+  $oldest = '2019.7'
+  $newest = '2021.2'
+  $supported = ($version =~ SemVerRange(">= ${oldest} <= ${newest}"))
 
   unless $supported {
     fail(@("REASON"/L))
       This version of the puppetlabs-peadm module does not support PE ${version}.
 
-      For PE versions older than 2019.7, please use version 1.x of the \
+      For PE versions older than ${oldest}, please use version 1.x of the \
       puppetlabs-peadm module.
 
-      For PE versions newer than 2021.0, check to see if a new version of peadm \
+      For PE versions newer than ${newest}, check to see if a new version of peadm \
       exists which supports that version of PE.
 
       | REASON

--- a/spec/functions/assert_supported_pe_version_spec.rb
+++ b/spec/functions/assert_supported_pe_version_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe 'peadm::assert_supported_pe_version' do
   context 'invalid PE versions' do
     it 'rejects PE versions that are too new' do
-      is_expected.to run.with_params('2021.1.0').and_raise_error(Puppet::ParseError, %r{This\ version\ of\ the})
+      is_expected.to run.with_params('2035.0.0').and_raise_error(Puppet::ParseError, %r{This\ version\ of\ the})
     end
 
     it 'rejects PE versions that are too old' do
@@ -18,12 +18,12 @@ describe 'peadm::assert_supported_pe_version' do
       is_expected.to run.with_params('2019.7.0').and_return({ 'supported' => true })
     end
 
-    it 'accepts the newest supported version number' do
-      is_expected.to run.with_params('2021.0.0').and_return({ 'supported' => true })
+    it 'accepts the newest supported version' do
+      is_expected.to run.with_params('2021.2.1').and_return({ 'supported' => true })
     end
 
     it 'accepts a version in the middle' do
-      is_expected.to run.with_params('2019.8.4').and_return({ 'supported' => true })
+      is_expected.to run.with_params('2019.8.7').and_return({ 'supported' => true })
     end
   end
 end


### PR DESCRIPTION
Sets the upper bound for supported PE to something that matches a
released version of 2021.