### PR TITLE
Add development and testing option to permit installing unsupported PE versions

### DIFF
--- a/functions/assert_supported_pe_version.pp
+++ b/functions/assert_supported_pe_version.pp
@@ -2,10 +2,18 @@
 # @param [String] the version number to check
 function peadm::assert_supported_pe_version (
   String $version,
+  Boolean $permit_unsafe_versions = false,
 ) >> Struct[{'supported' => Boolean}] {
   $oldest = '2019.7'
   $newest = '2021.3'
-  $supported = ($version =~ SemVerRange(">= ${oldest} <= ${newest}"))
+  $supported = (($version =~ SemVerRange(">= ${oldest} <= ${newest}")) or $permit_unsafe_versions)
+
+  if $permit_unsafe_versions {
+    warning(@("WARN"/L))
+      WARNING: Permitting unsafe PE versions. This is not supported or tested.
+        Proceeding with this action could result in a broken PE Infrastructure.
+      | WARN
+  }
 
   unless $supported {
     fail(@("REASON"/L))

--- a/functions/assert_supported_pe_version.pp
+++ b/functions/assert_supported_pe_version.pp
@@ -6,7 +6,7 @@ function peadm::assert_supported_pe_version (
 ) >> Struct[{'supported' => Boolean}] {
   $oldest = '2019.7'
   $newest = '2021.3'
-  $supported = (($version =~ SemVerRange(">= ${oldest} <= ${newest}")) or $permit_unsafe_versions)
+  $supported = ($version =~ SemVerRange(">= ${oldest} <= ${newest}"))
 
   if $permit_unsafe_versions {
     warning(@("WARN"/L))
@@ -15,7 +15,12 @@ function peadm::assert_supported_pe_version (
       | WARN
   }
 
-  unless $supported {
+  if (!$supported and $permit_unsafe_versions) {
+    warning(@("WARN"/L))
+      WARNING: PE version ${version} is NOT SUPPORTED!
+      | WARN
+  }
+  elsif (!$supported) {
     fail(@("REASON"/L))
       This version of the puppetlabs-peadm module does not support PE ${version}.
 

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -46,12 +46,13 @@ plan peadm::install (
   Optional[String]                  $license_key_content = undef,
 
   # Other
-  Optional[String]                  $stagingdir    = undef,
-  Enum[direct,bolthost]             $download_mode = 'bolthost',
+  Optional[String]                  $stagingdir             = undef,
+  Enum[direct,bolthost]             $download_mode          = 'bolthost',
+  Boolean                           $permit_unsafe_versions = false,
 ) {
   peadm::assert_supported_bolt_version()
 
-  peadm::assert_supported_pe_version($version)
+  peadm::assert_supported_pe_version($version, $permit_unsafe_versions)
 
   $install_result = run_plan('peadm::subplans::install',
     # Standard
@@ -83,6 +84,7 @@ plan peadm::install (
     # Other
     stagingdir                     => $stagingdir,
     download_mode                  => $download_mode,
+    permit_unsafe_versions         => $permit_unsafe_versions,
   )
 
   $configure_result = run_plan('peadm::subplans::configure',

--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -49,10 +49,11 @@ plan peadm::subplans::install (
   Optional[String]     $license_key_content = undef,
 
   # Other
-  String                $stagingdir    = '/tmp',
-  Enum[direct,bolthost] $download_mode = 'bolthost',
+  String                $stagingdir             = '/tmp',
+  Enum[direct,bolthost] $download_mode          = 'bolthost',
+  Boolean               $permit_unsafe_versions = false,
 ) {
-  peadm::assert_supported_pe_version($version)
+  peadm::assert_supported_pe_version($version, $permit_unsafe_versions)
 
   # Convert inputs into targets.
   $primary_target            = peadm::get_targets($primary_host, 1)

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -31,9 +31,10 @@ plan peadm::upgrade (
   Optional[String] $internal_compiler_b_pool_address = undef,
 
   # Other
-  Optional[String]      $token_file    = undef,
-  String                $stagingdir    = '/tmp',
-  Enum[direct,bolthost] $download_mode = 'bolthost',
+  Optional[String]      $token_file             = undef,
+  String                $stagingdir             = '/tmp',
+  Enum[direct,bolthost] $download_mode          = 'bolthost',
+  Boolean               $permit_unsafe_versions = false,
 
   Optional[Enum[
     'upgrade-primary',
@@ -45,7 +46,7 @@ plan peadm::upgrade (
 ) {
   peadm::assert_supported_bolt_version()
 
-  peadm::assert_supported_pe_version($version)
+  peadm::assert_supported_pe_version($version, $permit_unsafe_versions)
 
   # Ensure input valid for a supported architecture
   $arch = peadm::assert_supported_architecture(

--- a/spec/functions/assert_supported_pe_version_spec.rb
+++ b/spec/functions/assert_supported_pe_version_spec.rb
@@ -29,11 +29,11 @@ describe 'peadm::assert_supported_pe_version' do
 
   context 'unsafe versions' do
     it 'accepts PE versions that are too old' do
-      is_expected.to run.with_params('2018.1.0', true).and_return({ 'supported' => true })
+      is_expected.to run.with_params('2018.1.0', true).and_return({ 'supported' => false })
     end
 
     it 'accepts PE versions that are too new' do
-      is_expected.to run.with_params('2035.0.0', true).and_return({ 'supported' => true })
+      is_expected.to run.with_params('2035.0.0', true).and_return({ 'supported' => false })
     end
 
     it 'accepts PE versions that are in the supported range' do

--- a/spec/functions/assert_supported_pe_version_spec.rb
+++ b/spec/functions/assert_supported_pe_version_spec.rb
@@ -26,4 +26,18 @@ describe 'peadm::assert_supported_pe_version' do
       is_expected.to run.with_params('2019.8.7').and_return({ 'supported' => true })
     end
   end
+
+  context 'unsafe versions' do
+    it 'accepts PE versions that are too old' do
+      is_expected.to run.with_params('2018.1.0', true).and_return({ 'supported' => true })
+    end
+
+    it 'accepts PE versions that are too new' do
+      is_expected.to run.with_params('2035.0.0', true).and_return({ 'supported' => true })
+    end
+
+    it 'accepts PE versions that are in the supported range' do
+      is_expected.to run.with_params('2019.8.7', true).and_return({ 'supported' => true })
+    end
+  end
 end


### PR DESCRIPTION
Prior to this PR, there was no way to force an override to the PE version assertion. This PR adds a new parameter that will override the PE version check and output a warning when enabled. This is useful in testing new PE versions that are not yet supported by the module.

Note that the installation plan will emit two copies of the warning due to the function call in the `install` and `subplan::install` plans. I did not correct this as it seems acceptable to emit the warning multiple times.

```
Starting: plan peadm::install
WARNING: Permitting unsafe PE versions. This is not supported or tested.
  Proceeding with this action could result in a broken PE Infrastructure.

WARNING: Permitting unsafe PE versions. This is not supported or tested.
  Proceeding with this action could result in a broken PE Infrastructure.

Starting: plan peadm::subplans::install
```
