### PR TITLE
Support PE 2021.3

### DIFF
--- a/.github/workflows/test-add-replica.yaml
+++ b/.github/workflows/test-add-replica.yaml
@@ -15,7 +15,7 @@ on:
       version:
         description: 'PE version to install'
         required: true
-        default: '2019.8.7'
+        default: '2019.8.8'
       ssh-debugging:
         description: 'Boolean; whether or not to pause for ssh debugging'
         required: true

--- a/.github/workflows/test-install-matrix.yaml
+++ b/.github/workflows/test-install-matrix.yaml
@@ -28,8 +28,8 @@ jobs:
           - large
           - extra-large-with-dr
         version:
-          - 2019.8.7
-          - 2021.2.0
+          - 2019.8.8
+          - 2021.3.0
         image:
           - centos-7
 

--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -15,7 +15,7 @@ on:
       version:
         description: 'PE version to install'
         required: true
-        default: '2019.8.7'
+        default: '2021.3.0'
       ssh-debugging:
         description: 'Boolean; whether or not to pause for ssh debugging'
         required: true

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ The normal usage pattern for peadm is as follows.
 
 ### Requirements
 
-* Puppet Enterprise 2019.8.1 or newer (tested with PE 2021.2)
-* Bolt 3.10.0 or newer (tested with Bolt 3.10.0)
+* Puppet Enterprise 2019.8.1 or newer (tested with PE 2021.3)
+* Bolt 3.17.0 or newer (tested with Bolt 3.17.0)
 * EL 7, EL 8, Ubuntu 18.04, or Ubuntu 20.04
 * Classifier Data enabled. This PE feature is enabled by default on new installs, but can be disabled by users if they remove the relevant configuration from their global hiera.yaml file. See the [PE docs](https://puppet.com/docs/pe/latest/config_console.html#task-5039) for more information.
 

--- a/functions/assert_supported_bolt_version.pp
+++ b/functions/assert_supported_bolt_version.pp
@@ -4,7 +4,7 @@
 function peadm::assert_supported_bolt_version (
   # No arguments
 ) >> Struct[{'supported' => Boolean}] {
-  $supported_bolt_version = '>= 3.10.0 < 4.0.0'
+  $supported_bolt_version = '>= 3.17.0 < 4.0.0'
   $supported = (peadm::bolt_version() =~ SemVerRange($supported_bolt_version))
 
   unless $supported {

--- a/functions/assert_supported_pe_version.pp
+++ b/functions/assert_supported_pe_version.pp
@@ -4,15 +4,15 @@ function peadm::assert_supported_pe_version (
   String $version,
 ) >> Struct[{'supported' => Boolean}] {
   $oldest = '2019.7'
-  $newest = '2021.2'
+  $newest = '2021.3'
   $supported = ($version =~ SemVerRange(">= ${oldest} <= ${newest}"))
 
   unless $supported {
     fail(@("REASON"/L))
       This version of the puppetlabs-peadm module does not support PE ${version}.
 
-      For PE versions older than ${oldest}, please use version 1.x of the \
-      puppetlabs-peadm module.
+      For PE versions older than ${oldest}, please check to see if version 1.x \
+      or 2.x of the puppetlabs-peadm module supports your PE version.
 
       For PE versions newer than ${newest}, check to see if a new version of peadm \
       exists which supports that version of PE.


### PR DESCRIPTION
This commit updates CI defaults and supported version assertions to
indicate that PE 2021.3 is supported, and tested.