### PR TITLE
Make versions match SemVer pattern

### DIFF
--- a/plans/install.pp
+++ b/plans/install.pp
@@ -26,7 +26,7 @@ plan peadm::install (
 
   # Common Configuration
   String                            $console_password,
-  String                            $version                          = '2019.8.8',
+  Peadm::Pe_version                 $version                          = '2019.8.8',
   Optional[Array[String]]           $dns_alt_names                    = undef,
   Optional[String]                  $compiler_pool_address            = undef,
   Optional[String]                  $internal_compiler_a_pool_address = undef,

--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -34,7 +34,7 @@ plan peadm::subplans::install (
 
   # Common Configuration
   String               $console_password,
-  String               $version       = '2019.8.5',
+  Peadm::Pe_version    $version,
   Array[String]        $dns_alt_names = [ ],
   Hash                 $pe_conf_data  = { },
 

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -25,10 +25,10 @@ plan peadm::upgrade (
   Optional[Peadm::SingleTargetSpec] $replica_postgresql_host = undef,
 
   # Common Configuration
-  String           $version,
-  Optional[String] $compiler_pool_address            = undef,
-  Optional[String] $internal_compiler_a_pool_address = undef,
-  Optional[String] $internal_compiler_b_pool_address = undef,
+  Peadm::Pe_version $version,
+  Optional[String]  $compiler_pool_address            = undef,
+  Optional[String]  $internal_compiler_a_pool_address = undef,
+  Optional[String]  $internal_compiler_b_pool_address = undef,
 
   # Other
   Optional[String]      $token_file             = undef,

--- a/spec/plans/subplans/install_spec.rb
+++ b/spec/plans/subplans/install_spec.rb
@@ -37,8 +37,9 @@ describe 'peadm::subplans::install' do
     ##########
 
     params = {
-      'primary_host' => 'primary',
+      'primary_host'     => 'primary',
       'console_password' => 'puppetlabs',
+      'version'          => '2019.8.10',
     }
 
     expect(run_plan('peadm::subplans::install', params)).to be_ok

--- a/types/pe_version.pp
+++ b/types/pe_version.pp
@@ -1,0 +1,1 @@
+type Peadm::Pe_version = Pattern[/^\d+\.\d+\.\d+(-.+)?$/]


### PR DESCRIPTION
All PE version downloads need to match the x.y.z format. This commit
changes the type specifier to require this format.

This is especially useful to help guide people to the right parameters
if they specify a version like "2022.4" instead of "2022.4.0".