### PR TITLE
Move plans/action/* to plans/subplans/*

### DIFF
--- a/plans/install.pp
+++ b/plans/install.pp
@@ -53,7 +53,7 @@ plan peadm::install (
 
   peadm::assert_supported_pe_version($version)
 
-  $install_result = run_plan('peadm::action::install',
+  $install_result = run_plan('peadm::subplans::install',
     # Standard
     primary_host                   => $primary_host,
     replica_host                   => $replica_host,
@@ -85,7 +85,7 @@ plan peadm::install (
     download_mode                  => $download_mode,
   )
 
-  $configure_result = run_plan('peadm::action::configure',
+  $configure_result = run_plan('peadm::subplans::configure',
     # Standard
     primary_host                     => $primary_host,
     replica_host                     => $replica_host,

--- a/plans/subplans/configure.pp
+++ b/plans/subplans/configure.pp
@@ -12,7 +12,7 @@
 #   compilers. This is used for DR configuration in large and extra large
 #   architectures.
 #
-plan peadm::action::configure (
+plan peadm::subplans::configure (
   # Standard
   Peadm::SingleTargetSpec           $primary_host,
   Optional[Peadm::SingleTargetSpec] $replica_host = undef,

--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -1,3 +1,5 @@
+# @api private
+#
 # @summary Perform initial installation of Puppet Enterprise Extra Large
 #
 # @param r10k_remote
@@ -18,7 +20,7 @@
 #   Config data to plane into pe.conf when generated on all hosts, this can be
 #   used for tuning data etc.
 #
-plan peadm::action::install (
+plan peadm::subplans::install (
   # Standard
   Peadm::SingleTargetSpec           $primary_host,
   Optional[Peadm::SingleTargetSpec] $replica_host             = undef,

--- a/spec/plans/install_spec.rb
+++ b/spec/plans/install_spec.rb
@@ -5,8 +5,8 @@ describe 'peadm::install' do
 
   describe 'basic functionality' do
     it 'runs successfully with the minimum required parameters' do
-      expect_plan('peadm::action::install')
-      expect_plan('peadm::action::configure')
+      expect_plan('peadm::subplans::install')
+      expect_plan('peadm::subplans::configure')
       expect(run_plan('peadm::install', 'primary_host' => 'primary', 'console_password' => 'puppetlabs')).to be_ok
     end
   end

--- a/spec/plans/subplans/configure_spec.rb
+++ b/spec/plans/subplans/configure_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'peadm::action::configure' do
+describe 'peadm::subplans::configure' do
   include BoltSpec::Plans
 
   describe 'Standard architecture without DR' do
@@ -13,7 +13,7 @@ describe 'peadm::action::configure' do
       expect_task('peadm::provision_replica').not_be_called
       expect_task('peadm::code_manager').not_be_called
 
-      expect(run_plan('peadm::action::configure', 'primary_host' => 'primary')).to be_ok
+      expect(run_plan('peadm::subplans::configure', 'primary_host' => 'primary')).to be_ok
     end
   end
 end

--- a/spec/plans/subplans/install_spec.rb
+++ b/spec/plans/subplans/install_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'peadm::action::install' do
+describe 'peadm::subplans::install' do
   # Include the BoltSpec library functions
   include BoltSpec::Plans
 
@@ -47,6 +47,6 @@ describe 'peadm::action::install' do
       'console_password' => 'puppetlabs',
     }
 
-    expect(run_plan('peadm::action::install', params)).to be_ok
+    expect(run_plan('peadm::subplans::install', params)).to be_ok
   end
 end


### PR DESCRIPTION
Establishing a pattern wherein plans which are really intended to be
pieces of other plans, rather than directly invoked by the user, are
located in the subplans directory. Having a separate "action" directory
for the subplans of peadm::install adds confusion, so it is being
consolidated.