### PR TITLE
Workflows for nightly testing pre-release install

### DIFF
--- a/.github/workflows/test-install-latest-dev.yaml
+++ b/.github/workflows/test-install-latest-dev.yaml
@@ -1,0 +1,190 @@
+---
+name: "Install latest dev test"
+
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: 'GCP image for test cluster'
+        required: true
+        default: 'almalinux-cloud/almalinux-8'
+      architecture:
+        type: choice
+        required: true
+        default: 'standard'
+        description: 'PE architecture to test'
+        options: 
+        - standard
+        - standard-with-dr
+        - large
+        - large-with-dr
+        - extra-large
+        - extra-large-with-dr
+      ssh-debugging:
+        description: 'Boolean; whether or not to pause for ssh debugging'
+        required: true
+        default: 'false'
+
+env:
+  HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
+  HONEYCOMB_DATASET: litmus tests
+
+jobs:
+  test-install:
+    name: "PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }}"
+    runs-on: ubuntu-20.04
+    env:
+      BOLT_GEM: true
+      BOLT_DISABLE_ANALYTICS: true
+      BUILDEVENT_FILE: '../buildevents.txt'
+      LANG: 'en_US.UTF-8'
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture:
+          - "${{ github.event.inputs.architecture }}"
+        image:
+          - "${{ github.event.inputs.image }}"
+
+    steps:
+      - name: 'Start SSH session'
+        if: ${{ github.event.inputs.ssh-debugging == 'true' }}
+        uses: luchihoratiu/debug-via-ssh@main
+        with:
+          NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
+          SSH_PASS: ${{ secrets.SSH_PASS }}
+
+      - name: "Honeycomb: Start recording"
+        uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
+        with:
+          apikey: ${{ env.HONEYCOMB_WRITEKEY }}
+          dataset: ${{ env.HONEYCOMB_DATASET }}
+          job-status: ${{ job.status }}
+
+      - name: "Honeycomb: Start first step"
+        run: |
+          echo STEP_ID=setup-test-cluster >> $GITHUB_ENV
+          echo STEP_START=$(date +%s) >> $GITHUB_ENV
+
+      - name: "Checkout Source"
+        uses: actions/checkout@v2
+
+      - name: "Activate Ruby 2.7"
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.7"
+          bundler-cache: true
+
+      - name: "Print bundle environment"
+        if: ${{ github.repository_owner == 'puppetlabs' }}
+        run: |
+          echo ::group::info:bundler
+            buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
+          echo ::endgroup::
+
+      - name: "Honeycomb: Record environment setup time"
+        if: ${{ always() }}
+        run: |
+          echo ::group::honeycomb
+            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Set up environment'
+            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-provision >> $GITHUB_ENV
+            echo STEP_START=$(date +%s) >> $GITHUB_ENV
+          echo ::endgroup::
+
+      - name: 'Provision test cluster'
+        timeout-minutes: 15
+        run: |
+          echo ::group::prepare
+            mkdir -p $HOME/.ssh
+            echo 'Host *'                      >  $HOME/.ssh/config
+            echo '    ServerAliveInterval 150' >> $HOME/.ssh/config
+            echo '    ServerAliveCountMax 2'   >> $HOME/.ssh/config
+            buildevents cmd $TRACE_ID $STEP_ID 'rake spec_prep' -- bundle exec rake spec_prep
+          echo ::endgroup::
+
+          echo ::group::provision
+            buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::provision_test_cluster' -- \
+              bundle exec bolt plan run peadm_spec::provision_test_cluster \
+                --modulepath spec/fixtures/modules \
+                provider=provision_service \
+                image=${{ matrix.image }} \
+                architecture=${{ matrix.architecture }}
+          echo ::endgroup::
+
+          echo ::group::info:request
+            cat request.json || true; echo
+          echo ::endgroup::
+
+          echo ::group::info:inventory
+            sed -e 's/password: .*/password: "[redacted]"/' < spec/fixtures/litmus_inventory.yaml || true
+          echo ::endgroup::
+
+      - name: "Honeycomb: Record provision time"
+        if: ${{ always() }}
+        run: |
+          echo ::group::honeycomb
+            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Provision test cluster'
+            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-install >> $GITHUB_ENV
+            echo STEP_START=$(date +%s) >> $GITHUB_ENV
+          echo ::endgroup::
+
+      - name: 'Activate twingate to obtain unreleased build'
+        uses: twingate/github-action@v1
+        with:
+          service-key: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
+
+      - name: 'Get latest build name'
+        id: latest
+        run: |
+          echo "::set-output name=ver::$(curl -q https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/main/ci-ready/LATEST)"
+
+      - name: 'Install PE on test cluster'
+        timeout-minutes: 120
+        run: |
+          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::install_test_cluster' -- \
+            bundle exec bolt plan run peadm_spec::install_test_cluster \
+              --inventoryfile spec/fixtures/litmus_inventory.yaml \
+              --modulepath spec/fixtures/modules \
+              permit_unsafe_versions=true \
+              download_mode="bolthost" \
+              architecture=${{ matrix.architecture }} \
+              pe_installer_source="https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/main/ci-ready/puppet-enterprise-${{ steps.latest.outputs.ver }}-el-8-x86_64.tar"
+
+      - name: "Honeycomb: Record install time"
+        if: ${{ always() }}
+        run: |
+          echo ::group::honeycomb
+            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Install PE on test cluster'
+            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-tear_down >> $GITHUB_ENV
+            echo STEP_START=$(date +%s) >> $GITHUB_ENV
+          echo ::endgroup::
+
+      - name: 'Wait as long as the file ${HOME}/pause file is present'
+        if: ${{ always() && github.event.inputs.ssh-debugging == 'true' }}
+        run: |
+          while [ -f "${HOME}/pause" ] ; do
+            echo "${HOME}/pause present, sleeping for 60 seconds..."
+            sleep 60
+          done 
+          echo "${HOME}/pause absent, continuing workflow."
+
+      - name: 'Tear down test cluster'
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          if [ -f spec/fixtures/litmus_inventory.yaml ]; then
+            echo ::group::tear_down
+              buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
+            echo ::endgroup::
+
+            echo ::group::info:request
+              cat request.json || true; echo
+            echo ::endgroup::
+          fi
+
+      - name: "Honeycomb: Record tear down time"
+        if: ${{ always() }}
+        run: |
+          echo ::group::honeycomb
+            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Tear down test cluster'
+          echo ::endgroup::

--- a/.github/workflows/test-install-latest-xlarge-dev-nightly.yaml
+++ b/.github/workflows/test-install-latest-xlarge-dev-nightly.yaml
@@ -1,0 +1,165 @@
+---
+name: "Install latest dev test nightly"
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+
+env:
+  IMAGE: 'almalinux-cloud/almalinux-8'
+  ARCHITECTURE: 'extra-large-with-dr'
+  HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
+  HONEYCOMB_DATASET: litmus tests
+
+jobs:
+  test-install:
+    name: "PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }}"
+    runs-on: ubuntu-20.04
+    env:
+      BOLT_GEM: true
+      BOLT_DISABLE_ANALYTICS: true
+      BUILDEVENT_FILE: '../buildevents.txt'
+      LANG: 'en_US.UTF-8'
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture:
+          - "${{ env.ARCHITECTURE }}"
+        image:
+          - "${{ env.IMAGE }}"
+
+    steps:
+      - name: "Honeycomb: Start recording"
+        uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
+        with:
+          apikey: ${{ env.HONEYCOMB_WRITEKEY }}
+          dataset: ${{ env.HONEYCOMB_DATASET }}
+          job-status: ${{ job.status }}
+
+      - name: "Honeycomb: Start first step"
+        run: |
+          echo STEP_ID=setup-test-cluster >> $GITHUB_ENV
+          echo STEP_START=$(date +%s) >> $GITHUB_ENV
+
+      - name: "Checkout Source"
+        uses: actions/checkout@v2
+
+      - name: "Activate Ruby 2.7"
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.7"
+          bundler-cache: true
+
+      - name: "Print bundle environment"
+        if: ${{ github.repository_owner == 'puppetlabs' }}
+        run: |
+          echo ::group::info:bundler
+            buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
+          echo ::endgroup::
+
+      - name: "Honeycomb: Record environment setup time"
+        if: ${{ always() }}
+        run: |
+          echo ::group::honeycomb
+            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Set up environment'
+            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-provision >> $GITHUB_ENV
+            echo STEP_START=$(date +%s) >> $GITHUB_ENV
+          echo ::endgroup::
+
+      - name: 'Provision test cluster'
+        timeout-minutes: 15
+        run: |
+          echo ::group::prepare
+            mkdir -p $HOME/.ssh
+            echo 'Host *'                      >  $HOME/.ssh/config
+            echo '    ServerAliveInterval 150' >> $HOME/.ssh/config
+            echo '    ServerAliveCountMax 2'   >> $HOME/.ssh/config
+            buildevents cmd $TRACE_ID $STEP_ID 'rake spec_prep' -- bundle exec rake spec_prep
+          echo ::endgroup::
+
+          echo ::group::provision
+            buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::provision_test_cluster' -- \
+              bundle exec bolt plan run peadm_spec::provision_test_cluster \
+                --modulepath spec/fixtures/modules \
+                provider=provision_service \
+                image=${{ matrix.image }} \
+                architecture=${{ matrix.architecture }}
+          echo ::endgroup::
+
+          echo ::group::info:request
+            cat request.json || true; echo
+          echo ::endgroup::
+
+          echo ::group::info:inventory
+            sed -e 's/password: .*/password: "[redacted]"/' < spec/fixtures/litmus_inventory.yaml || true
+          echo ::endgroup::
+
+      - name: "Honeycomb: Record provision time"
+        if: ${{ always() }}
+        run: |
+          echo ::group::honeycomb
+            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Provision test cluster'
+            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-install >> $GITHUB_ENV
+            echo STEP_START=$(date +%s) >> $GITHUB_ENV
+          echo ::endgroup::
+
+      - name: 'Activate twingate to obtain unreleased build'
+        uses: twingate/github-action@v1
+        with:
+          service-key: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
+
+      - name: 'Get latest build name'
+        id: latest
+        run: |
+          echo "::set-output name=ver::$(curl -q https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/main/ci-ready/LATEST)"
+
+      - name: 'Install PE on test cluster'
+        timeout-minutes: 120
+        run: |
+          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::install_test_cluster' -- \
+            bundle exec bolt plan run peadm_spec::install_test_cluster \
+              --inventoryfile spec/fixtures/litmus_inventory.yaml \
+              --modulepath spec/fixtures/modules \
+              permit_unsafe_versions=true \
+              download_mode="bolthost" \
+              architecture=${{ matrix.architecture }} \
+              pe_installer_source="https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/main/ci-ready/puppet-enterprise-${{ steps.latest.outputs.ver }}-el-8-x86_64.tar"
+
+      - name: "Honeycomb: Record install time"
+        if: ${{ always() }}
+        run: |
+          echo ::group::honeycomb
+            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Install PE on test cluster'
+            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-tear_down >> $GITHUB_ENV
+            echo STEP_START=$(date +%s) >> $GITHUB_ENV
+          echo ::endgroup::
+
+      - name: 'Wait as long as the file ${HOME}/pause file is present'
+        if: ${{ always() && github.event.inputs.ssh-debugging == 'true' }}
+        run: |
+          while [ -f "${HOME}/pause" ] ; do
+            echo "${HOME}/pause present, sleeping for 60 seconds..."
+            sleep 60
+          done 
+          echo "${HOME}/pause absent, continuing workflow."
+
+      - name: 'Tear down test cluster'
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          if [ -f spec/fixtures/litmus_inventory.yaml ]; then
+            echo ::group::tear_down
+              buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
+            echo ::endgroup::
+
+            echo ::group::info:request
+              cat request.json || true; echo
+            echo ::endgroup::
+          fi
+
+      - name: "Honeycomb: Record tear down time"
+        if: ${{ always() }}
+        run: |
+          echo ::group::honeycomb
+            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Tear down test cluster'
+          echo ::endgroup::

--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -198,11 +198,14 @@ plan peadm::subplans::install (
     )
   }
 
-  $pe_tarball_name     = "puppet-enterprise-${version}-${platform}.tar.gz"
-  $pe_tarball_source   = $pe_installer_source ? {
-    undef   => "https://s3.amazonaws.com/pe-builds/released/${version}/${pe_tarball_name}",
-    default => $pe_installer_source,
+  if $pe_installer_source {
+    $pe_tarball_name = $pe_installer_source.split('/')[-1]
+    $pe_tarball_source = $pe_installer_source
+  } else {
+    $pe_tarball_name   = "puppet-enterprise-${version}-${platform}.tar.gz"
+    $pe_tarball_source = "https://s3.amazonaws.com/pe-builds/released/${version}/${pe_tarball_name}"
   }
+
   $upload_tarball_path = "/tmp/${pe_tarball_name}"
 
   if $download_mode == 'bolthost' {

--- a/spec/acceptance/peadm_spec/plans/install_test_cluster.pp
+++ b/spec/acceptance/peadm_spec/plans/install_test_cluster.pp
@@ -1,7 +1,10 @@
 plan peadm_spec::install_test_cluster (
   String[1]                 $architecture,
-  String[1]                 $version,
-  Enum['enable', 'disable'] $fips = 'disable'
+  String                    $download_mode          = 'direct',
+  Optional[String[1]]       $version                = undef,
+  Optional[String[1]]       $pe_installer_source    = undef,
+  Boolean                   $permit_unsafe_versions = false,
+  Enum['enable', 'disable'] $fips                   = 'disable'
 ) {
 
   $t = get_targets('*')
@@ -22,9 +25,11 @@ plan peadm_spec::install_test_cluster (
   }
 
   $common_params = {
-    console_password => 'puppetlabs',
-    download_mode    => 'direct',
-    version          => $version,
+    console_password       => 'puppetlabs',
+    download_mode          => $download_mode,
+    version                => $version,
+    pe_installer_source    => $pe_installer_source,
+    permit_unsafe_versions => $permit_unsafe_versions,
   }
 
   $arch_params =

--- a/tasks/pe_install.sh
+++ b/tasks/pe_install.sh
@@ -22,7 +22,13 @@ fi
 tgzdir=$(dirname "$PT_tarball")
 pedir=$(tar -tf "$PT_tarball" | head -n 1 | xargs dirname)
 
-tar -C "$tgzdir" -xzf "$PT_tarball"
+if file "$PT_tarball" | grep -q gzip; then
+  tar_options="-xzf"
+else
+  tar_options="-xf"
+fi 
+
+tar -C "$tgzdir" "$tar_options" "$PT_tarball"
 
 if [ ! -z "$PT_peconf" ]; then
 	/bin/bash "${tgzdir}/${pedir}/puppet-enterprise-installer" -y -c "$PT_peconf"


### PR DESCRIPTION
Provide a manual and scheduled workflow which fetches the latest CI passing build of the next major PE version and does an install.

Scheduled does an Extra Large with DR deployment while manual, you can choose from a list.