### PR TITLE
Replace plan peadm::modify_cert_extensions with peadm::modify_certificate

### DIFF
--- a/plans/add_compiler.pp
+++ b/plans/add_compiler.pp
@@ -65,9 +65,9 @@ plan peadm::add_compiler(
 
   # If there was already a signed cert, force the certificate extensions we want
   # TODO: update peadm::util::add_cert_extensions to take care of dns alt names
-  run_plan('peadm::modify_cert_extensions', $compiler_target,
-    primary_host => $primary_target.peadm::certname(),
-    add  => {
+  run_plan('peadm::modify_certificate', $compiler_target,
+    primary_host   => $primary_target.peadm::certname(),
+    add_extensions => {
       peadm::oid('pp_auth_role')             => 'pe_compiler',
       peadm::oid('peadm_availability_group') => $avail_group_letter,
     },

--- a/plans/convert.pp
+++ b/plans/convert.pp
@@ -125,9 +125,9 @@ plan peadm::convert (
       }
     }
 
-    run_plan('peadm::modify_cert_extensions', $primary_target,
-      primary_host => $primary_target,
-      add          => {
+    run_plan('peadm::modify_certificate', $primary_target,
+      primary_host   => $primary_target,
+      add_extensions => {
         peadm::oid('peadm_role')               => 'puppet/server',
         peadm::oid('peadm_availability_group') => 'A',
       },
@@ -146,45 +146,45 @@ plan peadm::convert (
     # Kick off all the cert modification jobs in parallel
     $background_cert_jobs = [
       background('modify-replica-cert') || {
-        run_plan('peadm::modify_cert_extensions', $replica_target,
-          primary_host => $primary_target,
-          add          => {
+        run_plan('peadm::modify_certificate', $replica_target,
+          primary_host   => $primary_target,
+          add_extensions => {
             peadm::oid('peadm_role')               => 'puppet/server',
             peadm::oid('peadm_availability_group') => 'B',
           },
         )
       },
       background('modify-primary-postgresql-cert') || {
-        run_plan('peadm::modify_cert_extensions', $primary_postgresql_target,
-          primary_host => $primary_target,
-          add          => {
+        run_plan('peadm::modify_certificate', $primary_postgresql_target,
+          primary_host   => $primary_target,
+          add_extensions => {
             peadm::oid('peadm_role')               => 'puppet/puppetdb-database',
             peadm::oid('peadm_availability_group') => 'A',
           },
         )
       },
       background('modify-replica-postgresql-cert') || {
-        run_plan('peadm::modify_cert_extensions', $replica_postgresql_target,
-          primary_host => $primary_target,
-          add          => {
+        run_plan('peadm::modify_certificate', $replica_postgresql_target,
+          primary_host   => $primary_target,
+          add_extensions => {
             peadm::oid('peadm_role')               => 'puppet/puppetdb-database',
             peadm::oid('peadm_availability_group') => 'B',
           },
         )
       },
       background('modify-compilers-a-certs') || {
-        run_plan('peadm::modify_cert_extensions', $compiler_a_targets,
-          primary_host => $primary_target,
-          add          => {
+        run_plan('peadm::modify_certificate', $compiler_a_targets,
+          primary_host   => $primary_target,
+          add_extensions => {
             peadm::oid('pp_auth_role')             => 'pe_compiler',
             peadm::oid('peadm_availability_group') => 'A',
           },
         )
       },
       background('modify-compilers-b-certs') || {
-        run_plan('peadm::modify_cert_extensions', $compiler_b_targets,
-          primary_host => $primary_target,
-          add          => {
+        run_plan('peadm::modify_certificate', $compiler_b_targets,
+          primary_host   => $primary_target,
+          add_extensions => {
             peadm::oid('pp_auth_role')             => 'pe_compiler',
             peadm::oid('peadm_availability_group') => 'B',
           },

--- a/plans/modify_cert_extensions.pp
+++ b/plans/modify_cert_extensions.pp
@@ -1,38 +1,18 @@
+# @api private
 plan peadm::modify_cert_extensions (
   TargetSpec              $targets,
   Peadm::SingleTargetSpec $primary_host,
   Hash                    $add = { },
   Array                   $remove = [ ],
 ) {
-  $all_targets = peadm::get_targets($targets)
-  $primary_target = get_target($primary_host)
 
-  # Short-circuit if there are no targets
-  if $all_targets.empty { return(0) }
+  out::message(@(EOS))
+    The peadm::modify_cert_extensions plan has been deprecated.
+    Please use peadm::modify_certificate instead.
+    | EOS
 
-  # TODO: convert $add and $remove to OIDs, if friendly names have been given
-
-  $primary_certname = run_task('peadm::cert_data', $primary_target).first['certname']
-
-  # Do the primary first, if it's in the list
-  if ($primary_target in $all_targets) {
-    run_plan('peadm::subplans::modify_cert_extensions', $primary_target,
-      primary_host     => $primary_target,
-      primary_certname => $primary_certname,
-      add              => $add,
-      remove           => $remove,
-    )
-  }
-
-  # Then do the rest
-  parallelize($all_targets - $primary_target) |$target| {
-    run_plan('peadm::subplans::modify_cert_extensions', $target,
-      primary_host     => $primary_target,
-      primary_certname => $primary_certname,
-      add              => $add,
-      remove           => $remove,
-    )
-  }
-
-  return('Modified cert extensions')
+  return(run_plan('peadm::modify_certificate', $targets,
+           primary_host      => $primary_host,
+           add_extensions    => $add,
+           remove_extensions => $remove))
 }

--- a/plans/modify_cert_extensions.pp
+++ b/plans/modify_cert_extensions.pp
@@ -11,8 +11,11 @@ plan peadm::modify_cert_extensions (
     Please use peadm::modify_certificate instead.
     | EOS
 
-  return(run_plan('peadm::modify_certificate', $targets,
-           primary_host      => $primary_host,
-           add_extensions    => $add,
-           remove_extensions => $remove))
+  return(
+    run_plan('peadm::modify_certificate', $targets,
+      primary_host      => $primary_host,
+      add_extensions    => $add,
+      remove_extensions => $remove,
+    )
+  )
 }

--- a/plans/modify_certificate.pp
+++ b/plans/modify_certificate.pp
@@ -4,6 +4,7 @@ plan peadm::modify_certificate (
   Hash                    $add_extensions = { },
   Array                   $remove_extensions = [ ],
   Optional[Array]         $dns_alt_names = undef,
+  Boolean                 $force_regenerate = false,
 ) {
   $all_targets = peadm::get_targets($targets)
   $primary_target = get_target($primary_host)
@@ -24,6 +25,7 @@ plan peadm::modify_certificate (
       add_extensions    => $add_extensions,
       remove_extensions => $remove_extensions,
       dns_alt_names     => $dns_alt_names,
+      force_regenerate  => $force_regenerate,
     )
   }
 
@@ -35,6 +37,7 @@ plan peadm::modify_certificate (
       add_extensions    => $add_extensions,
       remove_extensions => $remove_extensions,
       dns_alt_names     => $dns_alt_names,
+      force_regenerate  => $force_regenerate,
     )
   }
 

--- a/plans/modify_certificate.pp
+++ b/plans/modify_certificate.pp
@@ -1,0 +1,42 @@
+plan peadm::modify_certificate (
+  TargetSpec              $targets,
+  Peadm::SingleTargetSpec $primary_host,
+  Hash                    $add_extensions = { },
+  Array                   $remove_extensions = [ ],
+  Optional[Array]         $dns_alt_names = undef,
+) {
+  $all_targets = peadm::get_targets($targets)
+  $primary_target = get_target($primary_host)
+
+  # Short-circuit if there are no targets
+  if $all_targets.empty { return(0) }
+
+  # TODO: convert $add_extensions and $remov_extensions  to OIDs, if friendly
+  # names have been given
+
+  $primary_certname = run_task('peadm::cert_data', $primary_target).first['certname']
+
+  # Do the primary first, if it's in the list
+  if ($primary_target in $all_targets) {
+    run_plan('peadm::subplans::modify_certificate', $primary_target,
+      primary_host      => $primary_target,
+      primary_certname  => $primary_certname,
+      add_extensions    => $add_extensions,
+      remove_extensions => $remove_extensions,
+      dns_alt_names     => $dns_alt_names,
+    )
+  }
+
+  # Then do the rest
+  parallelize($all_targets - $primary_target) |$target| {
+    run_plan('peadm::subplans::modify_certificate', $target,
+      primary_host      => $primary_target,
+      primary_certname  => $primary_certname,
+      add_extensions    => $add_extensions,
+      remove_extensions => $remove_extensions,
+      dns_alt_names     => $dns_alt_names,
+    )
+  }
+
+  return('Modified certificates')
+}

--- a/plans/subplans/modify_certificate.pp
+++ b/plans/subplans/modify_certificate.pp
@@ -30,11 +30,11 @@ plan peadm::subplans::modify_certificate (
 
   # If the existing certificate meets all the requirements, there's no need
   # to regenerate it. Skip it and move on to the next.
-  if ($certdata['certificate-exists']
-      and ($desired_alt_names == $existing_alt_names)
-      and ($desired_exts.all |$key,$val| { $existing_exts[$key] == $val })
-      and !($remove_extensions.any |$key| { $key in $existing_exts.keys })
-      and !$force_regenerate)
+  if ($certdata['certificate-exists'] and
+      ($desired_alt_names == $existing_alt_names) and
+      ($desired_exts.all |$key,$val| { $existing_exts[$key] == $val }) and
+      !($remove_extensions.any |$key| { $key in $existing_exts.keys }) and
+      !$force_regenerate)
   {
     out::message("${certname} already has requested modifications; certificate will not be re-issued")
     return('Skipped')
@@ -65,9 +65,9 @@ plan peadm::subplans::modify_certificate (
     # fail the plan unless it's a known circumstance in which it's okay to proceed.
     # Scenario 1: the primary's cert can't be cleaned because it's already revoked.
     # Scenario 2: the primary's cert can't be cleaned because it's been deleted.
-    unless ($target_is_primary
-            and ($ca_clean_result[merged_output] =~ /certificate revoked/
-                 or $ca_clean_result[merged_output] =~ /Could not find 'hostcert'/))
+    unless ($target_is_primary and
+            ($ca_clean_result[merged_output] =~ /certificate revoked/ or
+              $ca_clean_result[merged_output] =~ /Could not find 'hostcert'/))
     {
       fail_plan($ca_clean_result)
     }

--- a/plans/subplans/modify_certificate.pp
+++ b/plans/subplans/modify_certificate.pp
@@ -6,6 +6,7 @@ plan peadm::subplans::modify_certificate (
   Hash                    $add_extensions = { },
   Array                   $remove_extensions = [ ],
   Optional[Array]         $dns_alt_names = undef,
+  Boolean                 $force_regenerate = false,
 ) {
   $target = get_target($targets)
   $primary_target = get_target($primary_host)
@@ -22,20 +23,26 @@ plan peadm::subplans::modify_certificate (
   $target_is_primary = ($certname == $primary_certname)
 
   # These vars represent what the extensions currently are, vs. what they should be
-  $existing_alt_names = certdata['dns-alt-names'].split(',')
   $existing_exts = $certdata['extensions'].filter |$k,$v| { $k =~ /^1\.3\.6\.1\.4\.1\.34380\.1(?!\.3\.39)/ }
   $desired_exts = $existing_exts.filter |$k,$v| { !($k in $remove_extensions) } + $add_extensions
+  $existing_alt_names = ($certdata['dns-alt-names'] - $certdata['certname']).sort
+  $desired_alt_names = (pick($dns_alt_names, $existing_alt_names) - $certdata['certname']).sort
 
   # If the existing certificate meets all the requirements, there's no need
   # to regenerate it. Skip it and move on to the next.
   if ($certdata['certificate-exists']
+      and ($desired_alt_names == $existing_alt_names)
       and ($desired_exts.all |$key,$val| { $existing_exts[$key] == $val })
       and !($remove_extensions.any |$key| { $key in $existing_exts.keys })
-      and ($dns_alt_names == undef or !($dns_alt_names.all |$name| { $name in $existing_alt_names }))
-  ) {
-    out::message("${certname} already has requested extensions; certificate will not be re-issued")
+      and !$force_regenerate)
+  {
+    out::message("${certname} already has requested modifications; certificate will not be re-issued")
     return('Skipped')
   }
+
+  # The new subjectAltNames for the regenerated cert should be the common name
+  # plus whatever other names are specified
+  $alt_names = [$certdata['certname']] + $desired_alt_names
 
   # Everything starts the same; we always stop the agent and revoke the
   # existing cert. We use `run_command` in case the master is 2019.x but
@@ -58,9 +65,10 @@ plan peadm::subplans::modify_certificate (
     # fail the plan unless it's a known circumstance in which it's okay to proceed.
     # Scenario 1: the primary's cert can't be cleaned because it's already revoked.
     # Scenario 2: the primary's cert can't be cleaned because it's been deleted.
-    unless ($target_is_primary and (
-              $ca_clean_result[merged_output] =~ /certificate revoked/ or
-              $ca_clean_result[merged_output] =~ /Could not find 'hostcert'/)) {
+    unless ($target_is_primary
+            and ($ca_clean_result[merged_output] =~ /certificate revoked/
+                 or $ca_clean_result[merged_output] =~ /Could not find 'hostcert'/))
+    {
       fail_plan($ca_clean_result)
     }
   }
@@ -69,7 +77,7 @@ plan peadm::subplans::modify_certificate (
   unless ($target_is_primary) {
     # CLIENT cert regeneration
     run_task('peadm::ssl_clean', $target, certname => $certname)
-    run_task('peadm::submit_csr', $target, dns_alt_names => $dns_alt_names)
+    run_task('peadm::submit_csr', $target, dns_alt_names => $alt_names)
     run_task('peadm::sign_csr', $primary_target, certnames => [$certname])
 
     # Use a command instead of a task so that this works for Puppet 5 agents
@@ -83,11 +91,6 @@ plan peadm::subplans::modify_certificate (
   }
   else {
     # PRIMARY cert regeneration
-    $alt_names = $certdata['dns-alt-names'].empty ? {
-      true  => $certdata['certname'],
-      false => $certdata['dns-alt-names'].join(','),
-    }
-
     # The docs are broken, and the process is unclean. Sadface.
     run_task('service', $target, {action => 'stop', name => 'pe-puppetserver'})
     run_command(@("HEREDOC"/L), $target)
@@ -101,7 +104,7 @@ plan peadm::subplans::modify_certificate (
     run_command(@("HEREDOC"/L), $target)
       /opt/puppetlabs/bin/puppetserver ca generate \
         --certname ${certname} \
-        --subject-alt-names ${alt_names} \
+        --subject-alt-names ${alt_names.join(',')} \
         --ca-client
       |-HEREDOC
     run_task('service', $target, {action => 'start', name => 'pe-puppetserver'})

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -216,9 +216,9 @@ plan peadm::upgrade (
     }
 
     # If necessary, add missing cert extensions to compilers
-    run_plan('peadm::modify_cert_extensions', $convert_targets,
-      primary_host => $primary_target,
-      add          => {
+    run_plan('peadm::modify_certificate', $convert_targets,
+      primary_host   => $primary_target,
+      add_extensions => {
         'pp_auth_role' => 'pe_compiler',
       },
     )

--- a/spec/fixtures/plans/trusted_facts.json
+++ b/spec/fixtures/plans/trusted_facts.json
@@ -1,9 +1,13 @@
 {
-    "certname" : "primary",
-    "extensions" : {
-      "1.3.6.1.4.1.34380.1.3.39" : "true",
-      "1.3.6.1.4.1.34380.1.1.9812" : "puppet/primary",
-      "1.3.6.1.4.1.34380.1.1.9813" : "A"
-    },
-    "dns-alt-names" : [ "pe-server-d8b317-0.us-west1-a.c.davidsand.internal", "pe-server-d8b317-0.us-west1-a.c.davidsand.internal", "puppet" ]
-  }
+  "certname" : "primary",
+  "extensions" : {
+    "1.3.6.1.4.1.34380.1.3.39" : "true",
+    "1.3.6.1.4.1.34380.1.1.9812" : "puppet/primary",
+    "1.3.6.1.4.1.34380.1.1.9813" : "A"
+  },
+  "dns-alt-names" : [
+    "pe-server-d8b317-0.us-west1-a.c.davidsand.internal",
+    "pe-server-d8b317-0.us-west1-a.c.davidsand.internal",
+    "puppet"
+  ]
+}

--- a/spec/plans/add_compiler_spec.rb
+++ b/spec/plans/add_compiler_spec.rb
@@ -23,7 +23,7 @@ describe 'peadm::add_compiler' do
 
     it 'runs successfully when no alt-names are specified' do
       allow_standard_non_returning_calls
-      expect_plan('peadm::modify_cert_extensions').always_return('mock' => 'mock')
+      expect_plan('peadm::modify_certificate').always_return('mock' => 'mock')
       expect_task('peadm::agent_install')
         .with_params({ 'server'        => 'primary',
                        'install_flags' => [
@@ -47,7 +47,7 @@ describe 'peadm::add_compiler' do
 
       it 'runs successfully when alt-names are specified' do
         allow_standard_non_returning_calls
-        expect_plan('peadm::modify_cert_extensions').always_return('mock' => 'mock')
+        expect_plan('peadm::modify_certificate').always_return('mock' => 'mock')
         expect_task('peadm::agent_install')
           .with_params({ 'server'        => 'primary',
                          'install_flags' => [

--- a/spec/plans/convert_spec.rb
+++ b/spec/plans/convert_spec.rb
@@ -1,4 +1,4 @@
-# spec/spec_helper.rb
+require 'spec_helper'
 
 describe 'peadm::convert' do
   # Include the BoltSpec library functions
@@ -8,20 +8,22 @@ describe 'peadm::convert' do
     JSON.parse File.read(File.expand_path(File.join(fixtures, 'plans', 'trusted_facts.json')))
   end
 
-  it 'single primary no dr valid' do
-    expect_out_message
-    expect_task('peadm::trusted_facts').return_for_targets(
+  let(:params) do
+    { 'primary_host' => 'primary' }
+  end
 
-      'primary' => trustedjson,
-    )
-    pending('a lack of support for functions requires a workaround to be written')
-    expect_task('peadm::read_file').always_return({ 'content' => '2019.2.4' })
-    expect_command('systemctl is-active puppet.service')
-    expect_command('systemctl stop puppet.service')
-    # expect_plan('peadm::util::add_cert_extensions')
+  it 'single primary no dr valid' do
+    allow_out_message
+    allow_any_command
+    allow_any_task
     allow_apply
-    expect_task('peadm::cert_data')
-    expect_task('peadm::puppet_runonce')
-    expect(run_plan('peadm::convert', 'primary_host' => 'primary')).to be_ok
+
+    expect_task('peadm::cert_data').return_for_targets('primary' => trustedjson)
+    expect_task('peadm::read_file').always_return({ 'content' => '2019.2.4' })
+
+    # For some reason, expect_plan() was not working??
+    allow_plan('peadm::modify_certificate').always_return({})
+
+    expect(run_plan('peadm::convert', params)).to be_ok
   end
 end

--- a/spec/plans/modify_cert_extensions_spec.rb
+++ b/spec/plans/modify_cert_extensions_spec.rb
@@ -14,8 +14,8 @@ describe 'peadm::modify_cert_extensions' do
       end
 
       it 'runs successfully ' do
-        allow_task('peadm::cert_data').always_return({ 'certname' => 'primary' })
-        expect_plan('peadm::subplans::modify_cert_extensions').be_called_times(3)
+        allow_out_message
+        expect_plan('peadm::modify_certificate').always_return({})
 
         expect(run_plan('peadm::modify_cert_extensions', params)).to be_ok
       end

--- a/spec/plans/modify_certificate_spec.rb
+++ b/spec/plans/modify_certificate_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe 'peadm::modify_certificate' do
+  include BoltSpec::Plans
+
+  describe 'basic functionality' do
+    context 'modifying multiple client certificates' do
+      let(:params) do
+        {
+          'targets'        => 'foo,primary,bar',
+          'primary_host'   => 'primary',
+          'add_extensions' => { 'pe_role' => 'puppet/server' },
+        }
+      end
+
+      it 'runs successfully ' do
+        allow_task('peadm::cert_data').always_return({ 'certname' => 'primary' })
+        expect_plan('peadm::subplans::modify_certificate').be_called_times(3)
+
+        expect(run_plan('peadm::modify_certificate', params)).to be_ok
+      end
+    end
+  end
+end

--- a/spec/plans/subplans/modify_certificate_spec.rb
+++ b/spec/plans/subplans/modify_certificate_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'peadm::subplans::modify_cert_extensions' do
+describe 'peadm::subplans::modify_certificate' do
   include BoltSpec::Plans
 
   describe 'basic functionality' do
@@ -10,7 +10,7 @@ describe 'peadm::subplans::modify_cert_extensions' do
           'targets' => 'foo',
           'primary_host'     => 'primary',
           'primary_certname' => 'primary',
-          'add'              => { 'pe_role' => 'puppet/server' },
+          'add_extensions'   => { 'pe_role' => 'puppet/server' },
         }
       end
 
@@ -18,12 +18,12 @@ describe 'peadm::subplans::modify_cert_extensions' do
         expect_task('peadm::cert_data').be_called_times(1).return_for_targets(
           'primary' => { 'certificate-exists' => true,
                          'certname'           => 'primary',
-                         'dns-alt-names'      => '',
-                         'extensions'         => '' },
+                         'dns-alt-names'      => [],
+                         'extensions'         => {} },
           'foo'     => { 'certificate-exists' => true,
                          'certname'           => 'foo',
-                         'dns-alt-names'      => '',
-                         'extensions'         => '' },
+                         'dns-alt-names'      => [],
+                         'extensions'         => {} },
         )
         expect_command('systemctl is-active puppet.service')
         expect_command('systemctl stop puppet.service')
@@ -36,7 +36,7 @@ describe 'peadm::subplans::modify_cert_extensions' do
         allow_command('/opt/puppetlabs/bin/puppet facts upload')
         expect_command('systemctl start puppet.service')
 
-        expect(run_plan('peadm::subplans::modify_cert_extensions', params)).to be_ok
+        expect(run_plan('peadm::subplans::modify_certificate', params)).to be_ok
       end
     end
   end

--- a/spec/unit/task/submit_csr_spec.rb
+++ b/spec/unit/task/submit_csr_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+require_relative '../../../tasks/submit_csr'
+
+describe SubmitCSR do
+  subject(:submit_csr) { described_class.new(params) }
+
+  let(:params) { {} }
+  let(:status_dbl) { instance_double('Process::Status', success?: true) }
+
+  before(:each) do
+    allow(STDOUT).to receive(:puts)
+    allow(Puppet).to receive(:settings).and_return(dns_alt_names: 'default,settings',
+                                                   hostcert: '/not/a/real/file/test.pem',
+                                                   certname: 'test')
+  end
+
+  context 'on Puppet 5' do
+    before(:each) do
+      expect(Puppet).to receive(:version).and_return('5.5.0')
+    end
+
+    it 'runs `puppet certificate generate`' do
+      expect(Open3).to receive(:capture2e).with('/opt/puppetlabs/bin/puppet', 'certificate', any_args) { |*args|
+        expect(args).to include('--dns-alt-names', 'default,settings')
+      }.and_return(['output', status_dbl])
+
+      expect { submit_csr.execute! }.to raise_error(SystemExit) do |error|
+        expect(error.status).to eq(0)
+      end
+    end
+  end
+
+  context 'on Puppet 6' do
+    before(:each) do
+      expect(Puppet).to receive(:version).and_return('6.6.0')
+      allow(Open3).to receive(:capture2e).with('/opt/puppetlabs/bin/puppet', 'ssl', 'verify')
+                                         .and_return(['ssl-verify', instance_double('Process::Status', success?: false)])
+    end
+
+    it 'runs `puppet ssl submit_request' do
+      expect(Open3).to receive(:capture2e).with('/opt/puppetlabs/bin/puppet', 'ssl', 'submit_request', any_args) { |*args|
+        expect(args).not_to include('--dns_alt_names')
+      }.and_return(['output', status_dbl])
+
+      expect { submit_csr.execute! }.to raise_error(SystemExit) do |error|
+        expect(error.status).to eq(0)
+      end
+    end
+
+    describe 'with DNS alt names' do
+      let(:params) { { 'dns_alt_names' => ['one', 'two', 'three'] } }
+
+      it 'passes dns_alt_names when supplied' do
+        expect(Open3).to receive(:capture2e).with('/opt/puppetlabs/bin/puppet', 'ssl', 'submit_request', any_args) { |*args|
+          expect(args).to include('--dns_alt_names', 'one,two,three')
+        }.and_return(['output', status_dbl])
+
+        expect { submit_csr.execute! }.to raise_error(SystemExit) do |error|
+          expect(error.status).to eq(0)
+        end
+      end
+    end
+  end
+end

--- a/tasks/cert_data.rb
+++ b/tasks/cert_data.rb
@@ -6,79 +6,97 @@ require 'puppet'
 require 'puppet/ssl/oids'
 require 'json'
 
-def x509_certificate_from_path(path)
-  return nil unless File.exist?(path)
-  raw = File.read(path)
-  OpenSSL::X509::Certificate.new(raw)
-end
-
-def certname_from_x509_certificate(cert)
-  cert.subject.to_a.find { |item| item[0] == 'CN' }
-      .slice(1)
-end
-
-def extensions_from_x509_certificate(cert)
-  friendly_names = Puppet::SSL::Oids::PUPPET_OIDS.reduce({}) do |memo, oid|
-    memo.merge(oid[0] => oid[1])
+# Implementation class for task
+class CertData
+  def initialize(params)
+    @params = params
   end
 
-  cert.extensions.reduce({}) do |memo, ext|
-    next memo unless ext.oid.start_with?('1.3.6.1.4.1.34380.1') # ppCertExt
-    case friendly_names[ext.oid]
-    when nil
-      memo.merge({ ext.oid => ext.value[2..-1] })
-    else
-      memo.merge({ ext.oid => ext.value[2..-1], friendly_names[ext.oid] => ext.value[2..-1] })
+  def execute!
+    Puppet.settings.use(:agent, :server, :master, :main)
+    certpath = Puppet.settings[:hostcert]
+    result = if File.exist?(certpath)
+               cert = x509_certificate_from_path(certpath)
+               {
+                 'certificate-exists' => true,
+                 'certname'      => certname_from_x509_certificate(cert),
+                 'extensions'    => extensions_from_x509_certificate(cert),
+                 'dns-alt-names' => alt_names_from_x509_certificate(cert),
+               }
+             else
+               {
+                 'certificate-exists' => false,
+                 'certname'      => Puppet.settings[:certname],
+                 'extensions'    => extensions_from_csr_attributes_path(Puppet.settings[:csr_attributes]),
+                 'dns-alt-names' => Puppet.settings[:dns_alt_names].to_s.split(','),
+               }
+             end
+
+    # Put the result to stdout
+    puts result.to_json
+  end
+
+  def x509_certificate_from_path(path)
+    return nil unless File.exist?(path)
+    raw = File.read(path)
+    OpenSSL::X509::Certificate.new(raw)
+  end
+
+  def certname_from_x509_certificate(cert)
+    cert.subject.to_a.find { |item| item[0] == 'CN' }
+        .slice(1)
+  end
+
+  def extensions_from_x509_certificate(cert)
+    friendly_names = Puppet::SSL::Oids::PUPPET_OIDS.reduce({}) do |memo, oid|
+      memo.merge(oid[0] => oid[1])
+    end
+
+    cert.extensions.reduce({}) do |memo, ext|
+      next memo unless ext.oid.start_with?('1.3.6.1.4.1.34380.1') # ppCertExt
+      case friendly_names[ext.oid]
+      when nil
+        memo.merge({ ext.oid => ext.value[2..-1] })
+      else
+        memo.merge({ ext.oid => ext.value[2..-1], friendly_names[ext.oid] => ext.value[2..-1] })
+      end
+    end
+  end
+
+  def alt_names_from_x509_certificate(cert)
+    # Make sure this works for certs with or without subjectAltName extensions
+    cert.extensions.select { |ext| ext.oid == 'subjectAltName' }
+        .map { |ext| ext.value.split(', ') }
+        .flatten
+        .map { |str| str.slice(%r{^(DNS:)(.*)}, 2) }
+  end
+
+  def extensions_from_csr_attributes_path(path)
+    return {} unless File.exist?(path)
+
+    data = YAML.safe_load(File.read(path))
+    extension_requests = data['extension_requests']
+
+    oids = Puppet::SSL::Oids::PUPPET_OIDS.reduce({}) do |memo, oid|
+      memo.merge(oid[1] => oid[0])
+    end
+
+    extension_requests.reduce({}) do |memo, (request, value)|
+      case oids[request]
+      when nil
+        memo.merge({ request => value })
+      else
+        memo.merge({ request => value, oids[request] => value })
+      end
     end
   end
 end
 
-def alt_names_from_x509_certificate(cert)
-  cert.extensions.select { |ext| ext.oid == 'subjectAltName' }
-      .map { |ext| ext.value.split(', ').map { |str| str[4..-1] } }
-      .first
+# Run the task unless an environment flag has been set, signaling not to. The
+# environment flag is used to disable auto-execution and enable Ruby unit
+# testing of this task.
+unless ENV['RSPEC_UNIT_TEST_MODE']
+  Puppet.initialize_settings
+  cert_data = CertData.new(JSON.parse(STDIN.read))
+  cert_data.execute!
 end
-
-def extensions_from_csr_attributes_path(path)
-  return {} unless File.exist?(path)
-
-  data = YAML.safe_load(File.read(path))
-  extension_requests = data['extension_requests']
-
-  oids = Puppet::SSL::Oids::PUPPET_OIDS.reduce({}) do |memo, oid|
-    memo.merge(oid[1] => oid[0])
-  end
-
-  extension_requests.reduce({}) do |memo, (request, value)|
-    case oids[request]
-    when nil
-      memo.merge({ request => value })
-    else
-      memo.merge({ request => value, oids[request] => value })
-    end
-  end
-end
-
-Puppet.initialize_settings
-Puppet.settings.use(:agent, :server, :master, :main)
-certpath = Puppet.settings[:hostcert]
-
-result = if File.exist?(certpath)
-           cert = x509_certificate_from_path(certpath)
-           {
-             'certificate-exists' => true,
-             'certname'      => certname_from_x509_certificate(cert),
-             'extensions'    => extensions_from_x509_certificate(cert),
-             'dns-alt-names' => alt_names_from_x509_certificate(cert),
-           }
-         else
-           {
-             'certificate-exists' => false,
-             'certname'      => Puppet.settings[:certname],
-             'extensions'    => extensions_from_csr_attributes_path(Puppet.settings[:csr_attributes]),
-             'dns-alt-names' => Puppet.settings[:dns_alt_names].to_s.split(','),
-           }
-         end
-
-# Put the result to stdout
-puts result.to_json

--- a/tasks/submit_csr.json
+++ b/tasks/submit_csr.json
@@ -1,6 +1,11 @@
 {
   "description": "Submit a certificate signing request",
-  "parameters": { },
+  "parameters": {
+    "dns_alt_names": {
+      "type": "Optional[Array[String]]",
+      "description": "DNS Alternative Names to request for the certificate"
+    }
+  },
   "input_method": "stdin",
   "implementations": [
     {"name": "submit_csr.rb"}

--- a/tasks/submit_csr.rb
+++ b/tasks/submit_csr.rb
@@ -7,35 +7,53 @@ require 'open3'
 require 'puppet'
 require 'puppet/face'
 
-Puppet.initialize_settings
-
-def already_signed?
-  cmd = ['/opt/puppetlabs/bin/puppet', 'ssl', 'verify']
-  _, status = Open3.capture2(*cmd)
-  status.success?
-end
-
-def main
-  majver = Gem::Version.new(Puppet.version).segments.first
-  if majver < 6
-    # signed cert already exist, assuming it is valid, no good way to verify until Puppet 6
-    exit 0 if File.exist?(Puppet.settings[:hostcert])
-    cmd = ['/opt/puppetlabs/bin/puppet', 'certificate', 'generate',
-           '--ca-location', 'remote',
-           '--dns-alt-names', Puppet.settings[:dns_alt_names],
-           Puppet.settings[:certname]]
-  else
-    exit 0 if already_signed?
-    cmd = ['/opt/puppetlabs/bin/puppet', 'ssl', 'submit_request']
+# Submit a CSR
+class SubmitCSR
+  def initialize(params)
+    @dns_alt_names = params['dns_alt_names']
   end
 
-  stdout, status = Open3.capture2(*cmd)
-  puts stdout
-  if status.success?
-    exit 0
-  else
-    exit 1
+  def already_signed?
+    cmd = ['/opt/puppetlabs/bin/puppet', 'ssl', 'verify']
+    output, status = Open3.capture2e(*cmd)
+    STDOUT.puts output
+    status.success?
+  end
+
+  def execute!
+    majver = Gem::Version.new(Puppet.version).segments.first
+
+    if majver < 6
+      # signed cert already exist, assuming it is valid, no good way to verify until Puppet 6
+      exit 0 if File.exist?(Puppet.settings[:hostcert])
+      dns_alt_name_str = @dns_alt_names.nil? ? Puppet.settings[:dns_alt_names] : @dns_alt_names.join(',')
+      cmd = ['/opt/puppetlabs/bin/puppet', 'certificate', 'generate',
+             '--ca-location', 'remote',
+             '--dns-alt-names', dns_alt_name_str,
+             Puppet.settings[:certname]]
+    else
+      exit 0 if already_signed?
+      cmd = ['/opt/puppetlabs/bin/puppet', 'ssl', 'submit_request']
+      unless @dns_alt_names.nil?
+        cmd << '--dns_alt_names' << @dns_alt_names.join(',')
+      end
+    end
+
+    output, status = Open3.capture2e(*cmd)
+    STDOUT.puts output
+    if status.success?
+      exit 0
+    else
+      exit 1
+    end
   end
 end
 
-main
+# Run the task unless an environment flag has been set, signaling not to. The
+# environment flag is used to disable auto-execution and enable Ruby unit
+# testing of this task.
+unless ENV['RSPEC_UNIT_TEST_MODE']
+  Puppet.initialize_settings
+  submit = SubmitCSR.new(JSON.parse(STDIN.read))
+  submit.execute!
+end


### PR DESCRIPTION
This PR replaces the old `peadm::modify_cert_extensions` plan with the `peadm::modify_certificate` plan. This plan supports setting DNS alt names, in addition to adjusting other extensions. It's also just a more friendly name.