### PR TITLE
Global rename of primary/replica and postgresql parameters

### DIFF
--- a/.github/workflows/manual-smoke-test-with-debugging.yaml
+++ b/.github/workflows/manual-smoke-test-with-debugging.yaml
@@ -139,6 +139,12 @@ jobs:
             echo STEP_START=$(date +%s) >> $GITHUB_ENV
           echo ::endgroup::
 
+      - name: 'Start SSH session before tearing down the cluster'
+        uses: luchihoratiu/debug-via-ssh@main
+        with:
+          NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
+          SSH_PASS: ${{ secrets.SSH_PASS }}
+
       - name: 'Tear down test cluster'
         if: ${{ always() }}
         continue-on-error: true

--- a/.github/workflows/manual-smoke-test-with-debugging.yaml
+++ b/.github/workflows/manual-smoke-test-with-debugging.yaml
@@ -139,11 +139,14 @@ jobs:
             echo STEP_START=$(date +%s) >> $GITHUB_ENV
           echo ::endgroup::
 
-      - name: 'Start SSH session before tearing down the cluster'
-        uses: luchihoratiu/debug-via-ssh@main
-        with:
-          NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
-          SSH_PASS: ${{ secrets.SSH_PASS }}
+      - name: 'Wait as long as the file ${HOME}/pause file is present'
+        if: ${{ always() }}
+        run: |
+          while [ -f "${HOME}/pause" ] ; do
+            echo "${HOME}/pause present, sleeping for 60 seconds..."
+            sleep 60
+          done 
+          echo "${HOME}/pause absent, continuing workflow."
 
       - name: 'Tear down test cluster'
         if: ${{ always() }}

--- a/documentation/convert.md
+++ b/documentation/convert.md
@@ -9,7 +9,7 @@ Prepare to run the plan against all servers in the PE infrastructure, using a pa
 ```json
 {
   "primary_host": "pe-xl-core-0.lab1.puppet.vm",
-  "primary_replica_host": "pe-xl-core-1.lab1.puppet.vm",
+  "replica_host": "pe-xl-core-1.lab1.puppet.vm",
   "compiler_hosts": [
     "pe-xl-compiler-0.lab1.puppet.vm",
     "pe-xl-compiler-1.lab1.puppet.vm"

--- a/documentation/provision.md
+++ b/documentation/provision.md
@@ -88,9 +88,9 @@ Example params.json Bolt parameters file (shown: Extra Large with DR):
 ```json
 {
   "primary_host": "pe-xl-core-0.lab1.puppet.vm",
-  "puppetdb_database_host": "pe-xl-core-1.lab1.puppet.vm",
-  "primary_replica_host": "pe-xl-core-2.lab1.puppet.vm",
-  "puppetdb_database_replica_host": "pe-xl-core-3.lab1.puppet.vm",
+  "primary_postgresql_host": "pe-xl-core-1.lab1.puppet.vm",
+  "replica_host": "pe-xl-core-2.lab1.puppet.vm",
+  "replica_postgresql_host": "pe-xl-core-3.lab1.puppet.vm",
   "compiler_hosts": [
     "pe-xl-compiler-0.lab1.puppet.vm",
     "pe-xl-compiler-1.lab1.puppet.vm"
@@ -147,7 +147,7 @@ A parameters JSON file can then reference the target names, which will become th
 ```json
 {
   "primary_host": "pe-xl-core-0.lab1.puppet.vm",
-  "primary_replica_host": "pe-xl-core-1.lab1.puppet.vm",
+  "replica_host": "pe-xl-core-1.lab1.puppet.vm",
 
   "console_password": "puppetlabs",
   "dns_alt_names": [ "puppet", "puppet.lab1.puppet.vm" ],

--- a/documentation/upgrade.md
+++ b/documentation/upgrade.md
@@ -12,9 +12,9 @@ The following is an example parameters file for upgrading an Extra Large archite
 {
   "version": "2019.2.2",
   "primary_host": "pe-master-09a40c-0.us-west1-a.c.reidmv-peadm.internal",
-  "puppetdb_database_host": "pe-psql-09a40c-0.us-west1-a.c.reidmv-peadm.internal",
-  "primary_replica_host": "pe-master-09a40c-1.us-west1-b.c.reidmv-peadm.internal",
-  "puppetdb_database_replica_host": "pe-psql-09a40c-1.us-west1-b.c.reidmv-peadm.internal",
+  "primary_postgresql_host": "pe-psql-09a40c-0.us-west1-a.c.reidmv-peadm.internal",
+  "replica_host": "pe-master-09a40c-1.us-west1-b.c.reidmv-peadm.internal",
+  "replica_postgresql_host": "pe-psql-09a40c-1.us-west1-b.c.reidmv-peadm.internal",
   "compiler_hosts": [
     "pe-compiler-09a40c-0.us-west1-a.c.reidmv-peadm.internal",
     "pe-compiler-09a40c-1.us-west1-b.c.reidmv-peadm.internal",

--- a/examples/provision/extra-large-ha.json
+++ b/examples/provision/extra-large-ha.json
@@ -2,9 +2,9 @@
   "version": "2019.4.0",
   "console_password": "puppetlabs",
   "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
-  "primary_replica_host": "pe-master-1830cd-1.us-west1-b.c.reidmv-peadm.internal",
-  "puppetdb_database_host": "pe-psql-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
-  "puppetdb_database_replica_host": "pe-psql-1830cd-1.us-west1-b.c.reidmv-peadm.internal",
+  "replica_host": "pe-master-1830cd-1.us-west1-b.c.reidmv-peadm.internal",
+  "primary_postgresql_host": "pe-psql-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
+  "replica_postgresql_host": "pe-psql-1830cd-1.us-west1-b.c.reidmv-peadm.internal",
   "compiler_pool_address": "puppet.pe-compiler-lb-1830cd.il4.us-west1.lb.reidmv-peadm.internal",
   "compiler_hosts": [
     "pe-compiler-1830cd-0.us-west1-a.c.reidmv-peadm.internal",

--- a/examples/provision/extra-large.json
+++ b/examples/provision/extra-large.json
@@ -3,7 +3,7 @@
   "console_password": "puppetlabs",
   "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
 
-  "puppetdb_database_host": "pe-psql-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
+  "primary_postgresql_host": "pe-psql-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
 
   "compiler_pool_address": "puppet.pe-compiler-lb-1830cd.il4.us-west1.lb.reidmv-peadm.internal",
   "compiler_hosts": [

--- a/examples/provision/large-ha.json
+++ b/examples/provision/large-ha.json
@@ -2,7 +2,7 @@
   "version": "2019.4.0",
   "console_password": "puppetlabs",
   "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
-  "primary_replica_host": "pe-master-1830cd-1.us-west1-b.c.reidmv-peadm.internal",
+  "replica_host": "pe-master-1830cd-1.us-west1-b.c.reidmv-peadm.internal",
 
 
   "compiler_pool_address": "puppet.pe-compiler-lb-1830cd.il4.us-west1.lb.reidmv-peadm.internal",

--- a/examples/provision/standard-ha.json
+++ b/examples/provision/standard-ha.json
@@ -2,7 +2,7 @@
   "version": "2019.4.0",
   "console_password": "puppetlabs",
   "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
-  "primary_replica_host": "pe-master-1830cd-1.us-west1-b.c.reidmv-peadm.internal",
+  "replica_host": "pe-master-1830cd-1.us-west1-b.c.reidmv-peadm.internal",
 
 
   "compiler_pool_address": "puppet.pe-compiler-lb-1830cd.il4.us-west1.lb.reidmv-peadm.internal",

--- a/functions/assert_supported_architecture.pp
+++ b/functions/assert_supported_architecture.pp
@@ -1,15 +1,15 @@
 function peadm::assert_supported_architecture (
   TargetSpec                 $primary_host,
-  Variant[TargetSpec, Undef] $primary_replica_host = undef,
-  Variant[TargetSpec, Undef] $puppetdb_database_host = undef,
-  Variant[TargetSpec, Undef] $puppetdb_database_replica_host = undef,
+  Variant[TargetSpec, Undef] $replica_host = undef,
+  Variant[TargetSpec, Undef] $primary_postgresql_host = undef,
+  Variant[TargetSpec, Undef] $replica_postgresql_host = undef,
   Variant[TargetSpec, Undef] $compiler_hosts = undef,
 )  >> Hash {
   $result = case [
     !!($primary_host),
-    !!($primary_replica_host),
-    !!($puppetdb_database_host),
-    !!($puppetdb_database_replica_host),
+    !!($replica_host),
+    !!($primary_postgresql_host),
+    !!($replica_postgresql_host),
   ] {
     [true, false, false, false]: { # Standard or Large, no DR
       ({ 'disaster-recovery' => false, 'architecture' => $compiler_hosts ? {
@@ -33,13 +33,13 @@ function peadm::assert_supported_architecture (
       out::message(inline_epp(@(HEREDOC)))
         Invalid architecture! Recieved:
           - primary
-        <% if $primary_replica_host { -%>
+        <% if $replica_host { -%>
           - primary-replica
         <% } -%>
-        <% if $puppetdb_database_host { -%>
+        <% if $primary_postgresql_host { -%>
           - pdb-database
         <% } -%>
-        <% if $puppetdb_database_replica_host { -%>
+        <% if $replica_postgresql_host { -%>
           - pdb-database-replica
         <% } -%>
         <% if $compiler_hosts { -%>

--- a/manifests/setup/node_manager.pp
+++ b/manifests/setup/node_manager.pp
@@ -26,22 +26,22 @@ class peadm::setup::node_manager (
   String[1] $primary_host,
 
   # High Availability
-  Optional[String[1]] $primary_replica_host            = undef,
+  Optional[String[1]] $replica_host                     = undef,
 
   # Common
   Optional[String[1]] $compiler_pool_address            = undef,
   Optional[String[1]] $internal_compiler_a_pool_address = $primary_host,
-  Optional[String[1]] $internal_compiler_b_pool_address = $primary_replica_host,
+  Optional[String[1]] $internal_compiler_b_pool_address = $replica_host,
 
   # For the next two parameters, the default values are appropriate when
   # deploying Standard or Large architectures. These values only need to be
   # specified differently when deploying an Extra Large architecture.
 
   # Specify when using Extra Large
-  String[1]           $puppetdb_database_host         = $primary_host,
+  String[1]           $primary_postgresql_host         = $primary_host,
 
   # Specify when using Extra Large AND High Availability
-  Optional[String[1]] $puppetdb_database_replica_host = $primary_replica_host,
+  Optional[String[1]] $replica_postgresql_host         = $replica_host,
 ) {
 
   # Preserve existing user data and classes values. We only need to make sure
@@ -105,10 +105,10 @@ class peadm::setup::node_manager (
     ],
     data   => {
       'puppet_enterprise::profile::primary_master_replica' => {
-        'database_host_puppetdb' => $puppetdb_database_host,
+        'database_host_puppetdb' => $primary_postgresql_host,
       },
       'puppet_enterprise::profile::puppetdb'               => {
-        'database_host' => $puppetdb_database_host,
+        'database_host' => $primary_postgresql_host,
       },
     },
   }
@@ -124,7 +124,7 @@ class peadm::setup::node_manager (
     ],
     classes => {
       'puppet_enterprise::profile::puppetdb' => {
-        'database_host' => $puppetdb_database_host,
+        'database_host' => $primary_postgresql_host,
       },
       'puppet_enterprise::profile::master'   => {
         # lint:ignore:single_quote_string_with_variables
@@ -143,7 +143,7 @@ class peadm::setup::node_manager (
 
   # Create the replica and B groups if a replica primary and database host are
   # supplied
-  if $primary_replica_host {
+  if $replica_host {
     # We need to ensure this group provides the peadm_replica variable.
     node_group { 'PE DR Replica':
       ensure    => 'present',
@@ -163,10 +163,10 @@ class peadm::setup::node_manager (
       ],
       data   => {
         'puppet_enterprise::profile::primary_master_replica' => {
-          'database_host_puppetdb' => $puppetdb_database_replica_host,
+          'database_host_puppetdb' => $replica_postgresql_host,
         },
         'puppet_enterprise::profile::puppetdb'               => {
-          'database_host' => $puppetdb_database_replica_host,
+          'database_host' => $replica_postgresql_host,
         },
       },
     }
@@ -180,7 +180,7 @@ class peadm::setup::node_manager (
       ],
       classes => {
         'puppet_enterprise::profile::puppetdb' => {
-          'database_host' => $puppetdb_database_replica_host,
+          'database_host' => $replica_postgresql_host,
         },
         'puppet_enterprise::profile::master'   => {
           # lint:ignore:single_quote_string_with_variables

--- a/plans/action/configure.pp
+++ b/plans/action/configure.pp
@@ -15,14 +15,14 @@
 plan peadm::action::configure (
   # Standard
   Peadm::SingleTargetSpec           $primary_host,
-  Optional[Peadm::SingleTargetSpec] $primary_replica_host = undef,
+  Optional[Peadm::SingleTargetSpec] $replica_host = undef,
 
   # Large
   Optional[TargetSpec]              $compiler_hosts = undef,
 
   # Extra Large
-  Optional[Peadm::SingleTargetSpec] $puppetdb_database_host         = undef,
-  Optional[Peadm::SingleTargetSpec] $puppetdb_database_replica_host = undef,
+  Optional[Peadm::SingleTargetSpec] $primary_postgresql_host = undef,
+  Optional[Peadm::SingleTargetSpec] $replica_postgresql_host = undef,
 
   # Common Configuration
   String           $compiler_pool_address = $primary_host.peadm::certname(),
@@ -38,17 +38,17 @@ plan peadm::action::configure (
 
   # Convert inputs into targets.
   $primary_target                   = peadm::get_targets($primary_host, 1)
-  $primary_replica_target           = peadm::get_targets($primary_replica_host, 1)
-  $puppetdb_database_replica_target = peadm::get_targets($puppetdb_database_replica_host, 1)
+  $replica_target                   = peadm::get_targets($replica_host, 1)
+  $replica_postgresql_target        = peadm::get_targets($replica_postgresql_host, 1)
   $compiler_targets                 = peadm::get_targets($compiler_hosts)
-  $puppetdb_database_target         = peadm::get_targets($puppetdb_database_host, 1)
+  $primary_postgresql_target        = peadm::get_targets($primary_postgresql_host, 1)
 
   # Ensure input valid for a supported architecture
   $arch = peadm::assert_supported_architecture(
     $primary_host,
-    $primary_replica_host,
-    $puppetdb_database_host,
-    $puppetdb_database_replica_host,
+    $replica_host,
+    $primary_postgresql_host,
+    $replica_postgresql_host,
     $compiler_hosts,
   )
 
@@ -60,7 +60,7 @@ plan peadm::action::configure (
   ).first['content']
 
   run_task('peadm::mkdir_p_file', peadm::flatten_compact([
-    $primary_replica_target,
+    $replica_target,
     $compiler_targets,
   ]),
     path    => '/etc/puppetlabs/puppet/hiera.yaml',
@@ -79,9 +79,9 @@ plan peadm::action::configure (
 
     class { 'peadm::setup::node_manager':
       primary_host                     => $primary_target.peadm::certname(),
-      primary_replica_host             => $primary_replica_target.peadm::certname(),
-      puppetdb_database_host           => $puppetdb_database_target.peadm::certname(),
-      puppetdb_database_replica_host   => $puppetdb_database_replica_target.peadm::certname(),
+      replica_host                     => $replica_target.peadm::certname(),
+      primary_postgresql_host          => $primary_postgresql_target.peadm::certname(),
+      replica_postgresql_host          => $replica_postgresql_target.peadm::certname(),
       compiler_pool_address            => $compiler_pool_address,
       internal_compiler_a_pool_address => $internal_compiler_a_pool_address,
       internal_compiler_b_pool_address => $internal_compiler_b_pool_address,
@@ -92,23 +92,23 @@ plan peadm::action::configure (
   if $arch['disaster-recovery'] {
     # Run the PE Replica Provision
     run_task('peadm::provision_replica', $primary_target,
-      primary_replica => $primary_replica_target.peadm::certname(),
-      token_file      => $token_file,
+      replica    => $replica_target.peadm::certname(),
+      token_file => $token_file,
 
       # Race condition, where the provision command checks PuppetDB status and
       # probably gets "starting", but fails out because that's not "running".
       # Can remove flag when that issue is fixed.
-      legacy          => true,
+      legacy     => true,
     )
   }
 
   # Run Puppet everywhere to pick up last remaining config tweaks
   run_task('peadm::puppet_runonce', peadm::flatten_compact([
     $primary_target,
-    $puppetdb_database_target,
+    $primary_postgresql_target,
     $compiler_targets,
-    $primary_replica_target,
-    $puppetdb_database_replica_target,
+    $replica_target,
+    $replica_postgresql_target,
   ]))
 
   # Deploy an environment if a deploy environment is specified
@@ -121,9 +121,9 @@ plan peadm::action::configure (
   # Ensure Puppet agent service is running now that configuration is complete
   run_command('systemctl start puppet', peadm::flatten_compact([
     $primary_target,
-    $primary_replica_target,
-    $puppetdb_database_target,
-    $puppetdb_database_replica_target,
+    $replica_target,
+    $primary_postgresql_target,
+    $replica_postgresql_target,
     $compiler_targets,
   ]))
 

--- a/plans/action/install.pp
+++ b/plans/action/install.pp
@@ -149,7 +149,7 @@ plan peadm::action::install (
     'console_admin_password'                                          => $console_password,
     'puppet_enterprise::puppet_master_host'                           => $primary_target.peadm::certname(),
     'pe_install::puppet_master_dnsaltnames'                           => $dns_alt_names,
-    'puppet_enterprise::primary_postgresql_host'                      => $primary_postgresql_target.peadm::certname(),
+    'puppet_enterprise::puppetdb_database_host'                       => $primary_postgresql_target.peadm::certname(),
     'puppet_enterprise::profile::master::code_manager_auto_configure' => true,
     'puppet_enterprise::profile::master::r10k_remote'                 => $r10k_remote,
     'puppet_enterprise::profile::master::r10k_private_key'            => $r10k_private_key ? {

--- a/plans/convert.pp
+++ b/plans/convert.pp
@@ -1,14 +1,14 @@
 plan peadm::convert (
   # Standard
   Peadm::SingleTargetSpec           $primary_host,
-  Optional[Peadm::SingleTargetSpec] $primary_replica_host = undef,
+  Optional[Peadm::SingleTargetSpec] $replica_host = undef,
 
   # Large
   Optional[TargetSpec]              $compiler_hosts = undef,
 
   # Extra Large
-  Optional[Peadm::SingleTargetSpec] $puppetdb_database_host         = undef,
-  Optional[Peadm::SingleTargetSpec] $puppetdb_database_replica_host = undef,
+  Optional[Peadm::SingleTargetSpec] $primary_postgresql_host         = undef,
+  Optional[Peadm::SingleTargetSpec] $replica_postgresql_host = undef,
 
   # Common Configuration
   String                            $compiler_pool_address            = $primary_host,
@@ -28,25 +28,25 @@ plan peadm::convert (
 
   # Convert inputs into targets.
   $primary_target                   = peadm::get_targets($primary_host, 1)
-  $primary_replica_target           = peadm::get_targets($primary_replica_host, 1)
-  $puppetdb_database_replica_target = peadm::get_targets($puppetdb_database_replica_host, 1)
+  $replica_target                   = peadm::get_targets($replica_host, 1)
+  $replica_postgresql_target        = peadm::get_targets($replica_postgresql_host, 1)
   $compiler_targets                 = peadm::get_targets($compiler_hosts)
-  $puppetdb_database_target         = peadm::get_targets($puppetdb_database_host, 1)
+  $primary_postgresql_target        = peadm::get_targets($primary_postgresql_host, 1)
 
   $all_targets = peadm::flatten_compact([
     $primary_target,
-    $primary_replica_target,
-    $puppetdb_database_replica_target,
+    $replica_target,
+    $replica_postgresql_target,
     $compiler_targets,
-    $puppetdb_database_target,
+    $primary_postgresql_target,
   ])
 
   # Ensure input valid for a supported architecture
   $arch = peadm::assert_supported_architecture(
     $primary_host,
-    $primary_replica_host,
-    $puppetdb_database_host,
-    $puppetdb_database_replica_host,
+    $replica_host,
+    $primary_postgresql_host,
+    $replica_postgresql_host,
     $compiler_hosts,
   )
 
@@ -146,7 +146,7 @@ plan peadm::convert (
     # Kick off all the cert modification jobs in parallel
     $background_cert_jobs = [
       background('modify-replica-cert') || {
-        run_plan('peadm::modify_cert_extensions', $primary_replica_target,
+        run_plan('peadm::modify_cert_extensions', $replica_target,
           primary_host => $primary_target,
           add          => {
             peadm::oid('peadm_role')               => 'puppet/server',
@@ -155,7 +155,7 @@ plan peadm::convert (
         )
       },
       background('modify-primary-postgresql-cert') || {
-        run_plan('peadm::modify_cert_extensions', $puppetdb_database_target,
+        run_plan('peadm::modify_cert_extensions', $primary_postgresql_target,
           primary_host => $primary_target,
           add          => {
             peadm::oid('peadm_role')               => 'puppet/puppetdb-database',
@@ -164,7 +164,7 @@ plan peadm::convert (
         )
       },
       background('modify-replica-postgresql-cert') || {
-        run_plan('peadm::modify_cert_extensions', $puppetdb_database_replica_target,
+        run_plan('peadm::modify_cert_extensions', $replica_postgresql_target,
           primary_host => $primary_target,
           add          => {
             peadm::oid('peadm_role')               => 'puppet/puppetdb-database',
@@ -209,9 +209,9 @@ plan peadm::convert (
 
         class { 'peadm::setup::node_manager':
           primary_host                     => $primary_target.peadm::certname(),
-          primary_replica_host             => $primary_replica_target.peadm::certname(),
-          puppetdb_database_host           => $puppetdb_database_target.peadm::certname(),
-          puppetdb_database_replica_host   => $puppetdb_database_replica_target.peadm::certname(),
+          replica_host                     => $replica_target.peadm::certname(),
+          primary_postgresql_host          => $primary_postgresql_target.peadm::certname(),
+          replica_postgresql_host          => $replica_postgresql_target.peadm::certname(),
           compiler_pool_address            => $compiler_pool_address,
           internal_compiler_a_pool_address => $internal_compiler_a_pool_address,
           internal_compiler_b_pool_address => $internal_compiler_b_pool_address,

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -23,7 +23,7 @@ plan peadm::install (
   Optional[TargetSpec]              $compiler_hosts = undef,
 
   # Extra Large
-  Optional[Peadm::SingleTargetSpec] $primary_postgresql_host         = undef,
+  Optional[Peadm::SingleTargetSpec] $primary_postgresql_host = undef,
   Optional[Peadm::SingleTargetSpec] $replica_postgresql_host = undef,
 
   # Common Configuration

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -17,14 +17,14 @@
 plan peadm::install (
   # Standard
   Peadm::SingleTargetSpec           $primary_host,
-  Optional[Peadm::SingleTargetSpec] $primary_replica_host = undef,
+  Optional[Peadm::SingleTargetSpec] $replica_host = undef,
 
   # Large
   Optional[TargetSpec]              $compiler_hosts = undef,
 
   # Extra Large
-  Optional[Peadm::SingleTargetSpec] $puppetdb_database_host         = undef,
-  Optional[Peadm::SingleTargetSpec] $puppetdb_database_replica_host = undef,
+  Optional[Peadm::SingleTargetSpec] $primary_postgresql_host         = undef,
+  Optional[Peadm::SingleTargetSpec] $replica_postgresql_host = undef,
 
   # Common Configuration
   String                            $console_password,
@@ -55,15 +55,15 @@ plan peadm::install (
 
   $install_result = run_plan('peadm::action::install',
     # Standard
-    primary_host                    => $primary_host,
-    primary_replica_host            => $primary_replica_host,
+    primary_host                   => $primary_host,
+    replica_host                   => $replica_host,
 
     # Large
     compiler_hosts                 => $compiler_hosts,
 
     # Extra Large
-    puppetdb_database_host         => $puppetdb_database_host,
-    puppetdb_database_replica_host => $puppetdb_database_replica_host,
+    primary_postgresql_host        => $primary_postgresql_host,
+    replica_postgresql_host        => $replica_postgresql_host,
 
     # Common Configuration
     version                        => $version,
@@ -87,15 +87,15 @@ plan peadm::install (
 
   $configure_result = run_plan('peadm::action::configure',
     # Standard
-    primary_host                      => $primary_host,
-    primary_replica_host              => $primary_replica_host,
+    primary_host                     => $primary_host,
+    replica_host                     => $replica_host,
 
     # Large
     compiler_hosts                   => $compiler_hosts,
 
     # Extra Large
-    puppetdb_database_host           => $puppetdb_database_host,
-    puppetdb_database_replica_host   => $puppetdb_database_replica_host,
+    primary_postgresql_host          => $primary_postgresql_host,
+    replica_postgresql_host          => $replica_postgresql_host,
 
     # Common Configuration
     compiler_pool_address            => $compiler_pool_address,

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -21,7 +21,7 @@ plan peadm::upgrade (
   Optional[TargetSpec]              $compiler_hosts      = undef,
 
   # Extra Large
-  Optional[Peadm::SingleTargetSpec] $primary_postgresql_host         = undef,
+  Optional[Peadm::SingleTargetSpec] $primary_postgresql_host = undef,
   Optional[Peadm::SingleTargetSpec] $replica_postgresql_host = undef,
 
   # Common Configuration
@@ -57,9 +57,9 @@ plan peadm::upgrade (
   )
 
   # Convert inputs into targets.
-  $primary_target                   = peadm::get_targets($primary_host, 1)
-  $replica_target           = peadm::get_targets($replica_host, 1)
-  $primary_postgresql_target         = peadm::get_targets($primary_postgresql_host, 1)
+  $primary_target            = peadm::get_targets($primary_host, 1)
+  $replica_target            = peadm::get_targets($replica_host, 1)
+  $primary_postgresql_target = peadm::get_targets($primary_postgresql_host, 1)
   $replica_postgresql_target = peadm::get_targets($replica_postgresql_host, 1)
   $compiler_targets                 = peadm::get_targets($compiler_hosts)
 

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -15,14 +15,14 @@
 plan peadm::upgrade (
   # Standard
   Peadm::SingleTargetSpec           $primary_host,
-  Optional[Peadm::SingleTargetSpec] $primary_replica_host = undef,
+  Optional[Peadm::SingleTargetSpec] $replica_host = undef,
 
   # Large
   Optional[TargetSpec]              $compiler_hosts      = undef,
 
   # Extra Large
-  Optional[Peadm::SingleTargetSpec] $puppetdb_database_host         = undef,
-  Optional[Peadm::SingleTargetSpec] $puppetdb_database_replica_host = undef,
+  Optional[Peadm::SingleTargetSpec] $primary_postgresql_host         = undef,
+  Optional[Peadm::SingleTargetSpec] $replica_postgresql_host = undef,
 
   # Common Configuration
   String           $version,
@@ -50,31 +50,31 @@ plan peadm::upgrade (
   # Ensure input valid for a supported architecture
   $arch = peadm::assert_supported_architecture(
     $primary_host,
-    $primary_replica_host,
-    $puppetdb_database_host,
-    $puppetdb_database_replica_host,
+    $replica_host,
+    $primary_postgresql_host,
+    $replica_postgresql_host,
     $compiler_hosts,
   )
 
   # Convert inputs into targets.
   $primary_target                   = peadm::get_targets($primary_host, 1)
-  $primary_replica_target           = peadm::get_targets($primary_replica_host, 1)
-  $puppetdb_database_target         = peadm::get_targets($puppetdb_database_host, 1)
-  $puppetdb_database_replica_target = peadm::get_targets($puppetdb_database_replica_host, 1)
+  $replica_target           = peadm::get_targets($replica_host, 1)
+  $primary_postgresql_target         = peadm::get_targets($primary_postgresql_host, 1)
+  $replica_postgresql_target = peadm::get_targets($replica_postgresql_host, 1)
   $compiler_targets                 = peadm::get_targets($compiler_hosts)
 
   $all_targets = peadm::flatten_compact([
     $primary_target,
-    $puppetdb_database_target,
-    $primary_replica_target,
-    $puppetdb_database_replica_target,
+    $primary_postgresql_target,
+    $replica_target,
+    $replica_postgresql_target,
     $compiler_targets,
   ])
 
   $pe_installer_targets = peadm::flatten_compact([
     $primary_target,
-    $puppetdb_database_target,
-    $puppetdb_database_replica_target,
+    $primary_postgresql_target,
+    $replica_postgresql_target,
   ])
 
   out::message('# Gathering information')
@@ -112,7 +112,7 @@ plan peadm::upgrade (
 
   $compiler_m2_targets = $compiler_targets.filter |$target| {
     ($cert_extensions[$target.name][peadm::oid('peadm_availability_group')]
-      == $cert_extensions[$primary_replica_target[0].name][peadm::oid('peadm_availability_group')])
+      == $cert_extensions[$replica_target[0].name][peadm::oid('peadm_availability_group')])
   }
 
   $primary_target.peadm::fail_on_transport('pcp')
@@ -150,7 +150,7 @@ plan peadm::upgrade (
     # that are known to need it.
     $profile_database_puppetdb_hosts = {
       'puppet_enterprise::profile::database::puppetdb_hosts' => (
-        $compiler_targets + $primary_target + $primary_replica_target
+        $compiler_targets + $primary_target + $replica_target
       ).map |$t| { $t.peadm::certname() },
     }
 
@@ -158,8 +158,8 @@ plan peadm::upgrade (
     # is only ever consulted during install and upgrade of these nodes, but if
     # it contains the wrong values, upgrade will fail.
     peadm::flatten_compact([
-      $puppetdb_database_target,
-      $puppetdb_database_replica_target,
+      $primary_postgresql_target,
+      $replica_postgresql_target,
     ]).each |$target| {
       $current_pe_conf = run_task('peadm::read_file', $target,
         path => '/etc/puppetlabs/enterprise/conf.d/pe.conf',
@@ -183,7 +183,7 @@ plan peadm::upgrade (
     # of run_task(service, ...) so that upgrading from 2018.1 works over PCP.
     run_command('systemctl stop pe-puppetdb', $compiler_m1_targets)
 
-    run_task('peadm::pe_install', $puppetdb_database_target,
+    run_task('peadm::pe_install', $primary_postgresql_target,
       tarball               => $upload_tarball_path,
       puppet_service_ensure => 'stopped',
     )
@@ -203,7 +203,7 @@ plan peadm::upgrade (
     # Re-run Puppet immediately to fully re-enable
     run_task('peadm::puppet_runonce', peadm::flatten_compact([
       $primary_target,
-      $puppetdb_database_target,
+      $primary_postgresql_target,
     ]))
   }
 
@@ -233,9 +233,9 @@ plan peadm::upgrade (
 
       class { 'peadm::setup::node_manager':
         primary_host                     => $primary_target.peadm::certname(),
-        primary_replica_host             => $primary_replica_target.peadm::certname(),
-        puppetdb_database_host           => $puppetdb_database_target.peadm::certname(),
-        puppetdb_database_replica_host   => $puppetdb_database_replica_target.peadm::certname(),
+        replica_host                     => $replica_target.peadm::certname(),
+        primary_postgresql_host          => $primary_postgresql_target.peadm::certname(),
+        replica_postgresql_host          => $replica_postgresql_target.peadm::certname(),
         compiler_pool_address            => $compiler_pool_address,
         internal_compiler_a_pool_address => $internal_compiler_a_pool_address,
         internal_compiler_b_pool_address => $internal_compiler_b_pool_address,
@@ -259,7 +259,7 @@ plan peadm::upgrade (
     # over PCP.
     run_command('systemctl stop pe-puppetdb', $compiler_m2_targets)
 
-    run_task('peadm::pe_install', $puppetdb_database_replica_target,
+    run_task('peadm::pe_install', $replica_postgresql_target,
       tarball               => $upload_tarball_path,
       puppet_service_ensure => 'stopped',
     )
@@ -272,7 +272,7 @@ plan peadm::upgrade (
     # also run Puppet immediately on the primary.
     run_task('peadm::puppet_runonce', peadm::flatten_compact([
       $primary_target,
-      $puppetdb_database_replica_target,
+      $replica_postgresql_target,
     ]))
 
     # The `puppetdb delete-reports` CLI app has a bug in 2019.8.0 where it
@@ -281,7 +281,7 @@ plan peadm::upgrade (
     $pdbapps = '/opt/puppetlabs/server/apps/puppetdb/cli/apps'
     $workaround_delete_reports = $arch['disaster-recovery'] and $version =~ SemVerRange('>= 2019.8')
     if $workaround_delete_reports {
-      run_command(@("COMMAND"/$), $primary_replica_target)
+      run_command(@("COMMAND"/$), $replica_target)
         if [ -e ${pdbapps}/delete-reports -a ! -h ${pdbapps}/delete-reports ]
         then
           mv ${pdbapps}/delete-reports ${pdbapps}/delete-reports.original
@@ -293,13 +293,13 @@ plan peadm::upgrade (
     # Upgrade the primary replica.
     run_task('peadm::puppet_infra_upgrade', $primary_target,
       type       => 'replica',
-      targets    => $primary_replica_target.map |$t| { $t.peadm::certname() },
+      targets    => $replica_target.map |$t| { $t.peadm::certname() },
       token_file => $token_file,
     )
 
     # Return the delete-reports CLI app to its original state
     if $workaround_delete_reports {
-      run_command(@("COMMAND"/$), $primary_replica_target)
+      run_command(@("COMMAND"/$), $replica_target)
         if [ -e ${pdbapps}/delete-reports.original ]
         then
           mv ${pdbapps}/delete-reports.original ${pdbapps}/delete-reports

--- a/spec/docker/extra-large-ha/docker-compose.yaml
+++ b/spec/docker/extra-large-ha/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
     image: pe-base
     privileged: true # required for systemd
     labels:
-      com.puppet.role: "puppetdb_database_host"
+      com.puppet.role: "primary_postgresql_host"
     ports:
       - "22"
     hostname: pe-xl-db-0.puppet.vm
@@ -56,7 +56,7 @@ services:
     image: pe-base
     privileged: true # required for systemd
     labels:
-      com.puppet.role: "puppetdb_database_replica_host"
+      com.puppet.role: "replica_postgresql_host"
     ports:
       - "22"
     hostname: pe-xl-db-1.puppet.vm
@@ -80,7 +80,7 @@ services:
     image: pe-base
     privileged: true # required for systemd
     labels:
-      com.puppet.role: "primary_replica_host"
+      com.puppet.role: "replica_host"
     ports:
       - "22"
       - "8140"

--- a/spec/docker/extra-large-ha/params.json
+++ b/spec/docker/extra-large-ha/params.json
@@ -1,8 +1,8 @@
 {
   "primary_host": "pe-xl-core-0.puppet.vm",
-  "puppetdb_database_host": "pe-xl-db-0.puppet.vm",
-  "puppetdb_database_replica_host": "pe-xl-db-1.puppet.vm",
-  "primary_replica_host": "pe-xl-core-1.puppet.vm",
+  "primary_postgresql_host": "pe-xl-db-0.puppet.vm",
+  "replica_postgresql_host": "pe-xl-db-1.puppet.vm",
+  "replica_host": "pe-xl-core-1.puppet.vm",
   "compiler_hosts": ["pe-xl-compiler-0.puppet.vm"],
   "console_password": "puppetlabs",
   "dns_alt_names": [ "puppet", "pe-xl-core-0.puppet.vm", "puppet-xl.vm" ],

--- a/spec/docker/extra-large-ha/upgrade_params.json
+++ b/spec/docker/extra-large-ha/upgrade_params.json
@@ -1,8 +1,8 @@
 {
     "primary_host": "pe-xl-core-0.puppet.vm",
-    "puppetdb_database_host": "pe-xl-db-0.puppet.vm",
-    "puppetdb_database_replica_host": "pe-xl-db-1.puppet.vm",
-    "primary_replica_host": "pe-xl-core-1.puppet.vm",
+    "primary_postgresql_host": "pe-xl-db-0.puppet.vm",
+    "replica_postgresql_host": "pe-xl-db-1.puppet.vm",
+    "replica_host": "pe-xl-core-1.puppet.vm",
     "compiler_hosts": ["pe-xl-compiler-0.puppet.vm"],
     "version": "2019.8.5"
 }

--- a/spec/docker/extra-large/docker-compose.yaml
+++ b/spec/docker/extra-large/docker-compose.yaml
@@ -32,7 +32,7 @@ services:
     image: pe-base
     privileged: true # required for systemd
     labels:
-      com.puppet.role: "puppetdb_database_host"
+      com.puppet.role: "primary_postgresql_host"
     ports:
       - "22"
     hostname: pe-xl-db-0.puppet.vm

--- a/spec/docker/extra-large/params.json
+++ b/spec/docker/extra-large/params.json
@@ -1,6 +1,6 @@
 {
   "primary_host": "pe-xl-core-0.puppet.vm",
-  "puppetdb_database_host": "pe-xl-db-0.puppet.vm",
+  "primary_postgresql_host": "pe-xl-db-0.puppet.vm",
   "compiler_hosts": ["pe-xl-compiler-0.puppet.vm"],
   "console_password": "puppetlabs",
   "dns_alt_names": [ "puppet", "pe-xl-core-0.puppet.vm" ],

--- a/spec/docker/extra-large/upgrade_params.json
+++ b/spec/docker/extra-large/upgrade_params.json
@@ -1,6 +1,6 @@
 {
     "primary_host": "pe-xl-core-0.puppet.vm",
-    "puppetdb_database_host": "pe-xl-db-0.puppet.vm",
+    "primary_postgresql_host": "pe-xl-db-0.puppet.vm",
     "compiler_hosts": ["pe-xl-compiler-0.puppet.vm"],
     "version": "2019.8.5"
 }

--- a/spec/docker/large-ha/docker-compose.yaml
+++ b/spec/docker/large-ha/docker-compose.yaml
@@ -32,7 +32,7 @@ services:
         HOST: 'pe-lg-replica.puppet.vm'
     entrypoint: /sbin/init
     labels:
-      com.puppet.role: "primary_replica_host"
+      com.puppet.role: "replica_host"
     image: pe-base
     privileged: true # required for systemd
     ports:

--- a/spec/docker/large-ha/params.json
+++ b/spec/docker/large-ha/params.json
@@ -1,6 +1,6 @@
 {
   "primary_host": "pe-lg.puppet.vm",
-  "primary_replica_host": "pe-lg-replica.puppet.vm",
+  "replica_host": "pe-lg-replica.puppet.vm",
   "compiler_hosts": ["pe-lg-compiler-0.puppet.vm"],
   "console_password": "puppetlabs",
   "dns_alt_names": [ "puppet", "pe-lg.puppet.vm" ],

--- a/spec/docker/large-ha/upgrade_params.json
+++ b/spec/docker/large-ha/upgrade_params.json
@@ -1,6 +1,6 @@
 {
     "primary_host": "pe-lg.puppet.vm",
-    "primary_replica_host": "pe-lg-replica.puppet.vm",
+    "replica_host": "pe-lg-replica.puppet.vm",
     "compiler_hosts": ["pe-lg-compiler-0.puppet.vm"],
     "version": "2019.8.5"
 }

--- a/spec/docker/standard-ha/docker-compose.yaml
+++ b/spec/docker/standard-ha/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
     image: pe-base
     privileged: true # required for systemd
     labels:
-      com.puppet.role: "primary_replica_host"
+      com.puppet.role: "replica_host"
     ports:
       - "22"
       - "8140"

--- a/spec/docker/standard-ha/params.json
+++ b/spec/docker/standard-ha/params.json
@@ -1,6 +1,6 @@
 {
   "primary_host": "pe-std.puppet.vm",
-  "primary_replica_host": "pe-std-replica.puppet.vm",
+  "replica_host": "pe-std-replica.puppet.vm",
   "console_password": "puppetlabs",
   "dns_alt_names": [ "puppet", "pe-std.puppet.vm" ],
   "version": "2019.8.5"

--- a/spec/docker/standard-ha/upgrade_params.json
+++ b/spec/docker/standard-ha/upgrade_params.json
@@ -1,6 +1,6 @@
 {
     "primary_host": "pe-std.puppet.vm",
-    "primary_replica_host": "pe-std-replica.puppet.vm",
+    "replica_host": "pe-std-replica.puppet.vm",
     "version": "2019.8.5"
 }
   

--- a/spec/fixtures/modules/peadm_spec/plans/install_test_cluster.pp
+++ b/spec/fixtures/modules/peadm_spec/plans/install_test_cluster.pp
@@ -23,34 +23,35 @@ plan peadm_spec::install_test_cluster (
         primary_host => $t.filter |$n| { $n.vars['role'] == 'primary' },
       }}
       'standard-with-dr': {{
-        primary_host         => $t.filter |$n| { $n.vars['role'] == 'primary' },
-        primary_replica_host => $t.filter |$n| { $n.vars['role'] == 'replica' },
+        primary_host   => $t.filter |$n| { $n.vars['role'] == 'primary' },
+        replica_host   => $t.filter |$n| { $n.vars['role'] == 'replica' },
       }}
       'large': {{
         primary_host   => $t.filter |$n| { $n.vars['role'] == 'primary' },
         compiler_hosts => $t.filter |$n| { $n.vars['role'] == 'compiler' },
       }}
       'large-with-dr': {{
-        primary_host         => $t.filter |$n| { $n.vars['role'] == 'primary' },
-        primary_replica_host => $t.filter |$n| { $n.vars['role'] == 'replica' },
-        compiler_hosts       => $t.filter |$n| { $n.vars['role'] == 'compiler' },
+        primary_host   => $t.filter |$n| { $n.vars['role'] == 'primary' },
+        replica_host   => $t.filter |$n| { $n.vars['role'] == 'replica' },
+        compiler_hosts => $t.filter |$n| { $n.vars['role'] == 'compiler' },
       }}
       'extra-large': {{
-        primary_host           => $t.filter |$n| { $n.vars['role'] == 'primary' },
-        puppetdb_database_host => $t.filter |$n| { $n.vars['role'] == 'primary-pdb-postgresql' },
-        compiler_hosts         => $t.filter |$n| { $n.vars['role'] == 'compiler' },
+        primary_host            => $t.filter |$n| { $n.vars['role'] == 'primary' },
+        primary_postgresql_host => $t.filter |$n| { $n.vars['role'] == 'primary-pdb-postgresql' },
+        compiler_hosts          => $t.filter |$n| { $n.vars['role'] == 'compiler' },
       }}
       'extra-large-with-dr': {{
-        primary_host                   => $t.filter |$n| { $n.vars['role'] == 'primary' },
-        puppetdb_database_host         => $t.filter |$n| { $n.vars['role'] == 'primary-pdb-postgresql' },
-        primary_replica_host           => $t.filter |$n| { $n.vars['role'] == 'replica' },
-        puppetdb_database_replica_host => $t.filter |$n| { $n.vars['role'] == 'replica-pdb-postgresql' },
-        compiler_hosts                 => $t.filter |$n| { $n.vars['role'] == 'compiler' },
+        primary_host             => $t.filter |$n| { $n.vars['role'] == 'primary' },
+        primary_postgresql_host  => $t.filter |$n| { $n.vars['role'] == 'primary-pdb-postgresql' },
+        replica_host             => $t.filter |$n| { $n.vars['role'] == 'replica' },
+        replica_postgresql_host  => $t.filter |$n| { $n.vars['role'] == 'replica-pdb-postgresql' },
+        compiler_hosts           => $t.filter |$n| { $n.vars['role'] == 'compiler' },
       }}
+      default: { fail('Invalid architecture!') }
     }
 
   $install_result =
-    run_plan("peadm::install", $arch_params + $common_params)
+    run_plan('peadm::install', $arch_params + $common_params)
 
   return($install_result)
 }

--- a/spec/functions/assert_supported_architecture_spec.rb
+++ b/spec/functions/assert_supported_architecture_spec.rb
@@ -12,13 +12,13 @@ describe 'peadm::assert_supported_architecture' do
   let(:primary_host) do
     'puppet-std.puppet.vm'
   end
-  let(:primary_replica_host) do
+  let(:replica_host) do
     'pup-replica.puppet.vm'
   end
-  let(:puppetdb_database_host) do
+  let(:primary_postgresql_host) do
     'pup-db.puppet.vm'
   end
-  let(:puppetdb_database_replica_host) do
+  let(:replica_postgresql_host) do
     'pup-db-replica.puppet.vm'
   end
   let(:compiler_hosts) do
@@ -32,7 +32,7 @@ describe 'peadm::assert_supported_architecture' do
                                   'architecture' => 'standard')
   }
   it {
-    is_expected.to run.with_params(primary_host, primary_replica_host)
+    is_expected.to run.with_params(primary_host, replica_host)
                       .and_return('supported' => true,
                                   'disaster-recovery' => true,
                                   'architecture' => 'standard')
@@ -40,7 +40,7 @@ describe 'peadm::assert_supported_architecture' do
 
   it do
     is_expected.to run.with_params(primary_host,
-                                   primary_replica_host,
+                                   replica_host,
                                    nil,
                                    nil,
                                    compiler_hosts)
@@ -62,9 +62,9 @@ describe 'peadm::assert_supported_architecture' do
 
   it do
     is_expected.to run.with_params(primary_host,
-                                   primary_replica_host,
-                                   puppetdb_database_host,
-                                   puppetdb_database_replica_host,
+                                   replica_host,
+                                   primary_postgresql_host,
+                                   replica_postgresql_host,
                                    compiler_hosts)
                       .and_return('supported' => true,
                                   'disaster-recovery' => true,
@@ -74,7 +74,7 @@ describe 'peadm::assert_supported_architecture' do
   it do
     is_expected.to run.with_params(primary_host,
                                    nil,
-                                   puppetdb_database_host,
+                                   primary_postgresql_host,
                                    nil,
                                    compiler_hosts)
                       .and_return('supported' => true,

--- a/spec/plans/action/install_spec.rb
+++ b/spec/plans/action/install_spec.rb
@@ -11,7 +11,7 @@ describe 'peadm::action::install' do
         'platform' => 'el-7.11-x86_64'
       },
     )
-    expect_task('peadm::mkdir_p_file').be_called_times(4)
+    expect_task('peadm::mkdir_p_file').be_called_times(5)
     expect_plan('peadm::util::retrieve_and_upload')
     expect_task('peadm::read_file')
     expect_task('peadm::pe_install')

--- a/tasks/enable_replica.json
+++ b/tasks/enable_replica.json
@@ -1,7 +1,7 @@
 {
   "description": "Execute the enable replica puppet command ",
   "parameters": {
-    "primary_replica": {
+    "replica": {
       "type": "String",
       "description": "The name of the replica to enable"
     },

--- a/tasks/enable_replica.sh
+++ b/tasks/enable_replica.sh
@@ -14,7 +14,7 @@ set -e
 env PATH="/opt/puppetlabs/bin:${PATH}" \
     USER="$USER" \
     HOME="$HOME" \
-    puppet infrastructure enable replica "$PT_primary_replica" \
+    puppet infrastructure enable replica "$PT_replica" \
       --skip-agent-config \
       --topology mono-with-compile \
       --yes --token-file "$TOKEN_FILE"

--- a/tasks/provision_replica.json
+++ b/tasks/provision_replica.json
@@ -1,7 +1,7 @@
 {
   "description": "Execute the replica provision puppet command ",
   "parameters": {
-    "primary_replica": {
+    "replica": {
       "type": "String",
       "description": "The name of the replica to provision"
     },

--- a/tasks/provision_replica.sh
+++ b/tasks/provision_replica.sh
@@ -14,17 +14,17 @@ fi
 set -e
 
 if [ "$PT_legacy" = "false" ]; then
-  puppet infrastructure provision replica "$PT_primary_replica" \
+  puppet infrastructure provision replica "$PT_replica" \
     --yes --token-file "$TOKEN_FILE" \
     --skip-agent-config \
     --topology mono-with-compile \
     --enable
 
 elif [ "$PT_legacy" = "true" ]; then
-  puppet infrastructure provision replica "$PT_primary_replica" \
+  puppet infrastructure provision replica "$PT_replica" \
     --token-file "$TOKEN_FILE"
 
-  puppet infrastructure enable replica "$PT_primary_replica" \
+  puppet infrastructure enable replica "$PT_replica" \
     --yes --token-file "$TOKEN_FILE" \
     --skip-agent-config \
     --topology mono-with-compile


### PR DESCRIPTION
Global rename of:
* primary_repica_host -> replica_host
* puppetdb_database_host -> primary_postgresql_host
* puppetdb_database_replica_host ->  replica_postgresql_host

Also local target variables are renamed accordingly.
