### PR TITLE
Clean up output of puppet_runonce task

### DIFF
--- a/tasks/puppet_runonce.sh
+++ b/tasks/puppet_runonce.sh
@@ -5,7 +5,7 @@
 # Wait for up to five minutes for an in-progress Puppet agent run to complete
 # TODO: right now the check is just for lock file existence. Improve the check
 #       to account for situations where the lockfile is stale.
-echo -n "Check for and wait up to 5 minutes for in-progress run to complete: "
+echo -n "Check for and wait up to 5 minutes for in-progress run to complete"
 lockfile=$(/opt/puppetlabs/bin/puppet config print agent_catalog_run_lockfile)
 n=0
 until [ $n -ge 300 ]
@@ -17,6 +17,11 @@ do
 done
 echo
 
+# Notes:
+#   - Do not run with color, as the color codes can make interpreting output when
+#     passed through Bolt difficult.
+#   - Without --detailed-exitcodes, the `puppet agent` command will return 0 even
+#     if there are a resource failures. So, use --detailed-exitcodes.
 /opt/puppetlabs/bin/puppet agent \
   --onetime \
   --verbose \
@@ -25,11 +30,11 @@ echo
   --no-splay \
   --no-use_cached_catalog \
   --detailed-exitcodes \
+  --color false \
   $NOOP_FLAG
 
-# Without --detailed-exitcodes, the `puppet agent` command will return 0 even
-# if there are resource failures. Use --detailed-exitcodes but only exit
-# non-zero if an error occurred. Changes (code 2) are not errors.
+# Only exit non-zero if an error occurred. Changes (detailed exit code 2) are
+# not errors.
 exitcode=$?
 if [ $exitcode -eq 0 -o $exitcode -eq 2 ]; then
   exit 0


### PR DESCRIPTION
- Do not use color codes, as this makes the output difficult to read
  when returned by Bolt.

- Do not print \<space\>\<newline\>, since this combination will prevent
  Ruby's yaml emitter from using the block form (which is easier to read
  when newlines are involved). This doesn't have an immediate impact
  since we will be seeing the error in JSON, probably, but it
  potentially heads off confusion in the future if we choose to emit
  yaml instead.