### PR TITLE
Fix XL failures in finalize step of peadm::convert

### DIFF
--- a/plans/convert.pp
+++ b/plans/convert.pp
@@ -246,7 +246,8 @@ plan peadm::convert (
     # Restart cluster compiler services that are likely not restarted by our
     # final Puppet run to increase chance everything is functional upon plan
     # completion
-    run_command('systemctl restart pe-puppetserver.service pe-puppetdb.service', $all_targets - $primary_target)
+    run_command('systemctl restart pe-puppetserver.service pe-puppetdb.service',
+                $all_targets - $primary_target - $primary_postgresql_target - $replica_postgresql_target)
   }
 
   return("Conversion to peadm Puppet Enterprise ${arch['architecture']} completed.")


### PR DESCRIPTION
Prior to this commit, the finalize step of `peadm::convert` would fail when operating on PE XL installations as the Primary Database and Replica Database nodes do not run the pe-puppetdb or pe-puppetserver services:

```
  The command failed with exit code 5
  STDERR:
    Failed to restart pe-puppetserver.service: Unit not found.
    Failed to restart pe-puppetdb.service: Unit not found.
```

This commit updates the convert plan to exclude the database nodes from that service restart.