### PR TITLE
Set additional rules on replica when adding compiler

### DIFF
--- a/plans/add_compiler.pp
+++ b/plans/add_compiler.pp
@@ -107,6 +107,11 @@ plan peadm::add_compiler(
     },
   )
 
+  # Source the global hiera.yaml from Primary and synchronize to new compiler
+  run_plan('peadm::util::sync_global_hiera', $compiler_target,
+    primary_host => $primary_target
+  )
+
   # On <compiler-host>, run the puppet agent
   run_task('peadm::puppet_runonce', $compiler_target)
 

--- a/plans/add_compiler.pp
+++ b/plans/add_compiler.pp
@@ -14,13 +14,35 @@ plan peadm::add_compiler(
   Peadm::SingleTargetSpec $compiler_host,
   Peadm::SingleTargetSpec $primary_host,
   Peadm::SingleTargetSpec $primary_postgresql_host,
-){
+) {
   $compiler_target           = peadm::get_targets($compiler_host, 1)
   $primary_target            = peadm::get_targets($primary_host, 1)
   $primary_postgresql_target = peadm::get_targets($primary_postgresql_host, 1)
 
+  # Get current peadm config to determine where to setup additional rules for
+  # compiler's secondary PuppetDB instances
+  $peadm_config = run_task('peadm::get_peadm_config', $primary_target).first.value
+
+  # Return the opposite server than the compiler to be added so it can be
+  # configured with the appropriate rules for Puppet Server access from
+  # compiler
+  $replica_avail_group_letter = $avail_group_letter ? { 'A' => 'B', 'B' => 'A' }
+  $replica_puppetdb = $peadm_config['role-letter']['server'][$replica_avail_group_letter]
+
+  $replica_puppetdb_target = peadm::get_targets($replica_puppetdb, 1)
+
   # Stop puppet.service
-  run_command('systemctl stop puppet.service', $primary_postgresql_target)
+  run_command('systemctl stop puppet.service', peadm::flatten_compact([
+    $primary_postgresql_target,
+    $replica_puppetdb_target
+  ]))
+
+  apply($replica_puppetdb_target) {
+    file_line { 'pe-puppetdb-compiler-cert-allow':
+      path => '/etc/puppetlabs/puppetdb/certificate-allowlist',
+      line => $compiler_target.peadm::certname(),
+    }
+  }
 
   # Add the following two lines to /opt/puppetlabs/server/data/postgresql/11/data/pg_ident.conf
   # 
@@ -89,11 +111,15 @@ plan peadm::add_compiler(
   run_task('peadm::puppet_runonce', $compiler_target)
 
   # On <primary_postgresql_host> run the puppet agent
-  run_task('peadm::puppet_runonce', $primary_postgresql_target)
+  run_task('peadm::puppet_runonce', peadm::flatten_compact([
+    $primary_postgresql_target,
+    $replica_puppetdb_target
+  ]))
 
   # On <primary_postgresql_host> start puppet.service
   run_command('systemctl start puppet.service', peadm::flatten_compact([
     $primary_postgresql_target,
+    $replica_puppetdb_target,
     $compiler_target,
   ]))
 

--- a/spec/plans/add_compiler_spec.rb
+++ b/spec/plans/add_compiler_spec.rb
@@ -19,10 +19,24 @@ describe 'peadm::add_compiler' do
       }
     end
 
+    let(:cfg) do
+      {
+        'params' => {
+          'primary_host' => 'primary'
+        },
+        'role-letter' => {
+          'server' => {
+            'A' => 'server_a',
+            'B' => 'server_b'
+          }
+        }
+      }
+    end
     let(:certdata) { { 'certname' => 'primary', 'extensions' => { '1.3.6.1.4.1.34380.1.1.9813' => 'A' } } }
 
     it 'runs successfully when no alt-names are specified' do
       allow_standard_non_returning_calls
+      expect_task('peadm::get_peadm_config').always_return(cfg)
       expect_plan('peadm::modify_certificate').always_return('mock' => 'mock')
       expect_task('peadm::agent_install')
         .with_params({ 'server'        => 'primary',
@@ -35,6 +49,7 @@ describe 'peadm::add_compiler' do
       #   ["--puppet-service-ensure", "stopped",
       #   "extension_requests:1.3.6.1.4.1.34380.1.3.13=pe_compiler", "extension_requests:1.3.6.1.4.1.34380.1.1.9813=A", "main:certname=compiler"], "server"=>"primary"}
 
+      expect_plan('peadm::util::sync_global_hiera').be_called_times(1)
       expect(run_plan('peadm::add_compiler', params)).to be_ok
     end
 
@@ -45,6 +60,7 @@ describe 'peadm::add_compiler' do
 
       it 'runs successfully when alt-names are specified' do
         allow_standard_non_returning_calls
+        expect_task('peadm::get_peadm_config').always_return(cfg)
         expect_plan('peadm::modify_certificate').always_return('mock' => 'mock')
         expect_task('peadm::agent_install')
           .with_params({ 'server'        => 'primary',
@@ -53,7 +69,7 @@ describe 'peadm::add_compiler' do
                            '--puppet-service-ensure', 'stopped',
                            'main:certname=compiler'
                          ] })
-
+        expect_plan('peadm::util::sync_global_hiera').be_called_times(1)
         expect(run_plan('peadm::add_compiler', params2)).to be_ok
       end
     end


### PR DESCRIPTION
Fix that ensures compiler is functional when deployed using `add_compiler` and a replica server is present