### PR TITLE
Fix docs references from "provision" to "install"

### DIFF
--- a/documentation/convert.md
+++ b/documentation/convert.md
@@ -19,7 +19,7 @@ Prepare to run the plan against all servers in the PE infrastructure, using a pa
 }
 ```
 
-See the [provision](provision.md#reference-architectures) documentation for a list of supported architectures. Note that for convert, *all infrastructure being converted must already be functional*; you cannot use convert to add new systems to the infrastructure, nor can you use it to change your architecture.
+See the [install](install.md#reference-architectures) documentation for a list of supported architectures. Note that for convert, *all infrastructure being converted must already be functional*; you cannot use convert to add new systems to the infrastructure, nor can you use it to change your architecture.
 
 ```
 bolt plan run peadm::convert --params @params.json 

--- a/documentation/upgrade.md
+++ b/documentation/upgrade.md
@@ -42,7 +42,7 @@ Installation content can be downloaded from [https://puppet.com/try-puppet/puppe
 
 ## Online usage
 
-The peadm::provision plan can be configured to download installation content directly to hosts. To configure online installation, set the `download_mode` parameter of the `peadm::provision` plan to `direct`. The direct mode is often more efficient when PE hosts have a route to the internet.
+The `peadm::install` plan can be configured to download installation content directly to hosts. To configure online installation, set the `download_mode` parameter of the `peadm::install` plan to `direct`. The direct mode is often more efficient when PE hosts have a route to the internet.
 
 ## Usage over the Orchestrator transport
 


### PR DESCRIPTION
### Changes

Just a cosmetic thing, switching the Plan name from provision to install in the convert and upgrade documentation

----

Related PR: https://github.com/puppetlabs/puppetlabs-peadm/commit/631b94aac3028c37ee1922660a7e783cf8c42cd3