### PR TITLE
Only require primary host param for backup

### DIFF
--- a/plans/backup.pp
+++ b/plans/backup.pp
@@ -3,31 +3,31 @@
 # This plan can backup data as outlined at insert doc 
 # 
 plan peadm::backup (
-  # Standard
-  Peadm::SingleTargetSpec           $primary_host,
-  Optional[Peadm::SingleTargetSpec] $replica_host            = undef,
-
-  # Large
-  Optional[TargetSpec]              $compiler_hosts          = undef,
-
-  # Extra Large
-  Optional[Peadm::SingleTargetSpec] $primary_postgresql_host = undef,
-  Optional[Peadm::SingleTargetSpec] $replica_postgresql_host = undef,
+  Peadm::SingleTargetSpec $primary_host,
 
   # Which data to backup
-  Boolean                            $backup_orchestrator    = true,
-  Boolean                            $backup_rbac            = true,
-  Boolean                            $backup_activity        = true,
-  Boolean                            $backup_ca_ssl          = true,
-  Boolean                            $backup_puppetdb        = false,
-  Boolean                            $backup_classification  = true,
-  String                             $output_directory       = '/tmp',
-){
+  Boolean                 $backup_orchestrator    = true,
+  Boolean                 $backup_rbac            = true,
+  Boolean                 $backup_activity        = true,
+  Boolean                 $backup_ca_ssl          = true,
+  Boolean                 $backup_puppetdb        = false,
+  Boolean                 $backup_classification  = true,
+  String                  $output_directory       = '/tmp',
+) {
+  peadm::assert_supported_bolt_version()
+  $cluster = run_task('peadm::get_peadm_config', $primary_host).first
+  $arch = peadm::assert_supported_architecture(
+    $primary_host,
+    $cluster['replica_host'],
+    $cluster['primary_postgresql_host'],
+    $cluster['replica_postgresql_host'],
+    $cluster['compiler_hosts'],
+  )
 
   $timestamp = Timestamp.new().strftime('%F_%T')
   $backup_directory = "${output_directory}/pe-backup-${timestamp}"
+
   # Create backup folder
-  apply_prep($primary_host)
   apply($primary_host){
     file { $backup_directory :
       ensure => 'directory',
@@ -36,20 +36,10 @@ plan peadm::backup (
       mode   => '0770'
     }
   }
+
   # Create an array of the names of databases and whether they have to be backed up to use in a lambda later
   $database_to_backup = [ $backup_orchestrator, $backup_activity, $backup_rbac, $backup_puppetdb]
   $database_names     = [ 'pe-orchestrator' , 'pe-activity' , 'pe-rbac' , 'pe-puppetdb' ]
-
-  peadm::assert_supported_bolt_version()
-
-  # Ensure input valid for a supported architecture
-  $arch = peadm::assert_supported_architecture(
-    $primary_host,
-    $replica_host,
-    $primary_postgresql_host,
-    $replica_postgresql_host,
-    $compiler_hosts,
-  )
 
   if $backup_classification {
     out::message('# Backing up classification')
@@ -77,8 +67,8 @@ plan peadm::backup (
     if $value {
     out::message("# Backing up database ${database_names[$index]}")
       # If the primary postgresql host is set then pe-puppetdb needs to be remotely backed up to primary.
-      if $database_names[$index] == 'pe-puppetdb' and $primary_postgresql_host {
-        run_command("sudo -u pe-puppetdb /opt/puppetlabs/server/bin/pg_dump \"sslmode=verify-ca host=${primary_postgresql_host} sslcert=/etc/puppetlabs/puppetdb/ssl/${primary_host}.cert.pem sslkey=/etc/puppetlabs/puppetdb/ssl/${primary_host}.private_key.pem sslrootcert=/etc/puppetlabs/puppet/ssl/certs/ca.pem dbname=pe-puppetdb\" -f /tmp/puppetdb_$(date +%F_%T).bin" , $primary_host) # lint:ignore:140chars
+      if $database_names[$index] == 'pe-puppetdb' and $cluster['primary_postgresql_host'] {
+        run_command("sudo -u pe-puppetdb /opt/puppetlabs/server/bin/pg_dump \"sslmode=verify-ca host=${cluster['primary_postgresql_host']} sslcert=/etc/puppetlabs/puppetdb/ssl/${primary_host}.cert.pem sslkey=/etc/puppetlabs/puppetdb/ssl/${primary_host}.private_key.pem sslrootcert=/etc/puppetlabs/puppet/ssl/certs/ca.pem dbname=pe-puppetdb\" -f /tmp/puppetdb_$(date +%F_%T).bin" , $primary_host) # lint:ignore:140chars
       } else {
         run_command("sudo -u pe-postgres /opt/puppetlabs/server/bin/pg_dump -Fc \"${database_names[$index]}\" -f \"${backup_directory}/${database_names[$index]}_$(date +%F_%T).bin\"" , $primary_host) # lint:ignore:140chars
       }

--- a/spec/plans/backup_spec.rb
+++ b/spec/plans/backup_spec.rb
@@ -5,8 +5,8 @@ describe 'peadm::backup' do
   let(:params) { { 'primary_host' => 'primary' } }
 
   it 'runs with default params' do
-    allow_apply_prep
     allow_apply
+    expect_task('peadm::get_peadm_config').always_return({ 'primary_postgresql_host' => 'postgres' })
     expect_out_message.with_params('# Backing up ca and ssl certificates')
     # The commands all have a timestamp in them and frankly its prooved to hard with bolt spec to work this out
     allow_any_command


### PR DESCRIPTION
The rest can be auto-determined.

Also move all validation code as high up as possible, to enable maximum fail-fast semantics.