### PR TITLE
Highlight user-facing plans by hiding internal plans from bolt plan show output

### DIFF
--- a/plans/misc/divert_code_manager.pp
+++ b/plans/misc/divert_code_manager.pp
@@ -1,3 +1,6 @@
+# @api private
+# @private true
+#
 # @summary This plan exists to account for a scenario where a PE XL
 # architecture is in use, but code manager is not.
 #

--- a/plans/modify_cert_extensions.pp
+++ b/plans/modify_cert_extensions.pp
@@ -1,4 +1,5 @@
 # @api private
+# @private true
 plan peadm::modify_cert_extensions (
   TargetSpec              $targets,
   Peadm::SingleTargetSpec $primary_host,

--- a/plans/subplans/configure.pp
+++ b/plans/subplans/configure.pp
@@ -1,3 +1,6 @@
+# @api private
+# @private true
+#
 # @summary Configure first-time classification and DR setup
 #
 # @param compiler_pool_address 

--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -1,4 +1,5 @@
 # @api private
+# @private true
 #
 # @summary Perform initial installation of Puppet Enterprise Extra Large
 #

--- a/plans/subplans/modify_certificate.pp
+++ b/plans/subplans/modify_certificate.pp
@@ -1,4 +1,5 @@
 # @api private
+# @private true
 plan peadm::subplans::modify_certificate (
   Peadm::SingleTargetSpec $targets,
   TargetSpec              $primary_host,

--- a/plans/util/insert_csr_extension_requests.pp
+++ b/plans/util/insert_csr_extension_requests.pp
@@ -1,3 +1,5 @@
+# @api private
+# @private true
 plan peadm::util::insert_csr_extension_requests (
   TargetSpec $targets,
   Hash       $extension_requests,

--- a/plans/util/retrieve_and_upload.pp
+++ b/plans/util/retrieve_and_upload.pp
@@ -1,3 +1,5 @@
+# @api private
+# @private true
 plan peadm::util::retrieve_and_upload(
   TargetSpec $nodes,
   String[1]  $source,

--- a/plans/util/sanitize_pg_pe_conf.pp
+++ b/plans/util/sanitize_pg_pe_conf.pp
@@ -1,3 +1,5 @@
+# @api private
+# @private true
 plan peadm::util::sanitize_pg_pe_conf (
   TargetSpec              $targets,
   Peadm::SingleTargetSpec $primary_host,


### PR DESCRIPTION
Many plans in this module are not intended to be run directly, and are
instead subplans or utility plans for internal use. This commit updates
the doc comments in the plans to indicate to Bolt that they should not
be shown or displayed when running commands like `bolt plan show`.