### PR TITLE
Add SLES Support to pre_check task

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -58,6 +58,12 @@
         "18.04",
         "20.04"
       ]
+    },
+    {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "12"
+      ]
     }
   ],
   "requirements": [

--- a/tasks/precheck.sh
+++ b/tasks/precheck.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
 
 hostname=$(hostname -f)
-osfamily=$(cat /etc/os-release | grep -qi ubuntu && echo "ubuntu" || echo "el")
 version=$(grep VERSION_ID /etc/os-release | cut -d '"' -f 2)
 arch=$(uname -m)
+if grep -qi ubuntu /etc/os-release; then
+  osfamily="ubuntu"
+elif grep -qi sles /etc/os-release; then
+  osfamily="sles"
+else
+  osfamily="el"
+fi
 
 # OS-specific modifications
 [ "$osfamily" = "ubuntu" -a "$arch" = "x86_64" ] && arch="amd64"
-[ "$osfamily" = "el" ] && version=$(echo "$version" | cut -d . -f 1)
+[ "$osfamily" = "el"  ] || [ "$osfamily" = "sles"  ]  && version=$(echo "$version" | cut -d . -f 1)
 
 # Output a JSON result for ease of Task usage in Puppet Task Plans
 cat <<EOS


### PR DESCRIPTION
Prior to this commit when run against a SLES platform, peadm::download would assume the platform was EL based and form a url that was the SLES version number with the EL os family, and ultimately Fail.

This commit adds logic to detect SLES, it leaves EL detection in an "else" catch all, but this is only problematic if the plan is run against an unsupported Primary OS Family, and maintains existing behavior.

this commit is brought to you by "works for me" level testing, in that i have successfully spun up Stadard EL   / sles / and Ubuntu environments with this modification