### PR TITLE
Remove hardcoded mem settings from default pe.conf

### DIFF
--- a/functions/generate_pe_conf.pp
+++ b/functions/generate_pe_conf.pp
@@ -1,13 +1,12 @@
-# Generates a pe.conf file, removing undef parameters
+# @summary Generate a pe.conf file in JSON format
 #
-# @param user_settings
+# @param settings
 #   A hash of settings to set in the config file. Any keys that are set to
-#   undef will not be included in the config file. This is done to reduce the
-#   amount of logic required within plans if parameters are not passed in.
+#   undef will not be included in the config file.
 #
 function peadm::generate_pe_conf (
   Hash $settings,
-) {
+)  >> String {
   # Check that console_admin_password is present
   unless $settings['console_admin_password'] =~ String {
     fail('pe.conf must have the console_admin_password set')
@@ -16,23 +15,26 @@ function peadm::generate_pe_conf (
   # Define the configuration settings that will be placed in pe.conf by
   # default. These can be overriden by user-supplied values in the $settings
   # hash.
+  #
+  # At this time, there are no defaults which need to be modified from the
+  # out-of-box defaults.
   $defaults = {
-    'puppet_enterprise::profile::master::java_args' => {
-      'Xmx' => '2048m',
-      'Xms' => '512m',
-    },
-    'puppet_enterprise::profile::console::java_args' => {
-      'Xmx' => '768m',
-      'Xms' => '256m',
-    },
-    'puppet_enterprise::profile::orchestrator::java_args' => {
-      'Xmx' => '768m',
-      'Xms' => '256m',
-    },
-    'puppet_enterprise::profile::puppetdb::java_args' => {
-      'Xmx' => '768m',
-      'Xms' => '256m',
-    },
+    # 'puppet_enterprise::profile::master::java_args' => {
+    #   'Xmx' => '2048m',
+    #   'Xms' => '512m',
+    # },
+    # 'puppet_enterprise::profile::console::java_args' => {
+    #   'Xmx' => '768m',
+    #   'Xms' => '256m',
+    # },
+    # 'puppet_enterprise::profile::orchestrator::java_args' => {
+    #   'Xmx' => '768m',
+    #   'Xms' => '256m',
+    # },
+    # 'puppet_enterprise::profile::puppetdb::java_args' => {
+    #   'Xmx' => '768m',
+    #   'Xms' => '256m',
+    # },
   }
 
   # Merge the defaults with user-supplied settings, remove anything that is

--- a/functions/generate_pe_conf.pp
+++ b/functions/generate_pe_conf.pp
@@ -12,35 +12,9 @@ function peadm::generate_pe_conf (
     fail('pe.conf must have the console_admin_password set')
   }
 
-  # Define the configuration settings that will be placed in pe.conf by
-  # default. These can be overriden by user-supplied values in the $settings
-  # hash.
-  #
-  # At this time, there are no defaults which need to be modified from the
-  # out-of-box defaults.
-  $defaults = {
-    # 'puppet_enterprise::profile::master::java_args' => {
-    #   'Xmx' => '2048m',
-    #   'Xms' => '512m',
-    # },
-    # 'puppet_enterprise::profile::console::java_args' => {
-    #   'Xmx' => '768m',
-    #   'Xms' => '256m',
-    # },
-    # 'puppet_enterprise::profile::orchestrator::java_args' => {
-    #   'Xmx' => '768m',
-    #   'Xms' => '256m',
-    # },
-    # 'puppet_enterprise::profile::puppetdb::java_args' => {
-    #   'Xmx' => '768m',
-    #   'Xms' => '256m',
-    # },
-  }
-
-  # Merge the defaults with user-supplied settings, remove anything that is
-  # undef, then output to JSON (and therefore HOCON, because HOCON is a
-  # superset of JSON)
-  ($defaults + $settings).filter |$key,$value| {
+  # Remove anything that is undef, then output to JSON (and therefore HOCON,
+  # because HOCON is a superset of JSON)
+  $settings.filter |$key,$value| {
     $value != undef
   }.to_json_pretty()
 }


### PR DESCRIPTION
A long time ago these settings were added to faciliate local development
on VirtualBox, using developer workstations. We should not provide
different memory defaults for PE installs than what is provided by PE
itself.

Additional fix: found Puppet Strings bug which prevented generating a
REFERENCE.md file. It is now possible to use Puppet Strings to generate
a REFERENCE.md.