### PR TITLE
Parameter for setting final state of agents

### DIFF
--- a/plans/install.pp
+++ b/plans/install.pp
@@ -21,6 +21,9 @@
 #   The parameter should be set to a valid set of connection settings as
 #   documented for the PE RBAC /ds endpoint. See:
 #   https://puppet.com/docs/pe/latest/rbac_api_v1_directory.html#put_ds-request_format
+# @param final_agent_state
+#   Configures the state the puppet agent should be in on infrastructure nodes
+#   after PE is configured successfully.
 #
 plan peadm::install (
   # Standard
@@ -56,10 +59,11 @@ plan peadm::install (
   Optional[String]                  $license_key_content = undef,
 
   # Other
-  Optional[String]                  $stagingdir             = undef,
-  Enum[direct,bolthost]             $download_mode          = 'bolthost',
-  Boolean                           $permit_unsafe_versions = false,
-  String                            $token_lifetime         = '1y',
+  Optional[String]           $stagingdir             = undef,
+  Enum['running', 'stopped'] $final_agent_state      = 'running',
+  Enum['direct', 'bolthost'] $download_mode          = 'bolthost',
+  Boolean                    $permit_unsafe_versions = false,
+  String                     $token_lifetime         = '1y',
 ) {
   peadm::assert_supported_bolt_version()
 
@@ -121,6 +125,7 @@ plan peadm::install (
 
     # Other
     stagingdir                       => $stagingdir,
+    final_agent_state                => $final_agent_state,
   )
 
   # Return a string banner reporting on what was done


### PR DESCRIPTION
Provides a parameter in plans peadm::install and peadm::subplans::configure which can be used to set the final state of the puppet agent which runs on infrastructure nodes. Allows for stopped or running states only.