### PR TITLE
Ensure fips commands exists before using it

### DIFF
--- a/tasks/precheck.sh
+++ b/tasks/precheck.sh
@@ -7,7 +7,7 @@ if grep -qi ubuntu /etc/os-release; then
   osfamily="ubuntu"
 elif grep -qi sles /etc/os-release; then
   osfamily="sles"
-elif grep -qi redhat /etc/os-release && fips-mode-setup --is-enabled; then
+elif grep -qi redhat /etc/os-release && (which fips-mode-setup &>/dev/null && fips-mode-setup --is-enabled); then
   osfamily="redhatfips"
 else
   osfamily="el"


### PR DESCRIPTION
Commit fixes failures which occur in some Bolt operating scenarios when OS is a RedHat derivative and commands for enabling fips are missing.