### PR TITLE
Add semicolons in multi-line cmd for pbrun compat

### DIFF
--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -294,11 +294,10 @@ plan peadm::upgrade (
     $workaround_delete_reports = $arch['disaster-recovery'] and $version =~ SemVerRange('>= 2019.8')
     if $workaround_delete_reports {
       run_command(@("COMMAND"/$), $replica_target)
-        if [ -e ${pdbapps}/delete-reports -a ! -h ${pdbapps}/delete-reports ]
-        then
-          mv ${pdbapps}/delete-reports ${pdbapps}/delete-reports.original
-          ln -s \$(which true) ${pdbapps}/delete-reports
-        fi
+        if [ -e ${pdbapps}/delete-reports -a ! -h ${pdbapps}/delete-reports ]; then
+          mv ${pdbapps}/delete-reports ${pdbapps}/delete-reports.original;
+          ln -s \$(which true) ${pdbapps}/delete-reports;
+        fi;
         | COMMAND
     }
 
@@ -312,10 +311,9 @@ plan peadm::upgrade (
     # Return the delete-reports CLI app to its original state
     if $workaround_delete_reports {
       run_command(@("COMMAND"/$), $replica_target)
-        if [ -e ${pdbapps}/delete-reports.original ]
-        then
-          mv ${pdbapps}/delete-reports.original ${pdbapps}/delete-reports
-        fi
+        if [ -e ${pdbapps}/delete-reports.original ]; then
+          mv ${pdbapps}/delete-reports.original ${pdbapps}/delete-reports;
+        fi;
         | COMMAND
     }
   }


### PR DESCRIPTION
Apparently, non-sudo escalations can get tricky with multi-line
run_command() invocations. As a temporary workaround for the
peadm::upgrade plan, just add some semicolons in. This works around it
for now.