### PR TITLE
Add PE download signature checking

### DIFF
--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -203,11 +203,10 @@ plan peadm::subplans::install (
     )
   } else {
     # Download PE tarballs directly to nodes that need it
-    $result = run_task('peadm::download', $pe_installer_targets,
+    run_task('peadm::download', $pe_installer_targets,
       source => $pe_tarball_source,
       path   => $upload_tarball_path,
     )
-    out::message($result)
   }
 
   # Create csr_attributes.yaml files for the nodes that need them. Ensure that

--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -203,10 +203,11 @@ plan peadm::subplans::install (
     )
   } else {
     # Download PE tarballs directly to nodes that need it
-    run_task('peadm::download', $pe_installer_targets,
+    $result = run_task('peadm::download', $pe_installer_targets,
       source => $pe_tarball_source,
       path   => $upload_tarball_path,
     )
+    out::message($result)
   }
 
   # Create csr_attributes.yaml files for the nodes that need them. Ensure that

--- a/tasks/download.json
+++ b/tasks/download.json
@@ -8,6 +8,11 @@
     "path": {
       "type": "String",
       "description": "Where to save the downloaded file"
+    },
+    "check_download": {
+      "type": "Boolean",
+      "description": "Whether to check the integrity of the downloaded file",
+      "default": false
     }
   },
   "input_method": "environment",

--- a/tasks/download.json
+++ b/tasks/download.json
@@ -12,7 +12,7 @@
     "check_download": {
       "type": "Boolean",
       "description": "Whether to check the integrity of the downloaded file",
-      "default": false
+      "default": true
     }
   },
   "input_method": "environment",

--- a/tasks/download.sh
+++ b/tasks/download.sh
@@ -17,26 +17,29 @@ if [[ "$PT_check_download" != "true" ]]; then
 fi
 
 if ! which gpg ; then
-  echo "gpg binary required in path for checking download"
-  exit 1
+  echo "gpg binary required in path for checking download. Skipping check."
+  exit 0
 fi
+
 echo "Importing Puppet gpg public key"
 gpg --keyserver hkp://keyserver.ubuntu.com:11371 --recv-key 4528B6CD9E61EF26
 if gpg --list-key --fingerprint 4528B6CD9E61EF26 | grep -q -E "D681 +1ED3 +ADEE +B844 +1AF5 +AA8F +4528 +B6CD +9E61 +EF26" ; then
-  echo "gpg public key imported successfully!"
+  echo "gpg public key imported successfully."
 else
-  echo "Could not import gpg public key - wrong fingerprint"
+  echo "Could not import gpg public key - wrong fingerprint."
   exit 1
 fi
+
 sigpath=${PT_path}.asc
 sigsource=${PT_source}.asc
-echo "Downloading tarball signature from ${sigsource}"
+
+echo "Downloading tarball signature from ${sigsource}..."
 curl -f -L -o "${sigpath}" "${sigsource}"
-echo "Downloaded tarball signature to ${sigpath}"
-echo "Checking tarball signature at ${sigpath}"
+echo "Downloaded tarball signature to ${sigpath}."
+echo "Checking tarball signature at ${sigpath}..."
 if gpg --verify "${sigpath}" "${PT_path}" | grep "Good signature" ; then
   echo "Signature verification failed, please re-run the installation."
   exit 1
 else
-  echo "Signature verification suceeded!"
+  echo "Signature verification suceeded."
 fi

--- a/tasks/download.sh
+++ b/tasks/download.sh
@@ -16,7 +16,7 @@ if [[ "$PT_check_download" == "false" ]]; then
   exit 0
 fi
 
-if ! which gpg ; then
+if ! which -s gpg ; then
   echo "gpg binary required in path for checking download. Skipping check."
   exit 0
 fi
@@ -37,8 +37,8 @@ echo "Downloading tarball signature from ${sigsource}..."
 curl -f -L -o "${sigpath}" "${sigsource}"
 echo "Downloaded tarball signature to ${sigpath}."
 echo "Checking tarball signature at ${sigpath}..."
-if gpg --verify "${sigpath}" "${PT_path}" | grep "Good signature" ; then
-  echo "Signature verification suceeded."
+if gpg --verify "${sigpath}" "${PT_path}" ; then
+  echo "Signature verification succeeded."
 else
   echo "Signature verification failed, please re-run the installation."
   exit 1

--- a/tasks/download.sh
+++ b/tasks/download.sh
@@ -12,7 +12,7 @@ else
   curl -f -L -o "$PT_path" "$PT_source"
 fi
 
-if [[ "$PT_check_download" != "true" ]]; then
+if [[ "$PT_check_download" == "false" ]]; then
   exit 0
 fi
 
@@ -38,8 +38,8 @@ curl -f -L -o "${sigpath}" "${sigsource}"
 echo "Downloaded tarball signature to ${sigpath}."
 echo "Checking tarball signature at ${sigpath}..."
 if gpg --verify "${sigpath}" "${PT_path}" | grep "Good signature" ; then
+  echo "Signature verification suceeded."
+else
   echo "Signature verification failed, please re-run the installation."
   exit 1
-else
-  echo "Signature verification suceeded."
 fi

--- a/tasks/download.sh
+++ b/tasks/download.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 urisize=$(curl -s -L --head "$PT_source" | sed -n 's/Content-Length: \([0-9]\+\)/\1/p' | tr -d '\012\015')
 filesize=$(stat -c%s "$PT_path" 2>/dev/null)

--- a/tasks/download.sh
+++ b/tasks/download.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 urisize=$(curl -s -L --head "$PT_source" | sed -n 's/Content-Length: \([0-9]\+\)/\1/p' | tr -d '\012\015')
 filesize=$(stat -c%s "$PT_path" 2>/dev/null)


### PR DESCRIPTION
The download task now accepts an extra parameter "check_download" and if set to true, downloads the signature file and checks the downloaded tarball against the signature. It requires the gpg binary to be installed on the download host.