### PR TITLE
Create sample plan to display code sync status

### DIFF
--- a/plans/util/code_sync_status.pp
+++ b/plans/util/code_sync_status.pp
@@ -1,3 +1,4 @@
+# @api private
 plan peadm::util::code_sync_status (
   Peadm::SingleTargetSpec $targets,
 ) {

--- a/plans/util/code_sync_status.pp
+++ b/plans/util/code_sync_status.pp
@@ -8,9 +8,8 @@ plan peadm::util::code_sync_status (
   out::message(
     format::table({
       title => 'Summary',
-      rows  => $data['environments'].reduce([
-                 ["Overall sync status", $data['sync']]]) |$memo, $val| {
-                   $memo << ["${val[0]} environment in sync", $val[1]['sync']] }}))
+      rows  => $data['environments'].reduce([['Overall sync status', $data['sync']]]) |$memo, $val| {
+        $memo << ["${val[0]} environment in sync", $val[1]['sync']] }}))
 
   # Print a server status table, one for each environment
   $data['environments'].each |$env, $_| {
@@ -19,7 +18,7 @@ plan peadm::util::code_sync_status (
         title => "Server sync status - ${env}",
         head  => ['Server', 'In Sync', 'Commit'],
         rows  => $data['environments'][$env]['servers'].reduce([]) |$memo, $val| {
-                   $memo << [$val[0], $val[1]['sync'], $val[1]['commit']] }}))
+          $memo << [$val[0], $val[1]['sync'], $val[1]['commit']] }}))
   }
 
   return('Done')

--- a/plans/util/code_sync_status.pp
+++ b/plans/util/code_sync_status.pp
@@ -1,0 +1,25 @@
+plan peadm::util::code_sync_status (
+  Peadm::SingleTargetSpec $targets,
+) {
+  $data = run_task('peadm::code_sync_status', $targets).first.value
+
+  # Print a table of summary status
+  out::message(
+    format::table({
+      title => 'Summary',
+      rows  => $data['environments'].reduce([
+                 ["Overall sync status", $data['sync']]]) |$memo, $val| {
+                   $memo << ["${val[0]} environment in sync", $val[1]['sync']] }}))
+
+  # Print a server status table, one for each environment
+  $data['environments'].each |$env, $_| {
+    out::message(
+      format::table({
+        title => "Server sync status - ${env}",
+        head  => ['Server', 'In Sync', 'Commit'],
+        rows  => $data['environments'][$env]['servers'].reduce([]) |$memo, $val| {
+                   $memo << [$val[0], $val[1]['sync'], $val[1]['commit']] }}))
+  }
+
+  return('Done')
+}

--- a/tasks/code_sync_status.rb
+++ b/tasks/code_sync_status.rb
@@ -98,9 +98,12 @@ class CodeSyncStatus
     environmentstocheck.each do |environment|
       results[environment] = check_environment_code(environment, servers, status_call)
     end
+
     # Confirm are all environments being checked in sync
-    results['sync'] = results.all? { |_k, v| v['sync'] == true }
-    results
+    {
+      'environments' => results,
+      'sync' => results.all? { |_k, v| v['sync'] == true },
+    }
   end
 end
 # Run the task unless an environment flag has been set, signaling not to. The


### PR DESCRIPTION
Just a draft to save some doodling. The JSON from the task is not the easiest to read, compared to output such as the following.

```
Starting: plan peadm::util::code_sync_status
Starting: task peadm::code_sync_status on pe-server-37cf31-0.us-west1-a.c.puppet-solutions-architects.internal
Finished: task peadm::code_sync_status with 0 failures in 4.49 sec
+--------------------------------+------+
|                Summary                |
+--------------------------------+------+
| Overall sync status            | true |
| production environment in sync | true |
+--------------------------------+------+
+-----------------------------------------------------------------------------------+---------+---------------------------------------------+
|                                                      Server sync status - production                                                      |
+-----------------------------------------------------------------------------------+---------+---------------------------------------------+
| Server                                                                            | In Sync | Commit                                      |
+-----------------------------------------------------------------------------------+---------+---------------------------------------------+
| pe-server-37cf31-0.us-west1-a.c.puppet-solutions-architects.internal              | true    | Commit content to file sync storage service |
| pe-compiler-37cf31-3.us-west1-a.c.puppet-solutions-architects.internal            | true    | Commit content to file sync storage service |
| pe-server-37cf31-1.us-west1-b.c.puppet-solutions-architects.internal              | true    | Commit content to file sync storage service |
| pe-compiler-37cf31-0.us-west1-a.c.puppet-solutions-architects.internal            | true    | Commit content to file sync storage service |
| pe-compiler-37cf31-2.us-west1-c.c.puppet-solutions-architects.internal            | true    | Commit content to file sync storage service |
| pe-compiler-37cf31-1.us-west1-b.c.puppet-solutions-architects.internal            | true    | Commit content to file sync storage service |
| pe-server-37cf31-0.us-west1-a.c.puppet-solutions-architects.internal-orchestrator | true    | Commit content to file sync storage service |
+-----------------------------------------------------------------------------------+---------+---------------------------------------------+
Finished: plan peadm::util::code_sync_status in 4.53 sec
"Done"
```