### PR TITLE
Add optional `pe_installer_source` parameter

### DIFF
--- a/plans/install.pp
+++ b/plans/install.pp
@@ -11,6 +11,11 @@
 #   A load balancer address directing traffic to any of the "B" pool
 #   compilers. This is used for DR configuration in large and extra large
 #   architectures.
+# @param pe_installer_source
+#   The URL to download the Puppet Enterprise installer media from. If not
+#   specified, PEAdm will attempt to download PE installation media from its
+#   standard public source. When specified, PEAdm will download directly from the
+#   URL given.
 #
 plan peadm::install (
   # Standard
@@ -27,6 +32,7 @@ plan peadm::install (
   # Common Configuration
   String                            $console_password,
   Peadm::Pe_version                 $version                          = '2019.8.8',
+  Optional[String]                  $pe_installer_source              = undef,
   Optional[Array[String]]           $dns_alt_names                    = undef,
   Optional[String]                  $compiler_pool_address            = undef,
   Optional[String]                  $internal_compiler_a_pool_address = undef,
@@ -66,6 +72,7 @@ plan peadm::install (
 
     # Common Configuration
     version                        => $version,
+    pe_installer_source            => $pe_installer_source,
     console_password               => $console_password,
     dns_alt_names                  => $dns_alt_names,
     pe_conf_data                   => $pe_conf_data,

--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -20,6 +20,12 @@
 #   Config data to plane into pe.conf when generated on all hosts, this can be
 #   used for tuning data etc.
 #
+# @param pe_installer_source
+#   The URL to download the Puppet Enterprise installer media from. If not
+#   specified, PEAdm will attempt to download PE installation media from its
+#   standard public source. When specified, PEAdm will download directly from the
+#   URL given.
+#
 plan peadm::subplans::install (
   # Standard
   Peadm::SingleTargetSpec           $primary_host,
@@ -35,8 +41,9 @@ plan peadm::subplans::install (
   # Common Configuration
   String               $console_password,
   Peadm::Pe_version    $version,
-  Array[String]        $dns_alt_names = [ ],
-  Hash                 $pe_conf_data  = { },
+  Optional[String]     $pe_installer_source = undef,
+  Array[String]        $dns_alt_names       = [ ],
+  Hash                 $pe_conf_data        = { },
 
   # Code Manager
   Optional[String]     $r10k_remote              = undef,
@@ -191,7 +198,10 @@ plan peadm::subplans::install (
   }
 
   $pe_tarball_name     = "puppet-enterprise-${version}-${platform}.tar.gz"
-  $pe_tarball_source   = "https://s3.amazonaws.com/pe-builds/released/${version}/${pe_tarball_name}"
+  $pe_tarball_source   = $pe_installer_source ? {
+    undef   => "https://s3.amazonaws.com/pe-builds/released/${version}/${pe_tarball_name}",
+    default => $pe_installer_source,
+  }
   $upload_tarball_path = "/tmp/${pe_tarball_name}"
 
   if $download_mode == 'bolthost' {

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -11,6 +11,11 @@
 #   A load balancer address directing traffic to any of the "B" pool
 #   compilers. This is used for DR configuration in large and extra large
 #   architectures.
+# @param pe_installer_source
+#   The URL to download the Puppet Enterprise installer media from. If not
+#   specified, PEAdm will attempt to download PE installation media from its
+#   standard public source. When specified, PEAdm will download directly from the
+#   URL given.
 #
 plan peadm::upgrade (
   # Standard
@@ -26,6 +31,7 @@ plan peadm::upgrade (
 
   # Common Configuration
   Peadm::Pe_version $version,
+  Optional[String]  $pe_installer_source              = undef,
   Optional[String]  $compiler_pool_address            = undef,
   Optional[String]  $internal_compiler_a_pool_address = undef,
   Optional[String]  $internal_compiler_b_pool_address = undef,
@@ -121,7 +127,10 @@ plan peadm::upgrade (
 
   $platform = run_task('peadm::precheck', $primary_target).first['platform']
   $tarball_filename = "puppet-enterprise-${version}-${platform}.tar.gz"
-  $tarball_source   = "https://s3.amazonaws.com/pe-builds/released/${version}/${tarball_filename}"
+  $tarball_source   = $pe_installer_source ? {
+    undef   => "https://s3.amazonaws.com/pe-builds/released/${version}/${tarball_filename}",
+    default => $pe_installer_source,
+  }
   $upload_tarball_path = "/tmp/${tarball_filename}"
 
   peadm::plan_step('preparation') || {


### PR DESCRIPTION
This new parameter to peadm::install and peadm::upgrade allows users to manually specify where to download the PE installer tarball from.