### PR TITLE
Improve reliability of downloading PE tarball

### DIFF
--- a/tasks/download.sh
+++ b/tasks/download.sh
@@ -42,7 +42,7 @@ download() {
   echo "Temporary file created at: ${tmp_file}"
   curl -s -f -L -o ${tmp_file} "$1"
   if [ tar -tzf "${tmp_file}" >/dev/null ]; then
-    mv ${tmp_file} "$2"
+    mv "${tmp_file}" "$2"
   else
     echo "Puppet Enterprise download failed: Invalid tarball"
     echo "|_ Temporary: ${tmp_file}"

--- a/tasks/download.sh
+++ b/tasks/download.sh
@@ -38,13 +38,13 @@ download() {
   printf '%s\n' "Downloading: ${1}"
   tmp_file=$(mktemp "peadm-download.XXX")
   echo "Temporary file created at: ${tmp_file}"
-  download_file=$(curl -s -f -L -o ${tmp_file} "$1")
-  if [[ -z "$download_file" ]]; then
+
+  if curl -s -f -L -o ${tmp_file} "$1"; then
     mv "${tmp_file}" "$2"
     return 0
   else
     echo "Error: Curl has failed to download the file"
-    echo "|_ Removing temporary file: ${tmp_file}"
+    echo "Removing temporary file: ${tmp_file}"
     rm "${tmp_file}"
     return 1
   fi

--- a/tasks/download.sh
+++ b/tasks/download.sh
@@ -38,7 +38,7 @@ download() {
   local tmp_file_name="pe-tmp-file"
 
   printf '%s\n' "Downloading: ${1}"
-  tmp_file=$(mktemp -p /tmp/ "$tmp_file_name")
+  tmp_file=$(mktemp "peadm-download")
   echo "Temporary file created at: ${tmp_file}"
   curl -s -f -L -o ${tmp_file} "$1"
   if [ tar -tzf "${tmp_file}" >/dev/null ]; then

--- a/tasks/download.sh
+++ b/tasks/download.sh
@@ -35,8 +35,6 @@ verify-file() {
 }
 
 download() {
-  local tmp_file_name="pe-tmp-file"
-
   printf '%s\n' "Downloading: ${1}"
   tmp_file=$(mktemp "peadm-download")
   echo "Temporary file created at: ${tmp_file}"
@@ -45,7 +43,7 @@ download() {
     mv "${tmp_file}" "$2"
   else
     echo "Puppet Enterprise download failed: Invalid tarball"
-    echo "|_ Temporary: ${tmp_file}"
+    echo "|_ Removing temporary file: ${tmp_file}"
     rm "${tmp_file}"
   fi
 }

--- a/tasks/download.sh
+++ b/tasks/download.sh
@@ -36,7 +36,7 @@ verify-file() {
 
 download() {
   printf '%s\n' "Downloading: ${1}"
-  tmp_file=$(mktemp "peadm-download.XXX")
+  tmp_file=$(mktemp)
   echo "Temporary file created at: ${tmp_file}"
 
   if curl -s -f -L -o ${tmp_file} "$1"; then

--- a/tasks/download.sh
+++ b/tasks/download.sh
@@ -41,7 +41,7 @@ download() {
   tmp_file=$(mktemp -p /tmp/ "$tmp_file_name")
   echo "Temporary file created at: ${tmp_file}"
   curl -s -f -L -o ${tmp_file} "$1"
-  if [tar -tzf ${tmp_file} >/dev/null]; then
+  if [ tar -tzf "${tmp_file}" >/dev/null ]; then
     mv ${tmp_file} "$2"
   else
     echo "Puppet Enterprise download failed: Invalid tarball"

--- a/tasks/download.sh
+++ b/tasks/download.sh
@@ -39,11 +39,13 @@ download() {
 
   printf '%s\n' "Downloading: ${1}"
   tmp_file=$(mktemp -p /tmp/ "$tmp_file_name")
+  echo "Temporary file created at: ${tmp_file}"
   curl -s -f -L -o ${tmp_file} "$1"
   if [tar -tzf ${tmp_file} >/dev/null]; then
     mv ${tmp_file} "$2"
   else
     echo "Puppet Enterprise download failed: Invalid tarball"
+    echo "|_ Temporary: ${tmp_file}"
     rm ${tmp_file}
   fi
 }

--- a/tasks/download.sh
+++ b/tasks/download.sh
@@ -39,12 +39,14 @@ download() {
   tmp_file=$(mktemp "peadm-download")
   echo "Temporary file created at: ${tmp_file}"
   curl -s -f -L -o ${tmp_file} "$1"
-  if [ tar -tzf "${tmp_file}" >/dev/null ]; then
+  if [[ tar -tzf "${tmp_file}" >/dev/null ]]; then
     mv "${tmp_file}" "$2"
+    return 0
   else
     echo "Puppet Enterprise download failed: Invalid tarball"
     echo "|_ Removing temporary file: ${tmp_file}"
     rm "${tmp_file}"
+    return 1
   fi
 }
 

--- a/tasks/download.sh
+++ b/tasks/download.sh
@@ -38,13 +38,12 @@ download() {
   printf '%s\n' "Downloading: ${1}"
   tmp_file=$(mktemp "peadm-download.XXX")
   echo "Temporary file created at: ${tmp_file}"
-  curl -s -f -L -o ${tmp_file} "$1"
-  valid_tar=$(tar -tf ${tmp_file} >/dev/null)
-  if [[ -z "$valid_tar" ]]; then
+  download_file=$(curl -s -f -L -o ${tmp_file} "$1")
+  if [[ -z "$download_file" ]]; then
     mv "${tmp_file}" "$2"
     return 0
   else
-    echo "Puppet Enterprise download failed: Invalid tarball"
+    echo "Error: Curl has failed to download the file"
     echo "|_ Removing temporary file: ${tmp_file}"
     rm "${tmp_file}"
     return 1

--- a/tasks/download.sh
+++ b/tasks/download.sh
@@ -36,10 +36,11 @@ verify-file() {
 
 download() {
   printf '%s\n' "Downloading: ${1}"
-  tmp_file=$(mktemp "peadm-download")
+  tmp_file=$(mktemp "peadm-download.XXX")
   echo "Temporary file created at: ${tmp_file}"
   curl -s -f -L -o ${tmp_file} "$1"
-  if [[ tar -tzf "${tmp_file}" >/dev/null ]]; then
+  valid_tar=$(tar -tf ${tmp_file} >/dev/null)
+  if [[ -z "$valid_tar" ]]; then
     mv "${tmp_file}" "$2"
     return 0
   else

--- a/tasks/download.sh
+++ b/tasks/download.sh
@@ -35,8 +35,17 @@ verify-file() {
 }
 
 download() {
+  local tmp_file_name="pe-tmp-file"
+
   printf '%s\n' "Downloading: ${1}"
-  curl -s -f -L -o "$2" "$1"
+  tmp_file=$(mktemp -p /tmp/ "$tmp_file_name")
+  curl -s -f -L -o ${tmp_file} "$1"
+  if [tar -tzf ${tmp_file} >/dev/null]; then
+    mv ${tmp_file} "$2"
+  else
+    echo "Puppet Enterprise download failed: Invalid tarball"
+    rm ${tmp_file}
+  fi
 }
 
 download-size-verify() {

--- a/tasks/download.sh
+++ b/tasks/download.sh
@@ -46,7 +46,7 @@ download() {
   else
     echo "Puppet Enterprise download failed: Invalid tarball"
     echo "|_ Temporary: ${tmp_file}"
-    rm ${tmp_file}
+    rm "${tmp_file}"
   fi
 }
 


### PR DESCRIPTION
This fix makes it so that when files are downloaded, they are first downloaded to a temp file and moved into place only if the download completes and is successful. This avoids a scenario where a file can be partially downloaded, after which PEAdm thinks that the file is present and will attempt to use the partial file as-is, rather than re-downloading.

There are still ways that an incorrect file can end up being placed—namely, the download server returning HTTP 200 but the wrong file. This fix though should eliminate the problem caused by partial interrupted downloads.

### Changes

* I'm validating whether `curl` successfully downloaded the file so we can throw an error
