### PR TITLE
Use `allow_any_<action>` syntax to simplify specs

### DIFF
--- a/spec/plans/add_replica_spec.rb
+++ b/spec/plans/add_replica_spec.rb
@@ -3,17 +3,10 @@ require 'spec_helper'
 describe 'peadm::install' do
   include BoltSpec::Plans
 
-  def allow_standard_non_returning_calls(params)
+  def allow_standard_non_returning_calls
     allow_apply
-    allow_task('peadm::agent_install')
-    allow_task('peadm::ssl_clean')
-    allow_task('peadm::submit_csr')
-    allow_task('peadm::sign_csr')
-    allow_task('peadm::puppet_runonce')
-    allow_task('peadm::provision_replica')
-    allow_command('systemctl start puppet.service')
-    allow_command("puppet infrastructure forget #{params['replica_host']}")
-    allow_command("puppet node purge #{params['replica_host']}")
+    allow_any_task
+    allow_any_command
   end
 
   describe 'basic functionality' do
@@ -21,7 +14,7 @@ describe 'peadm::install' do
     let(:certdata) { { 'certname' => 'primary', 'extensions' => { '1.3.6.1.4.1.34380.1.1.9813' => 'A' } } }
 
     it 'runs successfully when the primary doesn\'t have alt-names' do
-      allow_standard_non_returning_calls(params)
+      allow_standard_non_returning_calls
       expect_task('peadm::cert_data').always_return(certdata)
       expect_task('peadm::agent_install')
         .with_params({ 'server'        => 'primary',
@@ -37,7 +30,7 @@ describe 'peadm::install' do
     end
 
     it 'runs successfully when the primary has alt-names' do
-      allow_standard_non_returning_calls(params)
+      allow_standard_non_returning_calls
       expect_task('peadm::cert_data').always_return(certdata.merge({ 'dns-alt-names' => ['primary', 'alt'] }))
       expect_task('peadm::agent_install')
         .with_params({ 'server'        => 'primary',

--- a/spec/plans/subplans/configure_spec.rb
+++ b/spec/plans/subplans/configure_spec.rb
@@ -5,11 +5,12 @@ describe 'peadm::subplans::configure' do
 
   describe 'Standard architecture without DR' do
     it 'runs successfully' do
-      expect_task('peadm::read_file').always_return({ 'content' => 'mock' })
-      expect_task('peadm::puppet_runonce')
-      expect_command('systemctl start puppet')
       allow_apply
+      allow_any_task
+      allow_any_plan
+      allow_any_command
 
+      expect_task('peadm::read_file').always_return({ 'content' => 'mock' })
       expect_task('peadm::provision_replica').not_be_called
       expect_task('peadm::code_manager').not_be_called
 

--- a/spec/plans/subplans/install_spec.rb
+++ b/spec/plans/subplans/install_spec.rb
@@ -5,22 +5,16 @@ describe 'peadm::subplans::install' do
   include BoltSpec::Plans
 
   it 'minimum variables to run' do
+    allow_any_task
+    allow_any_plan
+    allow_any_command
+
     allow_task('peadm::precheck').return_for_targets(
       'primary' => {
         'hostname' => 'primary',
         'platform' => 'el-7.11-x86_64'
       },
     )
-    expect_task('peadm::mkdir_p_file').be_called_times(5)
-    expect_plan('peadm::util::retrieve_and_upload')
-    expect_task('peadm::read_file')
-    expect_task('peadm::pe_install')
-    expect_command('systemctl stop pe-puppetdb')
-    expect_command('systemctl start pe-puppetdb')
-    expect_task('peadm::rbac_token')
-    expect_task('peadm::code_manager')
-    expect_task('peadm::puppet_runonce').be_called_times(2)
-    expect_task('peadm::wait_until_service_ready')
 
     #########
     ## <🤮>

--- a/spec/plans/upgrade_spec.rb
+++ b/spec/plans/upgrade_spec.rb
@@ -9,20 +9,15 @@ describe 'peadm::upgrade' do
   end
 
   it 'minimum variables to run' do
-    allow_out_message
-    expect_task('peadm::cert_data').return_for_targets(
-      'primary' => trustedjson,
-    )
-    expect_task('peadm::read_file').always_return({ 'content' => 'mock' })
-    expect_task('peadm::precheck')
-    expect_plan('peadm::util::retrieve_and_upload')
-    expect_command('systemctl stop puppet')
-    allow_task('peadm::puppet_runonce')
-    expect_plan('peadm::modify_cert_extensions')
     allow_apply
-    expect_task('peadm::pe_install')
-    allow_task('peadm::puppet_infra_upgrade')
-    expect_task('service')
+    allow_any_task
+    allow_any_plan
+    allow_any_command
+    allow_out_message
+
+    expect_task('peadm::cert_data').return_for_targets('primary' => trustedjson)
+    expect_task('peadm::read_file').always_return({ 'content' => 'mock' })
+
     expect(run_plan('peadm::upgrade', 'primary_host' => 'primary', 'version' => '2019.8.6')).to be_ok
   end
 end


### PR DESCRIPTION
We want our spec tests to focus on testing logic, not just enumerating
which plans/tasks/commands are called. A big value out of these tests is
just making sure they run to completion logically, assuming each of the
tasks/plans doesn't fail.

This commit simplifies the spec tests to allow execution actions by
default, to achieve the value of making sure the plans run to completion
with as little cognative overhead or unnecessary repetition as possible.