### PR TITLE
Fix private designation syntax in private plans

### DIFF
--- a/plans/misc/divert_code_manager.pp
+++ b/plans/misc/divert_code_manager.pp
@@ -1,3 +1,6 @@
+# @api private
+# @private true
+#
 # @summary This plan exists to account for a scenario where a PE XL
 # architecture is in use, but code manager is not.
 #

--- a/plans/modify_cert_extensions.pp
+++ b/plans/modify_cert_extensions.pp
@@ -1,4 +1,5 @@
 # @api private
+# @private true
 plan peadm::modify_cert_extensions (
   TargetSpec              $targets,
   Peadm::SingleTargetSpec $primary_host,

--- a/plans/subplans/configure.pp
+++ b/plans/subplans/configure.pp
@@ -1,3 +1,6 @@
+# @api private
+# @private true
+#
 # @summary Configure first-time classification and DR setup
 #
 # @param compiler_pool_address 

--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -1,4 +1,5 @@
 # @api private
+# @private true
 #
 # @summary Perform initial installation of Puppet Enterprise Extra Large
 #

--- a/plans/subplans/modify_certificate.pp
+++ b/plans/subplans/modify_certificate.pp
@@ -1,4 +1,5 @@
 # @api private
+# @private true
 plan peadm::subplans::modify_certificate (
   Peadm::SingleTargetSpec $targets,
   TargetSpec              $primary_host,

--- a/plans/util/insert_csr_extension_requests.pp
+++ b/plans/util/insert_csr_extension_requests.pp
@@ -1,3 +1,5 @@
+# @api private
+# @private true
 plan peadm::util::insert_csr_extension_requests (
   TargetSpec $targets,
   Hash       $extension_requests,

--- a/plans/util/retrieve_and_upload.pp
+++ b/plans/util/retrieve_and_upload.pp
@@ -1,3 +1,5 @@
+# @api private
+# @private true
 plan peadm::util::retrieve_and_upload(
   TargetSpec $nodes,
   String[1]  $source,

--- a/plans/util/sanitize_pg_pe_conf.pp
+++ b/plans/util/sanitize_pg_pe_conf.pp
@@ -1,3 +1,5 @@
+# @api private
+# @private true
 plan peadm::util::sanitize_pg_pe_conf (
   TargetSpec              $targets,
   Peadm::SingleTargetSpec $primary_host,

--- a/tasks/puppet_runonce.sh
+++ b/tasks/puppet_runonce.sh
@@ -5,7 +5,7 @@
 # Wait for up to five minutes for an in-progress Puppet agent run to complete
 # TODO: right now the check is just for lock file existence. Improve the check
 #       to account for situations where the lockfile is stale.
-echo -n "Check for and wait up to 5 minutes for in-progress run to complete: "
+echo -n "Check for and wait up to 5 minutes for in-progress run to complete"
 lockfile=$(/opt/puppetlabs/bin/puppet config print agent_catalog_run_lockfile)
 n=0
 until [ $n -ge 300 ]
@@ -17,19 +17,24 @@ do
 done
 echo
 
+# Notes:
+#   - Do not run with color, as the color codes can make interpreting output when
+#     passed through Bolt difficult.
+#   - Without --detailed-exitcodes, the `puppet agent` command will return 0 even
+#     if there are a resource failures. So, use --detailed-exitcodes.
 /opt/puppetlabs/bin/puppet agent \
   --onetime \
   --verbose \
   --no-daemonize \
   --no-usecacheonfailure \
   --no-splay \
+  --no-color \
   --no-use_cached_catalog \
   --detailed-exitcodes \
   $NOOP_FLAG
 
-# Without --detailed-exitcodes, the `puppet agent` command will return 0 even
-# if there are resource failures. Use --detailed-exitcodes but only exit
-# non-zero if an error occurred. Changes (code 2) are not errors.
+# Only exit non-zero if an error occurred. Changes (detailed exit code 2) are
+# not errors.
 exitcode=$?
 if [ $exitcode -eq 0 -o $exitcode -eq 2 ]; then
   exit 0


### PR DESCRIPTION
Many plans in this module are not intended to be run directly, and are instead subplans or utility plans for internal use. This commit updates the doc comments in the plans to indicate to Bolt that they should not be shown or displayed when running commands like `bolt plan show`.

Keeping `# @api private` from [Puppet Strings](https://puppet.com/docs/puppet/7/puppet_strings.html#puppet_strings_reference-strings-tags), and adding the [Bolt-specific](https://puppet.com/docs/bolt/latest/writing_plans.html#making-plans-private) `# @private true`. It's unfortunate that these two stanzas are different today.

See also the Bolt feature request: https://github.com/puppetlabs/bolt/issues/2945