### PR TITLE
Bump latest versoins to 2021.7.0 and 2019.8.12

### DIFF
--- a/.github/workflows/test-add-replica.yaml
+++ b/.github/workflows/test-add-replica.yaml
@@ -7,7 +7,7 @@ on:
       image:
         description: 'GCP image for test cluster'
         required: true
-        default: 'centos-7'
+        default: 'almalinux-cloud/almalinux-8'
       architecture:
         description: 'PE architecture to test'
         required: true
@@ -15,7 +15,7 @@ on:
       version:
         description: 'PE version to install'
         required: true
-        default: '2019.8.8'
+        default: '2021.7.0'
       ssh-debugging:
         description: 'Boolean; whether or not to pause for ssh debugging'
         required: true

--- a/.github/workflows/test-fips-install-matrix.yaml
+++ b/.github/workflows/test-fips-install-matrix.yaml
@@ -28,8 +28,8 @@ jobs:
           - large
           - extra-large-with-dr
         version:
-          - 2019.8.11
-          - 2021.6.0
+          - 2019.8.12
+          - 2021.7.0
         image:
           - rhel-8
         fips:

--- a/.github/workflows/test-install-matrix.yaml
+++ b/.github/workflows/test-install-matrix.yaml
@@ -28,8 +28,8 @@ jobs:
           - large
           - extra-large-with-dr
         version:
-          - 2019.8.11
-          - 2021.6.0
+          - 2019.8.12
+          - 2021.7.0
         image:
           - centos-7
 

--- a/.github/workflows/test-install-matrix.yaml
+++ b/.github/workflows/test-install-matrix.yaml
@@ -88,7 +88,8 @@ jobs:
                 --modulepath spec/fixtures/modules \
                 provider=provision_service \
                 image=${{ matrix.image }} \
-                architecture=${{ matrix.architecture }}
+                architecture=${{ matrix.architecture }} \
+                --log-level trace
           echo ::endgroup::
 
           echo ::group::info:request

--- a/.github/workflows/test-install-matrix.yaml
+++ b/.github/workflows/test-install-matrix.yaml
@@ -100,8 +100,6 @@ jobs:
             sed -e 's/password: .*/password: "[redacted]"/' < spec/fixtures/litmus_inventory.yaml || true
           echo ::endgroup::
 
-          touch ${HOME}/pause
-
       - name: "Honeycomb: Record provision time"
         if: ${{ always() }}
         run: |

--- a/.github/workflows/test-install-matrix.yaml
+++ b/.github/workflows/test-install-matrix.yaml
@@ -32,7 +32,7 @@ jobs:
           - 2021.7.0
         image:
           - centos-7
-
+          - almalinux-cloud/almalinux-8
     steps:
       - name: "Honeycomb: Start recording"
         uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
@@ -98,6 +98,8 @@ jobs:
           echo ::group::info:inventory
             sed -e 's/password: .*/password: "[redacted]"/' < spec/fixtures/litmus_inventory.yaml || true
           echo ::endgroup::
+
+          touch ${HOME}/pause
 
       - name: "Honeycomb: Record provision time"
         if: ${{ always() }}

--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -7,7 +7,7 @@ on:
       image:
         description: 'GCP image for test cluster'
         required: true
-        default: 'centos-7'
+        default: 'almalinux-cloud/almalinux-8'
       architecture:
         description: 'PE architecture to test'
         required: true
@@ -15,7 +15,7 @@ on:
       version:
         description: 'PE version to install'
         required: true
-        default: '2021.6.0'
+        default: '2021.7.0'
       ssh-debugging:
         description: 'Boolean; whether or not to pause for ssh debugging'
         required: true

--- a/.github/workflows/test-upgrade.yaml
+++ b/.github/workflows/test-upgrade.yaml
@@ -31,7 +31,7 @@ jobs:
         version_to_upgrade:
           - '2021.7.0'
         image:
-          - 'centos-7'
+          - 'almalinux-cloud/almalinux-8'
         download_mode:
           - 'direct'
 

--- a/.github/workflows/test-upgrade.yaml
+++ b/.github/workflows/test-upgrade.yaml
@@ -27,9 +27,9 @@ jobs:
           - 'standard'
           - 'extra-large-with-dr'
         version:
-          - '2019.8.11'
+          - '2019.8.12'
         version_to_upgrade:
-          - '2021.6.0'
+          - '2021.7.0'
         image:
           - 'centos-7'
         download_mode:

--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@ The peadm module is able to deploy and manage Puppet Enterprise 2019.x Standard,
 
 #### Table of Contents
 
-1. [Expectations and support](#expectations-and-support)
-2. [Overview](#overview)
-    * [What peadm affects](#what-peadm-affects)
-    * [What peadm does not affect](#what-peadm-does-not-affect)
-    * [Requirements](#requirements)
-3. [Usage](#usage)
-4. [Reference](#reference)
-5. [Getting Help](#getting-help)
+- [Puppet Enterprise (pe) Administration (adm) Module](#puppet-enterprise-pe-administration-adm-module)
+      - [Table of Contents](#table-of-contents)
+  - [Expectations and support](#expectations-and-support)
+  - [Overview](#overview)
+    - [What peadm affects](#what-peadm-affects)
+    - [What peadm does not affect](#what-peadm-does-not-affect)
+    - [Requirements](#requirements)
+  - [Usage](#usage)
+  - [Reference](#reference)
+  - [Getting Help](#getting-help)
 
 ## Expectations and support
 
@@ -42,7 +44,7 @@ The normal usage pattern for peadm is as follows.
 
 ### Requirements
 
-* Puppet Enterprise 2019.8.1 or newer (tested with PE 2021.6)
+* Puppet Enterprise 2019.8.1 or newer (tested with PE 2021.7)
 * Bolt 3.17.0 or newer (tested with Bolt 3.21.0)
 * EL 7, EL 8, Ubuntu 18.04, or Ubuntu 20.04
 * Classifier Data enabled. This PE feature is enabled by default on new installs, but can be disabled by users if they remove the relevant configuration from their global hiera.yaml file. See the [PE docs](https://puppet.com/docs/pe/latest/config_console.html#task-5039) for more information.

--- a/documentation/install.md
+++ b/documentation/install.md
@@ -103,7 +103,7 @@ Example params.json Bolt parameters file (shown: Extra Large with DR):
   "console_password": "puppetlabs",
   "dns_alt_names": [ "puppet", "puppet.lab1.puppet.vm" ],
   "compiler_pool_address": "puppet.lab1.puppet.vm",
-  "version": "2021.6.0"
+  "version": "2021.7.0"
 }
 ```
 

--- a/documentation/install.md
+++ b/documentation/install.md
@@ -168,7 +168,7 @@ A parameters JSON file can then reference the target names, which will become th
   "console_password": "puppetlabs",
   "dns_alt_names": [ "puppet", "puppet.lab1.puppet.vm" ],
   "compiler_pool_address": "puppet.lab1.puppet.vm",
-  "version": "2019.2.2"
+  "version": "2021.7.0"
 }
 ```
 

--- a/documentation/upgrade.md
+++ b/documentation/upgrade.md
@@ -10,7 +10,7 @@ The following is an example parameters file for upgrading an Extra Large archite
 
 ```json
 {
-  "version": "2019.2.2",
+  "version": "2021.7.0",
   "primary_host": "pe-master-09a40c-0.us-west1-a.c.reidmv-peadm.internal",
   "primary_postgresql_host": "pe-psql-09a40c-0.us-west1-a.c.reidmv-peadm.internal",
   "replica_host": "pe-master-09a40c-1.us-west1-b.c.reidmv-peadm.internal",

--- a/examples/provision/extra-large-ha.json
+++ b/examples/provision/extra-large-ha.json
@@ -1,5 +1,5 @@
 {
-  "version": "2019.4.0",
+  "version": "2021.7.0",
   "console_password": "puppetlabs",
   "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
   "replica_host": "pe-master-1830cd-1.us-west1-b.c.reidmv-peadm.internal",

--- a/examples/provision/extra-large.json
+++ b/examples/provision/extra-large.json
@@ -1,5 +1,5 @@
 {
-  "version": "2019.2.4",
+  "version": "2021.7.0",
   "console_password": "puppetlabs",
   "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
 

--- a/examples/provision/large-ha.json
+++ b/examples/provision/large-ha.json
@@ -1,5 +1,5 @@
 {
-  "version": "2019.4.0",
+  "version": "2021.7.0",
   "console_password": "puppetlabs",
   "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
   "replica_host": "pe-master-1830cd-1.us-west1-b.c.reidmv-peadm.internal",

--- a/examples/provision/large.json
+++ b/examples/provision/large.json
@@ -1,5 +1,5 @@
 {
-  "version": "2019.4.0",
+  "version": "2021.7.0",
   "console_password": "puppetlabs",
   "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
 

--- a/examples/provision/minimal.json
+++ b/examples/provision/minimal.json
@@ -1,5 +1,5 @@
 {
-  "version": "2019.4.0",
+  "version": "2021.7.0",
   "console_password": "puppetlabs",
   "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal"
 }

--- a/examples/provision/standard-ha.json
+++ b/examples/provision/standard-ha.json
@@ -1,5 +1,5 @@
 {
-  "version": "2019.4.0",
+  "version": "2021.7.0",
   "console_password": "puppetlabs",
   "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
   "replica_host": "pe-master-1830cd-1.us-west1-b.c.reidmv-peadm.internal",

--- a/examples/provision/standard.json
+++ b/examples/provision/standard.json
@@ -1,5 +1,5 @@
 {
-  "version": "2019.4.0",
+  "version": "2021.7.0",
   "console_password": "puppetlabs",
   "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
 

--- a/functions/assert_supported_pe_version.pp
+++ b/functions/assert_supported_pe_version.pp
@@ -4,9 +4,9 @@
 function peadm::assert_supported_pe_version (
   String $version,
   Boolean $permit_unsafe_versions = false,
-) >> Struct[{'supported' => Boolean}] {
+) >> Struct[{ 'supported' => Boolean }] {
   $oldest = '2019.7'
-  $newest = '2021.6'
+  $newest = '2021.7'
   $supported = ($version =~ SemVerRange(">= ${oldest} <= ${newest}"))
 
   if $permit_unsafe_versions {

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -36,7 +36,7 @@ plan peadm::install (
 
   # Common Configuration
   String                            $console_password,
-  Peadm::Pe_version                 $version                          = '2019.8.8',
+  Peadm::Pe_version                 $version                          = '2021.7.0',
   Optional[String]                  $pe_installer_source              = undef,
   Optional[Array[String]]           $dns_alt_names                    = undef,
   Optional[String]                  $compiler_pool_address            = undef,

--- a/spec/docker/extra-large-ha/params.json
+++ b/spec/docker/extra-large-ha/params.json
@@ -12,6 +12,6 @@
     "pe-xl-core-0.puppet.vm",
     "puppet-xl.vm"
   ],
-  "version": "2019.8.5",
+  "version": "2021.7.0",
   "compiler_pool_address": "puppet-xl.vm"
 }

--- a/spec/docker/extra-large-ha/upgrade_params.json
+++ b/spec/docker/extra-large-ha/upgrade_params.json
@@ -6,5 +6,5 @@
   "compiler_hosts": [
     "pe-xl-compiler-0.puppet.vm"
   ],
-  "version": "2019.8.5"
+  "version": "2021.7.0"
 }

--- a/spec/docker/extra-large/params.json
+++ b/spec/docker/extra-large/params.json
@@ -9,5 +9,5 @@
     "puppet",
     "pe-xl-core-0.puppet.vm"
   ],
-  "version": "2019.8.5"
+  "version": "2021.7.0"
 }

--- a/spec/docker/extra-large/upgrade_params.json
+++ b/spec/docker/extra-large/upgrade_params.json
@@ -2,5 +2,5 @@
     "primary_host": "pe-xl-core-0.puppet.vm",
     "primary_postgresql_host": "pe-xl-db-0.puppet.vm",
     "compiler_hosts": ["pe-xl-compiler-0.puppet.vm"],
-    "version": "2019.8.5" 
+    "version": "2021.7.0" 
 }

--- a/spec/docker/large-ha/params.json
+++ b/spec/docker/large-ha/params.json
@@ -9,5 +9,5 @@
     "puppet",
     "pe-lg.puppet.vm"
   ],
-  "version": "2019.8.5"
+  "version": "2021.7.0"
 }

--- a/spec/docker/large-ha/upgrade_params.json
+++ b/spec/docker/large-ha/upgrade_params.json
@@ -4,5 +4,5 @@
   "compiler_hosts": [
     "pe-lg-compiler-0.puppet.vm"
   ],
-  "version": "2019.8.5"
+  "version": "2021.7.0"
 }

--- a/spec/docker/large/params.json
+++ b/spec/docker/large/params.json
@@ -8,5 +8,5 @@
     "puppet",
     "pe-lg.puppet.vm"
   ],
-  "version": "2019.8.1"
+  "version": "2021.7.0"
 }

--- a/spec/docker/large/upgrade_params.json
+++ b/spec/docker/large/upgrade_params.json
@@ -3,5 +3,5 @@
   "compiler_hosts": [
     "pe-lg-compiler-0.puppet.vm"
   ],
-  "version": "2019.8.8"
+  "version": "2021.7.0"
 }

--- a/spec/docker/standard-ha/params.json
+++ b/spec/docker/standard-ha/params.json
@@ -6,5 +6,5 @@
     "puppet",
     "pe-std.puppet.vm"
   ],
-  "version": "2019.8.5"
+  "version": "2021.7.0"
 }

--- a/spec/docker/standard-ha/upgrade_params.json
+++ b/spec/docker/standard-ha/upgrade_params.json
@@ -1,5 +1,5 @@
 {
   "primary_host": "pe-std.puppet.vm",
   "replica_host": "pe-std-replica.puppet.vm",
-  "version": "2019.8.5"
+  "version": "2021.7.0"
 }

--- a/spec/docker/standard/params.json
+++ b/spec/docker/standard/params.json
@@ -5,5 +5,5 @@
     "puppet",
     "pe-std.puppet.vm"
   ],
-  "version": "2019.8.8"
+  "version": "2021.7.0"
 }

--- a/spec/docker/standard/upgrade_params.json
+++ b/spec/docker/standard/upgrade_params.json
@@ -1,4 +1,4 @@
 {
   "primary_host": "pe-std.puppet.vm",
-  "version": "2019.8.8"
+  "version": "2021.7.0"
 }

--- a/spec/functions/assert_supported_pe_version_spec.rb
+++ b/spec/functions/assert_supported_pe_version_spec.rb
@@ -19,7 +19,7 @@ describe 'peadm::assert_supported_pe_version' do
     end
 
     it 'accepts the newest supported version' do
-      is_expected.to run.with_params('2021.2.1').and_return({ 'supported' => true })
+      is_expected.to run.with_params('2021.7.0').and_return({ 'supported' => true })
     end
 
     it 'accepts a version in the middle' do

--- a/spec/plans/convert_spec.rb
+++ b/spec/plans/convert_spec.rb
@@ -19,7 +19,7 @@ describe 'peadm::convert' do
     allow_apply
 
     expect_task('peadm::cert_data').return_for_targets('primary' => trustedjson)
-    expect_task('peadm::read_file').always_return({ 'content' => '2019.2.4' })
+    expect_task('peadm::read_file').always_return({ 'content' => '2021.7.0' })
 
     # For some reason, expect_plan() was not working??
     allow_plan('peadm::modify_certificate').always_return({})

--- a/spec/plans/subplans/install_spec.rb
+++ b/spec/plans/subplans/install_spec.rb
@@ -39,7 +39,7 @@ describe 'peadm::subplans::install' do
     params = {
       'primary_host'     => 'primary',
       'console_password' => 'puppetlabs',
-      'version'          => '2019.8.11',
+      'version'          => '2019.8.12',
     }
 
     expect(run_plan('peadm::subplans::install', params)).to be_ok

--- a/spec/plans/upgrade_spec.rb
+++ b/spec/plans/upgrade_spec.rb
@@ -28,7 +28,7 @@ describe 'peadm::upgrade' do
 
     expect(run_plan('peadm::upgrade',
                     'primary_host' => 'primary',
-                    'version' => '2019.8.6')).to be_ok
+                    'version' => '2021.7.0')).to be_ok
   end
 
   it 'runs with a primary, compilers, but no replica' do
@@ -41,6 +41,6 @@ describe 'peadm::upgrade' do
     expect(run_plan('peadm::upgrade',
                     'primary_host' => 'primary',
                     'compiler_hosts' => 'compiler',
-                    'version' => '2019.8.6')).to be_ok
+                    'version' => '2021.7.0')).to be_ok
   end
 end


### PR DESCRIPTION
This PR bumps the versions of PE to the latest STS/LTS.
some tests were permanently failing but suddenly started passing, so not sure what was going on?