### PR TITLE
Fix upgrade bug for token files with newlines

### DIFF
--- a/tasks/puppet_infra_upgrade.rb
+++ b/tasks/puppet_infra_upgrade.rb
@@ -51,7 +51,7 @@ class PuppetInfraUpgrade
 
     request = Net::HTTP::Post.new(inventory_uri.request_uri)
     request['Content-Type'] = 'application/json'
-    request['X-Authentication'] = token
+    request['X-Authentication'] = token.chomp
     request.body = body
 
     request


### PR DESCRIPTION
Previously if a token file contained a newline, the upgrade plan would fail. This commit fixes that bug. Token files ending with a newline will not cause an error.