### PR TITLE
Add --color=false to other puppet commands

### DIFF
--- a/tasks/enable_replica.sh
+++ b/tasks/enable_replica.sh
@@ -15,6 +15,7 @@ env PATH="/opt/puppetlabs/bin:${PATH}" \
     USER="$USER" \
     HOME="$HOME" \
     puppet infrastructure enable replica "$PT_replica" \
+      --color false \
       --skip-agent-config \
       --topology mono-with-compile \
       --yes --token-file "$TOKEN_FILE"

--- a/tasks/provision_replica.sh
+++ b/tasks/provision_replica.sh
@@ -15,6 +15,7 @@ set -e
 
 if [ "$PT_legacy" = "false" ]; then
   puppet infrastructure provision replica "$PT_replica" \
+    --color false \
     --yes --token-file "$TOKEN_FILE" \
     --skip-agent-config \
     --topology mono-with-compile \
@@ -22,9 +23,11 @@ if [ "$PT_legacy" = "false" ]; then
 
 elif [ "$PT_legacy" = "true" ]; then
   puppet infrastructure provision replica "$PT_replica" \
+    --color false \
     --token-file "$TOKEN_FILE"
 
   puppet infrastructure enable replica "$PT_replica" \
+    --color false \
     --yes --token-file "$TOKEN_FILE" \
     --skip-agent-config \
     --topology mono-with-compile

--- a/tasks/puppet_infra_upgrade.rb
+++ b/tasks/puppet_infra_upgrade.rb
@@ -21,7 +21,7 @@ class PuppetInfraUpgrade
     exit 0 if @targets.empty?
     token_file = @token_file || File.join(Etc.getpwuid.dir, '.puppetlabs', 'token')
 
-    cmd = ['/opt/puppetlabs/bin/puppet-infrastructure', '--render-as', 'json', 'upgrade']
+    cmd = ['/opt/puppetlabs/bin/puppet-infrastructure', '--color', 'false', '--render-as', 'json', 'upgrade']
     cmd << '--token-file' << token_file unless @token_file.nil?
     cmd << @type << @targets.join(',')
 


### PR DESCRIPTION
Same rationale as before: easier to read, cleaner output when viewed
coming back from Bolt. The color codes make it harder to read in JSON or
YAML documents.