### PR TITLE
Remove Puppet-debugger customisation

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -2,8 +2,6 @@
 Gemfile:
   required:
     ':development':
-      - gem: 'puppet-debugger'
-        version: '>= 0.18.0'
       - gem: 'bolt'
         version: '>= 3.10.0'
   optional:


### PR DESCRIPTION
This is no longer needed as the version has increased since it was added and will create an issue when updating to PDK 2.6 which enforces Debugger  to 1 and above