### PR TITLE
Fix classification when adding some components

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,6 +3,7 @@ fixtures:
   forge_modules:
     ruby_task_helper: "puppetlabs/ruby_task_helper"
     service: "puppetlabs/service"
+    package: "puppetlabs/package"
   repositories:
     facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
     puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
     "python.linting.pylintEnabled": true,
-    "python.linting.enabled": true
+    "python.linting.enabled": true,
+    "git.ignoreLimitWarning": true
 }

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group :development do
   gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-debugger", '>= 0.18.0',                            require: false
   gem "bolt", '>= 3.17.0',                                       require: false
-  gem "github_changelog_generator",                              require: false
+  gem "github_changelog_generator", '>= 1.16.4',                 require: false
   gem "octokit", '4.21.0',                                       require: false
 end
 group :system_tests do

--- a/documentation/automated_recovery.md
+++ b/documentation/automated_recovery.md
@@ -22,7 +22,7 @@ Procedure:
 
 2. Temporarily set both primary and replica server nodes so that they use the remaining healthy PE-PostgreSQL server
 
-        bolt plan run peadm::util::update_db_setting --target <primary-server-fqdn>,<replica-server-fqdn> primary_postgresql_host=<working-postgres-server-fqdn>
+        bolt plan run peadm::util::update_db_setting --target <primary-server-fqdn>,<replica-server-fqdn> primary_postgresql_host=<working-postgres-server-fqdn> override=true
 
 3. Restart `pe-puppetdb.service` on Puppet server primary and replica
 

--- a/metadata.json
+++ b/metadata.json
@@ -33,6 +33,10 @@
       "version_requirement": ">= 1.3.0 < 3.0.0"
     },
     {
+      "name": "puppetlabs/package",
+      "version_requirement": ">= 2.1.0 < 3.0.0"
+    },
+    {
       "name": "puppetlabs/inifile",
       "version_requirement": ">= 5.2.0 < 6.0.0"
     }

--- a/plans/add_database.pp
+++ b/plans/add_database.pp
@@ -12,6 +12,9 @@ plan peadm::add_database(
 ) {
 
   $primary_target = peadm::get_targets($primary_host, 1)
+  $postgresql_target = peadm::get_targets($targets, 1)
+
+  $postgresql_host = $postgresql_target.peadm::certname()
 
   # Get current peadm config before making modifications and shutting down
   # PuppetDB
@@ -21,13 +24,13 @@ plan peadm::add_database(
 
   # Bail if this is trying to be ran against Standard
   if $compilers.empty {
-    fail_plan('Plan Peadm::Add_database only applicable for L and XL deployments')
+    fail_plan('Plan peadm::add_database is only applicable for L and XL deployments')
   }
 
   # Existing nodes and their assignments
   $replica_host = $peadm_config['params']['replica_host']
-  $primary_postgresql_host = $peadm_config['params']['primary_postgresql_host']
-  $replica_postgresql_host = $peadm_config['params']['replica_postgresql_host']
+  $postgresql_a_host = $peadm_config['role-letter']['postgresql']['A']
+  $postgresql_b_host = $peadm_config['role-letter']['postgresql']['B']
 
   $replica_target = peadm::get_targets($replica_host, 1)
 
@@ -41,8 +44,8 @@ plan peadm::add_database(
   } else {
     # If array is empty then no external databases were previously configured 
     $no_external_db = peadm::flatten_compact([
-      $primary_postgresql_host,
-      $replica_postgresql_host
+      $postgresql_a_host,
+      $postgresql_b_host
     ]).empty
 
     # Pick operating mode based on array check
@@ -67,26 +70,26 @@ plan peadm::add_database(
     # The letter which doesn't yet have a server assigned or in the event this
     # is a replacement operation, the letter this node was assigned to previously
     $avail_group_letter = peadm::flatten_compact($roles['postgresql'].map |$k,$v| {
-      if (! $v) or ($v == $targets.peadm::certname()) {
+      if (! $v) or ($v == $postgresql_host) {
         $k
       }
     })[0]
     # When in pair mode we assume the other PSQL node will serve as our source
     $source_db_host = peadm::flatten_compact([
-      $primary_postgresql_host,
-      $replica_postgresql_host
-    ]).reject($targets.peadm::certname())[0]
+      $postgresql_a_host,
+      $postgresql_b_host
+    ]).reject($postgresql_host)[0]
   }
 
-  out::message("Adding PostgreSQL server ${targets.peadm::certname()} to availability group ${avail_group_letter}")
-  out::message("Using ${source_db_host} to populate ${targets.peadm::certname()}")
+  out::message("Adding PostgreSQL server ${postgresql_host} to availability group ${avail_group_letter}")
+  out::message("Using ${source_db_host} to populate ${postgresql_host}")
 
   $source_db_target = peadm::get_targets($source_db_host, 1)
 
   peadm::plan_step('init-db-node') || {
     # Install PSQL on new node to be used as external PuppetDB backend by using
     # puppet in lieu of installer 
-    run_plan('peadm::subplans::component_install', $targets,
+    run_plan('peadm::subplans::component_install', $postgresql_target,
       primary_host       => $primary_target,
       avail_group_letter => $avail_group_letter,
       role               => 'puppet/puppetdb-database'
@@ -95,7 +98,7 @@ plan peadm::add_database(
 
   # Stop Puppet to ensure catalogs are not being compiled for PE infrastructure nodes
   run_command('systemctl stop puppet.service', peadm::flatten_compact([
-    $targets,
+    $postgresql_target,
     $compilers,
     $primary_target,
     $replica_target,
@@ -108,44 +111,60 @@ plan peadm::add_database(
 
   peadm::plan_step('replicate-db') || {
     # Replicate content from source to newly installed PSQL server
-    run_plan('peadm::subplans::db_populate', $targets, source_host => $source_db_target.peadm::certname())
+    run_plan('peadm::subplans::db_populate', $postgresql_target, source_host => $source_db_target.peadm::certname())
 
     # Run Puppet on new PSQL node to fix up certificates and permissions
-    run_task('peadm::puppet_runonce', $targets)
+    run_task('peadm::puppet_runonce', $postgresql_target)
   }
 
-  if $operating_mode == 'init' {
+  # Update classification and database.ini settings, assume a replica PSQL
+  # does not exist
+  peadm::plan_step('update-classification') || {
 
-    # Update classification and database.ini settings, assume a replica PSQL
-    # does not exist
-    peadm::plan_step('update-classification') || {
+    # To ensure everything is functional when a replica exists but only a single
+    # PostgreSQL node has been deployed, configure alternate availability group
+    # to connect to other group's new node
+    if ($operating_mode == 'init' and $replica_host) {
+      $a_host = $avail_group_letter ? { 'A' => $postgresql_host, default => undef }
+      $b_host = $avail_group_letter ? { 'B' => $postgresql_host, default => undef }
+      $host = pick($a_host, $b_host)
+      out::verbose("In transitive state, setting classification to ${host}")
       run_plan('peadm::util::update_classification', $primary_target,
-        primary_postgresql_host => pick($primary_postgresql_host, $targets),
-        peadm_config            => $peadm_config
+        postgresql_a_host => $host,
+        postgresql_b_host => $host,
+        peadm_config      => $peadm_config
+      )
+    } else {
+      run_plan('peadm::util::update_classification', $primary_target,
+        postgresql_a_host => $avail_group_letter ? { 'A' => $postgresql_host, default => undef },
+        postgresql_b_host => $avail_group_letter ? { 'B' => $postgresql_host, default => undef },
+        peadm_config      => $peadm_config
       )
     }
+  }
 
-    peadm::plan_step('update-db-settings') || {
-      run_plan('peadm::util::update_db_setting', peadm::flatten_compact([
-        $compilers,
-        $primary_target,
-        $replica_target
-      ]),
-        primary_postgresql_host => $targets,
-        peadm_config            => $peadm_config
-      )
+  peadm::plan_step('update-db-settings') || {
+    run_plan('peadm::util::update_db_setting', peadm::flatten_compact([
+      $compilers,
+      $primary_target,
+      $replica_target
+    ]),
+      postgresql_host => $postgresql_host,
+      peadm_config    => $peadm_config
+    )
 
-      # (Re-)Start PuppetDB now that we are done making modifications
-      run_command('systemctl restart pe-puppetdb.service', peadm::flatten_compact([
-        $primary_target,
-        $replica_target
-      ]))
-    }
+    # (Re-)Start PuppetDB now that we are done making modifications
+    run_command('systemctl restart pe-puppetdb.service', peadm::flatten_compact([
+      $primary_target,
+      $replica_target
+    ]))
+  }
 
-    # Clean up old puppetdb database on primary and those which were copied to
-    # new host.
-    peadm::plan_step('cleanup-db') || {
+  peadm::plan_step('cleanup-db') || {
 
+    if $operating_mode == 'init' {
+      # Clean up old puppetdb database on primary and those which were copied to
+      # new host.
       $target_db_purge = [
         'pe-activity',
         'pe-classifier',
@@ -157,7 +176,7 @@ plan peadm::add_database(
       # If a primary replica exists then pglogical is enabled and will prevent
       # the clean up of databases on our target because it opens a connection. 
       if $replica_host {
-        run_plan('peadm::util::db_disable_pglogical', $targets, databases => $target_db_purge)
+        run_plan('peadm::util::db_disable_pglogical', $postgresql_target, databases => $target_db_purge)
       }
 
       # Clean up old databases
@@ -167,39 +186,9 @@ plan peadm::add_database(
         $replica_target
       ])
 
-      run_plan('peadm::util::db_purge', $clean_source, databases => ['pe-puppetdb'])
-      run_plan('peadm::util::db_purge', $targets,      databases => $target_db_purge)
-    }
-  } else {
-    peadm::plan_step('update-classification') || {
-      run_plan('peadm::util::update_classification', $primary_target,
-        primary_postgresql_host => pick($primary_postgresql_host, $targets),
-        replica_postgresql_host => pick($replica_postgresql_host, $targets),
-        peadm_config            => $peadm_config
-      )
-    }
-
-    # Plan needs to know which node is being added as well as primary and
-    # replica designation
-    peadm::plan_step('update-db-settings') || {
-      run_plan('peadm::util::update_db_setting', peadm::flatten_compact([
-        $compilers,
-        $primary_target,
-        $replica_target
-      ]),
-        new_postgresql_host     => $targets,
-        primary_postgresql_host => pick($primary_postgresql_host, $targets),
-        replica_postgresql_host => pick($replica_postgresql_host, $targets),
-        peadm_config            => $peadm_config
-      )
-
-      # (Re-)Start PuppetDB now that we are done making modifications
-      run_command('systemctl restart pe-puppetdb.service', peadm::flatten_compact([
-        $primary_target,
-        $replica_target
-      ]))
-    }
-    peadm::plan_step('cleanup-db') || {
+      run_plan('peadm::util::db_purge', $clean_source,      databases => ['pe-puppetdb'])
+      run_plan('peadm::util::db_purge', $postgresql_target, databases => $target_db_purge)
+    } else {
       out::message("No databases to cleanup when in ${operating_mode}")
     }
   }
@@ -212,7 +201,7 @@ plan peadm::add_database(
   peadm::plan_step('finalize') || {
     # Run Puppet to sweep up but no restarts should occur so do them in parallel
     run_task('peadm::puppet_runonce', peadm::flatten_compact([
-      $targets,
+      $postgresql_target,
       $primary_target,
       $compilers,
       $replica_target
@@ -220,7 +209,7 @@ plan peadm::add_database(
 
     # Start Puppet agent
     run_command('systemctl start puppet.service', peadm::flatten_compact([
-      $targets,
+      $postgresql_target,
       $compilers,
       $primary_target,
       $replica_target,

--- a/plans/add_replica.pp
+++ b/plans/add_replica.pp
@@ -73,8 +73,10 @@ plan peadm::add_replica(
   }
 
   run_plan('peadm::util::update_classification', $primary_target,
-    replica_host                     => $replica_host,
-    internal_compiler_b_pool_address => $replica_host,
+    server_a_host                    => $replica_avail_group_letter ? { 'A' => $replica_host, default => undef },
+    server_b_host                    => $replica_avail_group_letter ? { 'B' => $replica_host, default => undef },
+    internal_compiler_a_pool_address => $replica_avail_group_letter ? { 'A' => $replica_host, default => undef },
+    internal_compiler_b_pool_address => $replica_avail_group_letter ? { 'B' => $replica_host, default => undef }
   )
 
   # Provision the new system as a replica

--- a/plans/add_replica.pp
+++ b/plans/add_replica.pp
@@ -79,6 +79,12 @@ plan peadm::add_replica(
     internal_compiler_b_pool_address => $replica_avail_group_letter ? { 'B' => $replica_host, default => undef }
   )
 
+  # Source the global hiera.yaml from Primary and synchronize to new Replica 
+  # Provision the new system as a replica
+  run_plan('peadm::util::sync_global_hiera', $replica_target,
+    primary_host => $primary_target
+  )
+
   # Provision the new system as a replica
   run_task('peadm::provision_replica', $primary_target,
     replica    => $replica_target.peadm::certname(),

--- a/plans/add_replica.pp
+++ b/plans/add_replica.pp
@@ -35,7 +35,7 @@ plan peadm::add_replica(
   $dns_alt_names = [$replica_target.peadm::certname()] + (pick($certdata['dns-alt-names'], []) - $certdata['certname'])
 
   # This has the effect of revoking the node's certificate, if it exists
-  run_command("puppet infrastructure forget ${replica_target.peadm::certname()}", $primary_target, _catch_errors => true)
+  run_command("/opt/puppetlabs/bin/puppet infrastructure forget ${replica_target.peadm::certname()}", $primary_target, _catch_errors => true)
 
   run_plan('peadm::subplans::component_install', $replica_target,
     primary_host       => $primary_target,

--- a/plans/subplans/component_install.pp
+++ b/plans/subplans/component_install.pp
@@ -7,18 +7,18 @@
 # @param dns_alt_names _ A comma_separated list of DNS alt names for the component
 # @param role _ Optional PEADM role the component will serve
 plan peadm::subplans::component_install(
-  Peadm::SingleTargetSpec $targets,
-  Peadm::SingleTargetSpec $primary_host,
-  Enum['A', 'B']          $avail_group_letter,
-  Optional[String[1]]     $dns_alt_names = undef,
-  Optional[String[1]]     $role          = undef
+  Peadm::SingleTargetSpec                $targets,
+  Peadm::SingleTargetSpec                $primary_host,
+  Enum['A', 'B']                         $avail_group_letter,
+  Optional[Variant[String[1], Array]] $dns_alt_names = undef,
+  Optional[String[1]]                    $role          = undef
 ){
   $component_target          = peadm::get_targets($targets, 1)
   $primary_target            = peadm::get_targets($primary_host, 1)
 
   run_plan('peadm::subplans::prepare_agent', $component_target,
     primary_host           => $primary_target,
-    dns_alt_name           => $dns_alt_names,
+    dns_alt_names          => peadm::flatten_compact([$dns_alt_names]),
     certificate_extensions => {
       peadm::oid('peadm_role')               => $role,
       peadm::oid('peadm_availability_group') => $avail_group_letter,

--- a/plans/subplans/modify_certificate.pp
+++ b/plans/subplans/modify_certificate.pp
@@ -21,8 +21,6 @@ plan peadm::subplans::modify_certificate (
   $certdata = run_task('peadm::cert_data', $target).first.value
   $certname = $certdata['certname']
 
-
-
   $target_is_primary = ($certname == $primary_certname)
 
   # These vars represent what the extensions currently are, vs. what they should be
@@ -68,13 +66,13 @@ plan peadm::subplans::modify_certificate (
     # fail the plan unless it's a known circumstance in which it's okay to proceed.
     # Scenario 1: the primary's cert can't be cleaned because it's already revoked.
     # Scenario 2: the primary's cert can't be cleaned because it's been deleted.
-    # Scenario 3: a component's cert can't be cleaned because it was previously by some other function.
+    # Scenario 3: any component's cert can't be cleaned because it's been deleted.
     unless ($target_is_primary and
             ($ca_clean_result[merged_output] =~ /certificate revoked/ or
-              $ca_clean_result[merged_output] =~ /Could not find 'hostcert'/ or
-                $ca_clean_result[merged_output] =~ /Could not find files to clean/))
+              $ca_clean_result[merged_output] =~ /Could not find 'hostcert'/)) or
+                ($ca_clean_result[merged_output] =~ /Could not find files to clean/)
     {
-      fail_plan($ca_clean_result)
+      fail_plan($ca_clean_result[merged_output])
     }
   }
 

--- a/plans/subplans/modify_certificate.pp
+++ b/plans/subplans/modify_certificate.pp
@@ -34,6 +34,7 @@ plan peadm::subplans::modify_certificate (
       ($desired_alt_names == $existing_alt_names) and
       ($desired_exts.all |$key,$val| { $existing_exts[$key] == $val }) and
       !($remove_extensions.any |$key| { $key in $existing_exts.keys }) and
+      !$certdata['certificate-revoked'] and
       !$force_regenerate)
   {
     out::message("${certname} already has requested modifications; certificate will not be re-issued")

--- a/plans/subplans/prepare_agent.pp
+++ b/plans/subplans/prepare_agent.pp
@@ -29,6 +29,11 @@ plan peadm::subplans::prepare_agent (
         "main:certname=${agent_target.peadm::certname()}",
       ],
     )
+  } else {
+    run_command('systemctl stop puppet.service', $agent_target)
+    out::message('Ensuring node is set to query current primary for Puppet Agent operations')
+    run_command("/opt/puppetlabs/bin/puppet config set --section main server ${primary_target.peadm::certname()}", $agent_target)
+    run_command('/opt/puppetlabs/bin/puppet config delete --section agent server_list', $agent_target)
   }
 
   # Ensures scenarios where agent was pre-installed but never on-boarding and

--- a/plans/subplans/prepare_agent.pp
+++ b/plans/subplans/prepare_agent.pp
@@ -31,6 +31,10 @@ plan peadm::subplans::prepare_agent (
     )
   } else {
     run_command('systemctl stop puppet.service', $agent_target)
+    # If re-using a node which was previously part of the infrastructure then it
+    # might have a bad configuration which will prevent it from reconfiguring. Best
+    # example of this is a failed primary being added back into infrastructure  as
+    # a replica
     out::message('Ensuring node is set to query current primary for Puppet Agent operations')
     run_command("/opt/puppetlabs/bin/puppet config set --section main server ${primary_target.peadm::certname()}", $agent_target)
     run_command('/opt/puppetlabs/bin/puppet config delete --section agent server_list', $agent_target)
@@ -43,10 +47,17 @@ plan peadm::subplans::prepare_agent (
   # Obtain data about certificate from agent
   $certdata = run_task('peadm::cert_data', $agent_target).first.value
 
+  # The invalid status is primarily serves as a way to catch revoked certificates.
+  # A primary server is the only thing that can reliably identify if agent
+  # certificates are revoked, if it is then skip the submit and sign process and
+  # just got directly to forcing a regeneration.
   if ($certstatus['certificate-status'] == 'invalid') {
     $force_regenerate = true
     $skip_csr = true
   } else {
+    # When the primary can't validate a certificate because it is missing but the
+    # agent claims it has one, clean the agent to get to an agreed upon state
+    # before moving onto the submit and sign process.
     if $certdata['certificate-exists'] and $certstatus['reason'] =~ /The private key is missing from/ {
       out::message("Agent: ${agent_target.peadm::certname()} has a local cert but Primary: ${primary_target.peadm::certname()} does not, force agent clean")
       run_task('peadm::ssl_clean', $agent_target, certname => $agent_target.peadm::certname())
@@ -68,6 +79,8 @@ plan peadm::subplans::prepare_agent (
     run_task('peadm::sign_csr', $primary_target, { 'certnames' => [$agent_target.peadm::certname()] } )
   }
 
+  # If agent certificate is good but lacks appropriate extensions, plan will still
+  # regenerate certificate
   run_plan('peadm::modify_certificate', $agent_target,
     primary_host     => $primary_target.peadm::certname(),
     add_extensions   => $certificate_extensions,

--- a/plans/subplans/prepare_agent.pp
+++ b/plans/subplans/prepare_agent.pp
@@ -11,7 +11,7 @@ plan peadm::subplans::prepare_agent (
 
   $dns_alt_names_flag = $dns_alt_names? {
     undef   => [],
-    default => ["main:dns_alt_names=${dns_alt_names}"],
+    default => ["main:dns_alt_names=${dns_alt_names.join(',')}"],
   }
 
   $status = run_task('package', $agent_target,

--- a/plans/util/sync_global_hiera.pp
+++ b/plans/util/sync_global_hiera.pp
@@ -1,0 +1,22 @@
+# @api private
+plan peadm::util::sync_global_hiera (
+  Peadm::SingleTargetSpec $targets,
+  Peadm::SingleTargetSpec $primary_host,
+) {
+
+  $primary_target             = peadm::get_targets($primary_host, 1)
+  $replica_target             = $targets
+
+  # Source the global hiera.yaml from Primary and synchronize to new Replica 
+  $global_hiera_yaml = run_task('peadm::read_file', $primary_target,
+    path => '/etc/puppetlabs/puppet/hiera.yaml',
+  ).first['content']
+
+  run_task('peadm::mkdir_p_file', $replica_target,
+    path    => '/etc/puppetlabs/puppet/hiera.yaml',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => $global_hiera_yaml,
+  )
+}

--- a/plans/util/update_classification.pp
+++ b/plans/util/update_classification.pp
@@ -31,17 +31,6 @@ plan peadm::util::update_classification (
   out::verbose('Current config is...')
   out::verbose($current)
 
-  # When a replica in configured, the B side of the deployment requires that
-  # replica_postgresql_host to be set, if it is not then PuppetDB will be left
-  # non-functional. Doing this will allow both sides of the deployment to start
-  # up and be functional until the second PostgreSQL node can be provisioned and configured.
-#  if (! $replica_postgresql_target.peadm::certname()) and $current['replica_host'] {
-#    out::message('Overriding replica_postgresql_host while in transitive state')
-#    $overridden_replica_postgresql_target = $primary_postgresql_target
-#  } else {
-#    $overridden_replica_postgresql_target = $replica_postgresql_target
-#  }
-
   $filtered_params = {
     'compiler_pool_address'            => $compiler_pool_address,
     'internal_compiler_a_pool_address' => $internal_compiler_a_pool_address,

--- a/plans/util/update_classification.pp
+++ b/plans/util/update_classification.pp
@@ -6,11 +6,12 @@ plan peadm::util::update_classification (
   # Standard
   Peadm::SingleTargetSpec           $targets,
   Optional[Hash]                    $peadm_config = undef,
-  Optional[Peadm::SingleTargetSpec] $replica_host = undef,
+  Optional[Peadm::SingleTargetSpec] $server_a_host = undef,
+  Optional[Peadm::SingleTargetSpec] $server_b_host = undef,
 
   # Extra Large
-  Optional[Peadm::SingleTargetSpec] $primary_postgresql_host = undef,
-  Optional[Peadm::SingleTargetSpec] $replica_postgresql_host = undef,
+  Optional[Peadm::SingleTargetSpec] $postgresql_a_host = undef,
+  Optional[Peadm::SingleTargetSpec] $postgresql_b_host = undef,
 
   # Common Configuration
   Optional[String] $compiler_pool_address = undef,
@@ -18,44 +19,60 @@ plan peadm::util::update_classification (
   Optional[String] $internal_compiler_b_pool_address = undef,
 ) {
 
-  # Convert inputs into targets.
-  $primary_target                   = peadm::get_targets($targets, 1)
-  $replica_target                   = peadm::get_targets($replica_host, 1)
-  $primary_postgresql_target        = peadm::get_targets($primary_postgresql_host, 1)
-  $replica_postgresql_target        = peadm::get_targets($replica_postgresql_host, 1)
+  $primary_target = peadm::get_targets($targets, 1)
 
   # Makes this more easily usable outside a plan
   if $peadm_config {
-    $current = $peadm_config['params']
+    $current = $peadm_config
   } else {
-    $current = run_task('peadm::get_peadm_config', $primary_target).first.value['params']
+    $current = run_task('peadm::get_peadm_config', $primary_target).first.value
   }
+
+  out::verbose('Current config is...')
+  out::verbose($current)
 
   # When a replica in configured, the B side of the deployment requires that
   # replica_postgresql_host to be set, if it is not then PuppetDB will be left
   # non-functional. Doing this will allow both sides of the deployment to start
   # up and be functional until the second PostgreSQL node can be provisioned and configured.
-  if (! $replica_postgresql_target.peadm::certname()) and $current['replica_host'] {
-    out::message('Overriding replica_postgresql_host while in transitive state')
-    $overridden_replica_postgresql_target = $primary_postgresql_target
-  } else {
-    $overridden_replica_postgresql_target = $replica_postgresql_target
-  }
+#  if (! $replica_postgresql_target.peadm::certname()) and $current['replica_host'] {
+#    out::message('Overriding replica_postgresql_host while in transitive state')
+#    $overridden_replica_postgresql_target = $primary_postgresql_target
+#  } else {
+#    $overridden_replica_postgresql_target = $replica_postgresql_target
+#  }
 
-  $filtered = {
-    'primary_host' => $primary_target.peadm::certname(),
-    'replica_host' => $replica_target.peadm::certname(),
-    'primary_postgresql_host' => $primary_postgresql_target.peadm::certname(),
-    'replica_postgresql_host' => $overridden_replica_postgresql_target.peadm::certname(),
-    'compiler_pool_address' => $compiler_pool_address,
+  $filtered_params = {
+    'compiler_pool_address'            => $compiler_pool_address,
     'internal_compiler_a_pool_address' => $internal_compiler_a_pool_address,
     'internal_compiler_b_pool_address' => $internal_compiler_b_pool_address
   }.filter |$parameter| { $parameter[1] }
 
-  $new = merge($current, $filtered)
+  $filtered_server = {
+    'A' => $server_a_host,
+    'B' => $server_b_host
+  }.filter |$parameter| { $parameter[1] }
 
-  out::message('Classification to be updated using the following hash...')
-  out::message($new)
+  $filtered_psql = {
+    'A' => $postgresql_a_host,
+    'B' => $postgresql_b_host
+  }.filter |$parameter| { $parameter[1] }
+
+  $filtered = {
+    'params'      => $filtered_params,
+    'role-letter' => {
+      'server'     => $filtered_server,
+      'postgresql' => $filtered_psql
+    }
+  }
+
+  out::verbose('New values are...')
+  out::verbose($filtered)
+
+  $new = deep_merge($current, $filtered)
+
+  out::verbose('Updating classification to...')
+  out::verbose($new)
 
   apply($primary_target) {
     class { 'peadm::setup::node_manager_yaml':
@@ -63,14 +80,14 @@ plan peadm::util::update_classification (
     }
 
     class { 'peadm::setup::node_manager':
-      primary_host                     => $new['primary_host'],
-      server_a_host                    => $new['primary_host'],
-      server_b_host                    => $new['replica_host'],
-      postgresql_a_host                => $new['primary_postgresql_host'],
-      postgresql_b_host                => $new['replica_postgresql_host'],
-      compiler_pool_address            => $new['compiler_pool_address'],
-      internal_compiler_a_pool_address => $new['internal_compiler_a_pool_address'],
-      internal_compiler_b_pool_address => $new['internal_compiler_b_pool_address'],
+      primary_host                     => $primary_target.peadm::certname(),
+      server_a_host                    => $new['role-letter']['server']['A'],
+      server_b_host                    => $new['role-letter']['server']['B'],
+      postgresql_a_host                => $new['role-letter']['postgresql']['A'],
+      postgresql_b_host                => $new['role-letter']['postgresql']['B'],
+      compiler_pool_address            => $new['params']['compiler_pool_address'],
+      internal_compiler_a_pool_address => $new['params']['internal_compiler_a_pool_address'],
+      internal_compiler_b_pool_address => $new['params']['internal_compiler_b_pool_address'],
       require                          => Class['peadm::setup::node_manager_yaml'],
     }
   }

--- a/plans/util/update_db_setting.pp
+++ b/plans/util/update_db_setting.pp
@@ -4,54 +4,35 @@
 #
 plan peadm::util::update_db_setting (
   TargetSpec                        $targets,
-  Optional[Peadm::SingleTargetSpec] $new_postgresql_host     = undef,
-  Optional[Peadm::SingleTargetSpec] $primary_postgresql_host = undef,
-  Optional[Peadm::SingleTargetSpec] $replica_postgresql_host = undef,
-  Optional[Hash]                    $peadm_config            = undef,
+  Optional[Peadm::SingleTargetSpec] $postgresql_host = undef,
+  Optional[Hash]                    $peadm_config    = undef,
 ) {
 
-  # Convert inputs into targets.
-  $primary_postgresql_target = peadm::get_targets($primary_postgresql_host, 1)
-  $replica_postgresql_target = peadm::get_targets($replica_postgresql_host, 1)
-
-  # Originally written to handle some additional logic which was eventually
-  # determined to not be useful and was pulled out. As a result could use
-  # more additional simplification. The goal is to match each infrastructure
-  # component to the PostgreSQL nodes which corresponds to their availability
-  # letter and if a match is not found, assume that new node is the match.
-  #
-  # FIX ME: Test removal of $primary_potsgresql_host and $replica_postgresql_host 
-  # parameter check. Likely only parameter needed is the node be added. Section
-  # also needs to be parallelized, can't use built functionality of apply().
+  # FIX ME: Section needs to be parallelized, can't use built in functionality
+  # of apply().
   get_targets($targets).each |$target| {
 
-    # Availability group does not matter if only one PSQL node in the cluster
-    if ($primary_postgresql_host and $replica_postgresql_host) {
+    # Existing config used to dynamically pair nodes with appropriate PSQL
+    # server
+    $roles = $peadm_config['role-letter']
 
-      # Existing config used to dynamically pair nodes with appropriate PSQL
-      # server
-      $roles = $peadm_config['role-letter']
-
-      # Determine configuration by pairing target with existing availability letter
-      # assignments, setting to the new node if no match is found.
-      $target_group_letter = peadm::flatten_compact([$roles['compilers'],$roles['server']].map |$role| {
-        $role.map |$k,$v| {
-          if $target.peadm::certname() in $v { $k }
-        }
-      })[0]
-      $match = $roles['postgresql'][$target_group_letter]
-      if $match {
-        $db = $match
-      } else {
-        $db = $new_postgresql_host
+    # Determine configuration by pairing target with existing availability letter
+    # assignments, setting to the new node if no match is found.
+    $target_group_letter = peadm::flatten_compact([$roles['compilers'],$roles['server']].map |$role| {
+      $role.map |$k,$v| {
+        if $target.peadm::certname() in $v { $k }
       }
-
-      $db_setting = "//${db}:5432/pe-puppetdb?ssl=true&sslfactory=org.postgresql.ssl.jdbc4.LibPQFactory&sslmode=verify-full&sslrootcert=/etc/puppetlabs/puppet/ssl/certs/ca.pem&sslkey=/etc/puppetlabs/puppetdb/ssl/${target.peadm::certname()}.private_key.pk8&sslcert=/etc/puppetlabs/puppetdb/ssl/${$target.peadm::certname()}.cert.pem"
+    })[0]
+    $match = $roles['postgresql'][$target_group_letter]
+    if $match {
+      $db = $match
     } else {
-      $db_setting = "//${primary_postgresql_host}:5432/pe-puppetdb?ssl=true&sslfactory=org.postgresql.ssl.jdbc4.LibPQFactory&sslmode=verify-full&sslrootcert=/etc/puppetlabs/puppet/ssl/certs/ca.pem&sslkey=/etc/puppetlabs/puppetdb/ssl/${target.peadm::certname()}.private_key.pk8&sslcert=/etc/puppetlabs/puppetdb/ssl/${$target.peadm::certname()}.cert.pem"
+      $db = $postgresql_host
     }
 
-    # Introduced new dependency for PEADM to enable modification of INI files
+    $db_setting = "//${db}:5432/pe-puppetdb?ssl=true&sslfactory=org.postgresql.ssl.jdbc4.LibPQFactory&sslmode=verify-full&sslrootcert=/etc/puppetlabs/puppet/ssl/certs/ca.pem&sslkey=/etc/puppetlabs/puppetdb/ssl/${target.peadm::certname()}.private_key.pk8&sslcert=/etc/puppetlabs/puppetdb/ssl/${$target.peadm::certname()}.cert.pem"
+
+    # Introduces dependency so PEADM can modify INI files
     apply($target) {
       ini_setting { 'database_setting':
         ensure  => present,

--- a/plans/util/update_db_setting.pp
+++ b/plans/util/update_db_setting.pp
@@ -6,28 +6,33 @@ plan peadm::util::update_db_setting (
   TargetSpec                        $targets,
   Optional[Peadm::SingleTargetSpec] $postgresql_host = undef,
   Optional[Hash]                    $peadm_config    = undef,
+  Boolean                           $override        = false
 ) {
 
   # FIX ME: Section needs to be parallelized, can't use built in functionality
   # of apply().
   get_targets($targets).each |$target| {
 
-    # Existing config used to dynamically pair nodes with appropriate PSQL
-    # server
-    $roles = $peadm_config['role-letter']
-
-    # Determine configuration by pairing target with existing availability letter
-    # assignments, setting to the new node if no match is found.
-    $target_group_letter = peadm::flatten_compact([$roles['compilers'],$roles['server']].map |$role| {
-      $role.map |$k,$v| {
-        if $target.peadm::certname() in $v { $k }
-      }
-    })[0]
-    $match = $roles['postgresql'][$target_group_letter]
-    if $match {
-      $db = $match
-    } else {
+    if $override {
       $db = $postgresql_host
+    } else {
+      # Existing config used to dynamically pair nodes with appropriate PSQL
+      # server
+      $roles = $peadm_config['role-letter']
+
+      # Determine configuration by pairing target with existing availability letter
+      # assignments, setting to the new node if no match is found.
+      $target_group_letter = peadm::flatten_compact([$roles['compilers'],$roles['server']].map |$role| {
+        $role.map |$k,$v| {
+          if $target.peadm::certname() in $v { $k }
+        }
+      })[0]
+      $match = $roles['postgresql'][$target_group_letter]
+      if $match {
+        $db = $match
+      } else {
+        $db = $postgresql_host
+      }
     }
 
     $db_setting = "//${db}:5432/pe-puppetdb?ssl=true&sslfactory=org.postgresql.ssl.jdbc4.LibPQFactory&sslmode=verify-full&sslrootcert=/etc/puppetlabs/puppet/ssl/certs/ca.pem&sslkey=/etc/puppetlabs/puppetdb/ssl/${target.peadm::certname()}.private_key.pk8&sslcert=/etc/puppetlabs/puppetdb/ssl/${$target.peadm::certname()}.cert.pem"

--- a/spec/plans/add_replica_spec.rb
+++ b/spec/plans/add_replica_spec.rb
@@ -11,17 +11,21 @@ describe 'peadm::add_replica' do
 
   describe 'basic functionality' do
     let(:params) { { 'primary_host' => 'primary', 'replica_host' => 'replica' } }
-    let(:certdata) { {
-      'certificate-exists' => true,
-      'certname'           => 'primary',
-      'extensions'         => { '1.3.6.1.4.1.34380.1.1.9813' => 'A' },
-      'dns-alt-names'      => []
-    } }
-    let(:certstatus) { {
-      'certificate-status' => 'valid',
-      'reason'             => 'Expires - 2099-01-01 00:00:00 UTC'
-    } }
     let(:cfg) { { 'params' => { 'primary_host' => 'primary' } } }
+    let(:certdata) do
+      {
+        'certificate-exists' => true,
+        'certname'           => 'primary',
+        'extensions'         => { '1.3.6.1.4.1.34380.1.1.9813' => 'A' },
+        'dns-alt-names'      => []
+      }
+    end
+    let(:certstatus) do
+      {
+        'certificate-status' => 'valid',
+        'reason'             => 'Expires - 2099-01-01 00:00:00 UTC'
+      }
+    end
 
     it 'runs successfully when the primary does not have alt-names' do
       allow_standard_non_returning_calls

--- a/spec/plans/add_replica_spec.rb
+++ b/spec/plans/add_replica_spec.rb
@@ -17,7 +17,7 @@ describe 'peadm::add_replica' do
     it 'runs successfully when the primary does not have alt-names' do
       allow_standard_non_returning_calls
       expect_task('peadm::get_peadm_config').always_return(cfg)
-      expect_task('peadm::cert_data').always_return(certdata).be_called_times(3)
+      expect_task('peadm::cert_data').always_return(certdata).be_called_times(4)
       expect_task('package').always_return({ 'status' => 'uninstalled' })
       expect_task('peadm::agent_install')
         .with_params({ 'server'        => 'primary',
@@ -35,7 +35,7 @@ describe 'peadm::add_replica' do
     it 'runs successfully when the primary has alt-names' do
       allow_standard_non_returning_calls
       expect_task('peadm::get_peadm_config').always_return(cfg)
-      expect_task('peadm::cert_data').always_return(certdata.merge({ 'dns-alt-names' => ['primary', 'alt'] })).be_called_times(3)
+      expect_task('peadm::cert_data').always_return(certdata.merge({ 'dns-alt-names' => ['primary', 'alt'] })).be_called_times(4)
       expect_task('package').always_return({ 'status' => 'uninstalled' })
       expect_task('peadm::agent_install')
         .with_params({ 'server'        => 'primary',

--- a/spec/plans/add_replica_spec.rb
+++ b/spec/plans/add_replica_spec.rb
@@ -11,13 +11,23 @@ describe 'peadm::add_replica' do
 
   describe 'basic functionality' do
     let(:params) { { 'primary_host' => 'primary', 'replica_host' => 'replica' } }
-    let(:certdata) { { 'certname' => 'primary', 'extensions' => { '1.3.6.1.4.1.34380.1.1.9813' => 'A' }, 'dns-alt-names' => [] } }
+    let(:certdata) { {
+      'certificate-exists' => true,
+      'certname'           => 'primary',
+      'extensions'         => { '1.3.6.1.4.1.34380.1.1.9813' => 'A' },
+      'dns-alt-names'      => []
+    } }
+    let(:certstatus) { {
+      'certificate-status' => 'valid',
+      'reason'             => 'Expires - 2099-01-01 00:00:00 UTC'
+    } }
     let(:cfg) { { 'params' => { 'primary_host' => 'primary' } } }
 
     it 'runs successfully when the primary does not have alt-names' do
       allow_standard_non_returning_calls
       expect_task('peadm::get_peadm_config').always_return(cfg)
       expect_task('peadm::cert_data').always_return(certdata).be_called_times(4)
+      expect_task('peadm::cert_valid_status').always_return(certstatus)
       expect_task('package').always_return({ 'status' => 'uninstalled' })
       expect_task('peadm::agent_install')
         .with_params({ 'server'        => 'primary',
@@ -26,6 +36,7 @@ describe 'peadm::add_replica' do
                          '--puppet-service-ensure', 'stopped',
                          'main:certname=replica'
                        ] })
+      expect_plan('peadm::util::sync_global_hiera')
 
       expect_out_verbose.with_params('Current config is...')
       expect_out_verbose.with_params('Updating classification to...')
@@ -36,6 +47,7 @@ describe 'peadm::add_replica' do
       allow_standard_non_returning_calls
       expect_task('peadm::get_peadm_config').always_return(cfg)
       expect_task('peadm::cert_data').always_return(certdata.merge({ 'dns-alt-names' => ['primary', 'alt'] })).be_called_times(4)
+      expect_task('peadm::cert_valid_status').always_return(certstatus)
       expect_task('package').always_return({ 'status' => 'uninstalled' })
       expect_task('peadm::agent_install')
         .with_params({ 'server'        => 'primary',
@@ -44,6 +56,8 @@ describe 'peadm::add_replica' do
                          '--puppet-service-ensure', 'stopped',
                          'main:certname=replica'
                        ] })
+      expect_plan('peadm::util::sync_global_hiera')
+
       expect_out_verbose.with_params('Current config is...')
       expect_out_verbose.with_params('Updating classification to...')
       expect(run_plan('peadm::add_replica', params)).to be_ok

--- a/spec/plans/add_replica_spec.rb
+++ b/spec/plans/add_replica_spec.rb
@@ -27,7 +27,8 @@ describe 'peadm::add_replica' do
                          'main:certname=replica'
                        ] })
 
-      expect_out_message.with_params('Classification to be updated using the following hash...')
+      expect_out_verbose.with_params('Current config is...')
+      expect_out_verbose.with_params('Updating classification to...')
       expect(run_plan('peadm::add_replica', params)).to be_ok
     end
 
@@ -43,7 +44,8 @@ describe 'peadm::add_replica' do
                          '--puppet-service-ensure', 'stopped',
                          'main:certname=replica'
                        ] })
-      expect_out_message.with_params('Classification to be updated using the following hash...')
+      expect_out_verbose.with_params('Current config is...')
+      expect_out_verbose.with_params('Updating classification to...')
       expect(run_plan('peadm::add_replica', params)).to be_ok
     end
   end

--- a/spec/plans/add_replica_spec.rb
+++ b/spec/plans/add_replica_spec.rb
@@ -11,33 +11,39 @@ describe 'peadm::add_replica' do
 
   describe 'basic functionality' do
     let(:params) { { 'primary_host' => 'primary', 'replica_host' => 'replica' } }
-    let(:certdata) { { 'certname' => 'primary', 'extensions' => { '1.3.6.1.4.1.34380.1.1.9813' => 'A' } } }
+    let(:certdata) { { 'certname' => 'primary', 'extensions' => { '1.3.6.1.4.1.34380.1.1.9813' => 'A' }, 'dns-alt-names' => [] } }
+    let(:cfg) { { 'params' => { 'primary_host' => 'primary' } } }
 
-    it 'runs successfully when the primary doesn\'t have alt-names' do
+    it 'runs successfully when the primary does not have alt-names' do
       allow_standard_non_returning_calls
-      expect_task('peadm::cert_data').always_return(certdata)
+      expect_task('peadm::get_peadm_config').always_return(cfg)
+      expect_task('peadm::cert_data').always_return(certdata).be_called_times(3)
+      expect_task('package').always_return({ 'status' => 'uninstalled' })
       expect_task('peadm::agent_install')
         .with_params({ 'server'        => 'primary',
                        'install_flags' => [
+                         'main:dns_alt_names=replica',
                          '--puppet-service-ensure', 'stopped',
-                         'main:certname=replica',
-                         'main:dns_alt_names=replica'
+                         'main:certname=replica'
                        ] })
 
+      expect_out_message.with_params('Classification to be updated using the following hash...')
       expect(run_plan('peadm::add_replica', params)).to be_ok
     end
 
     it 'runs successfully when the primary has alt-names' do
       allow_standard_non_returning_calls
-      expect_task('peadm::cert_data').always_return(certdata.merge({ 'dns-alt-names' => ['primary', 'alt'] }))
+      expect_task('peadm::get_peadm_config').always_return(cfg)
+      expect_task('peadm::cert_data').always_return(certdata.merge({ 'dns-alt-names' => ['primary', 'alt'] })).be_called_times(3)
+      expect_task('package').always_return({ 'status' => 'uninstalled' })
       expect_task('peadm::agent_install')
         .with_params({ 'server'        => 'primary',
                        'install_flags' => [
+                         'main:dns_alt_names=replica,alt',
                          '--puppet-service-ensure', 'stopped',
-                         'main:certname=replica',
-                         'main:dns_alt_names=replica,alt'
+                         'main:certname=replica'
                        ] })
-
+      expect_out_message.with_params('Classification to be updated using the following hash...')
       expect(run_plan('peadm::add_replica', params)).to be_ok
     end
   end

--- a/tasks/cert_valid_status.json
+++ b/tasks/cert_valid_status.json
@@ -1,0 +1,13 @@
+{
+  "description": "Check primary for valid state of a certificate",
+  "parameters": {
+    "certname": {
+      "type": "String",
+      "description": "The certifcate name to check validation of"
+    }
+  },
+  "input_method": "stdin",
+  "implementations": [
+    {"name": "cert_valid_status.rb"}
+  ]
+}

--- a/tasks/cert_valid_status.rb
+++ b/tasks/cert_valid_status.rb
@@ -1,0 +1,30 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+# frozen_string_literal: true
+
+require 'puppet'
+require 'json'
+
+$params = JSON.parse(STDIN.read)
+
+Puppet.initialize_settings
+
+Puppet.settings.use(:agent, :server, :master, :main)
+
+begin
+  cert_provider = Puppet::X509::CertProvider.new
+  ssl_provider = Puppet::SSL::SSLProvider.new
+  password = cert_provider.load_private_key_password
+  ssl_context = ssl_provider.load_context(certname: $params['certname'], password: password)
+rescue Puppet::SSL::CertVerifyError => e
+  status = { 'certificate-status' => 'invalid', 'reason' => e.message }
+rescue Puppet::Error => e
+  status = { 'certificate-status' => 'unknown', 'reason' => e.message }
+else
+  cert = ssl_context.client_chain.first
+  status = { 'certificate-status' => 'valid', 'reason' => "Expires - #{cert.not_after}" }
+end
+
+result = status
+
+# Put the result to stdout
+puts result.to_json

--- a/tasks/cert_valid_status.rb
+++ b/tasks/cert_valid_status.rb
@@ -4,7 +4,7 @@
 require 'puppet'
 require 'json'
 
-$params = JSON.parse(STDIN.read)
+params = JSON.parse(STDIN.read)
 
 Puppet.initialize_settings
 
@@ -14,7 +14,7 @@ begin
   cert_provider = Puppet::X509::CertProvider.new
   ssl_provider = Puppet::SSL::SSLProvider.new
   password = cert_provider.load_private_key_password
-  ssl_context = ssl_provider.load_context(certname: $params['certname'], password: password)
+  ssl_context = ssl_provider.load_context(certname: params['certname'], password: password)
 rescue Puppet::SSL::CertVerifyError => e
   status = { 'certificate-status' => 'invalid', 'reason' => e.message }
 rescue Puppet::Error => e


### PR DESCRIPTION
Ensure classification is updated appropriately. Lacking classification results in plans only being able to replace components if they are of the same name but entirely unconfigured.