### PR TITLE
Add read map so puppetdb can start on new compiler

### DIFF
--- a/plans/add_compiler.pp
+++ b/plans/add_compiler.pp
@@ -36,6 +36,10 @@ plan peadm::add_compiler(
       path => '/opt/puppetlabs/server/data/postgresql/11/data/pg_ident.conf',
       line => "pe-puppetdb-pe-puppetdb-migrator-map ${compiler_target.peadm::certname()} pe-puppetdb-migrator",
     }
+    file_line { 'pe-puppetdb-pe-puppetdb-read-map':
+      path => '/opt/puppetlabs/server/data/postgresql/11/data/pg_ident.conf',
+      line => "pe-puppetdb-pe-puppetdb-read-map ${compiler_target.peadm::certname()} pe-puppetdb-read",
+    }
   }
 
   # Reload pe-postgresql.service


### PR DESCRIPTION
This commit adds a file_line resource which will configure a
pe-puppetdb-pe-puppetdb-read-map in pg_ident.conf so that the PuppetDB
instance which is setup on new compilers using the add_compiler plan
will start properly.