### PR TITLE
Sync FIPS detection with the PE installer

### DIFF
--- a/tasks/precheck.sh
+++ b/tasks/precheck.sh
@@ -7,7 +7,7 @@ if grep -qi ubuntu /etc/os-release; then
   osfamily="ubuntu"
 elif grep -qi sles /etc/os-release; then
   osfamily="sles"
-elif grep -qi redhat /etc/os-release && (which fips-mode-setup &>/dev/null && fips-mode-setup --is-enabled); then
+elif grep -qi redhat /etc/os-release && [[ "$(cat /proc/sys/crypto/fips_enabled)" == "1" ]]; then
   osfamily="redhatfips"
 else
   osfamily="el"


### PR DESCRIPTION
Prior to this commit, `peadm` used the `fips-mode-setup --is-enabled` command to detect whether FIPS mode was enabled. Unfortunately, this command does not produce a meaningful exit code. It exits with success on RHEL 8 where the `--is-enabled` flag is invalid:

```
$ fips-mode-setup --is-enabled
Check, enable, or disable the system FIPS mode.
usage: /usr/bin/fips-mode-setup --enable|--disable [--no-bootcfg]
usage: /usr/bin/fips-mode-setup --check

$ echo $?
0
```

And exits with success when FIPS mode is disabled:

```
$ fips-mode-setup --check
Installation of FIPS modules is not completed.
FIPS mode is disabled.

$ echo $?
0
```

The end result is that if the `crypto-policies-scripts` package happens to be installed on a RHEL node, `peadm` will assume the node is in FIPS mode and download the wrong PE installer package.

This commit updates `peadm` to use the same method for detecting
FIPS as the PE installer: `cat /proc/sys/crypto/fips_enabled`