### PR TITLE
Allow compilers and replicas to merge csr_attributes.

### DIFF
--- a/plans/add_compiler.pp
+++ b/plans/add_compiler.pp
@@ -47,13 +47,19 @@ plan peadm::add_compiler(
     default => ["main:dns_alt_names=${dns_alt_names}"],
   }
 
+  # Check for and merge csr_attributes.
+  run_plan('peadm::util::insert_csr_extension_requests', $compiler_target,
+      extension_requests => {
+        peadm::oid('pp_auth_role')             => 'pe_compiler',
+        peadm::oid('peadm_availability_group') => $avail_group_letter
+      }
+    )
+
   # we first assume that there is no agent installed on the node. If there is, nothing will happen.
   run_task('peadm::agent_install', $compiler_target,
     server        => $primary_target.peadm::certname(),
     install_flags => $dns_alt_names_flag + [
       '--puppet-service-ensure', 'stopped',
-      "extension_requests:${peadm::oid('pp_auth_role')}=pe_compiler",
-      "extension_requests:${peadm::oid('peadm_availability_group')}=${avail_group_letter}",
       "main:certname=${compiler_target.peadm::certname()}",
     ],
   )

--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -324,23 +324,28 @@ plan peadm::subplans::install (
     ]
 
     $role_and_group =
-      if ($target in $compiler_a_targets) {[
-        "extension_requests:${peadm::oid('pp_auth_role')}=pe_compiler",
-        "extension_requests:${peadm::oid('peadm_availability_group')}=A",
-      ]}
-      elsif ($target in $compiler_b_targets) {[
-        "extension_requests:${peadm::oid('pp_auth_role')}=pe_compiler",
-        "extension_requests:${peadm::oid('peadm_availability_group')}=B",
-      ]}
-      elsif ($target in $replica_target) {[
-        "extension_requests:${peadm::oid('peadm_role')}=puppet/server",
-        "extension_requests:${peadm::oid('peadm_availability_group')}=B",
-      ]}
+      if ($target in $compiler_a_targets) {{
+        peadm::oid('pp_auth_role')             => 'pe_compiler',
+        peadm::oid('peadm_availability_group') => 'A',
+      }}
+      elsif ($target in $compiler_b_targets) {{
+        peadm::oid('pp_auth_role')             => 'pe_compiler',
+        peadm::oid('peadm_availability_group') => 'B',
+      }}
+      elsif ($target in $replica_target) {{
+        peadm::oid('peadm_role')               => 'puppet/server',
+        peadm::oid('peadm_availability_group') => 'B',
+      }}
+
+    # Merge extension requests with csr_attributes.yaml or create it
+    run_plan('peadm::util::insert_csr_extension_requests', $target,
+      extension_requests => $role_and_group
+    )
 
     # Get an agent installed and cert signed
     run_task('peadm::agent_install', $target,
       server        => $primary_target.peadm::certname(),
-      install_flags => $common_install_flags + $role_and_group,
+      install_flags => $common_install_flags,
     )
 
     # Ensure certificate requests have been submitted, then run Puppet

--- a/spec/plans/add_compiler_spec.rb
+++ b/spec/plans/add_compiler_spec.rb
@@ -28,8 +28,6 @@ describe 'peadm::add_compiler' do
         .with_params({ 'server'        => 'primary',
                        'install_flags' => [
                          '--puppet-service-ensure', 'stopped',
-                         'extension_requests:1.3.6.1.4.1.34380.1.3.13=pe_compiler',
-                         'extension_requests:1.3.6.1.4.1.34380.1.1.9813=A',
                          'main:certname=compiler'
                        ] })
 
@@ -53,8 +51,6 @@ describe 'peadm::add_compiler' do
                          'install_flags' => [
                            'main:dns_alt_names=foo,bar',
                            '--puppet-service-ensure', 'stopped',
-                           'extension_requests:1.3.6.1.4.1.34380.1.3.13=pe_compiler',
-                           'extension_requests:1.3.6.1.4.1.34380.1.1.9813=A',
                            'main:certname=compiler'
                          ] })
 

--- a/spec/plans/add_replica_spec.rb
+++ b/spec/plans/add_replica_spec.rb
@@ -20,8 +20,6 @@ describe 'peadm::add_replica' do
         .with_params({ 'server'        => 'primary',
                        'install_flags' => [
                          '--puppet-service-ensure', 'stopped',
-                         'extension_requests:1.3.6.1.4.1.34380.1.1.9812=puppet/server',
-                         'extension_requests:1.3.6.1.4.1.34380.1.1.9813=B',
                          'main:certname=replica',
                          'main:dns_alt_names=replica'
                        ] })
@@ -36,8 +34,6 @@ describe 'peadm::add_replica' do
         .with_params({ 'server'        => 'primary',
                        'install_flags' => [
                          '--puppet-service-ensure', 'stopped',
-                         'extension_requests:1.3.6.1.4.1.34380.1.1.9812=puppet/server',
-                         'extension_requests:1.3.6.1.4.1.34380.1.1.9813=B',
                          'main:certname=replica',
                          'main:dns_alt_names=replica,alt'
                        ] })


### PR DESCRIPTION
This update allows compilers and replica servers being provisioned to respect the contents of an existing csr_attributes.yaml file.