### PR TITLE
SOLARCH-716 update pe version and supported puppetlabs/service module version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,7 @@
     },
     {
       "name": "puppetlabs/service",
-      "version_requirement": ">= 1.3.0 < 2.0.0"
+      "version_requirement": ">= 1.3.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -26,7 +26,7 @@ plan peadm::install (
 
   # Common Configuration
   String                            $console_password,
-  String                            $version                          = '2019.8.5',
+  String                            $version                          = '2019.8.8',
   Optional[Array[String]]           $dns_alt_names                    = undef,
   Optional[String]                  $compiler_pool_address            = undef,
   Optional[String]                  $internal_compiler_a_pool_address = undef,


### PR DESCRIPTION
This ticket moves the default version of PE to the latest 2019.8.8 and allows puppetlabs/service module to 2.x support

2.x was about removing support for rhel/centos 5 and puppet 5