### PR TITLE
Fail with guidance if peadm::util::retrieve_and_upload is used on PE XL with the PCP transport

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -533,7 +533,7 @@ Fails if any nodes have the chosen transport.
 
 Useful for excluding PCP when it's not appopriate
 
-#### `peadm::fail_on_transport(TargetSpec $nodes, String $transport)`
+#### `peadm::fail_on_transport(TargetSpec $nodes, String $transport, String $message)`
 
 Fails if any nodes have the chosen transport.
 

--- a/functions/fail_on_transport.pp
+++ b/functions/fail_on_transport.pp
@@ -5,12 +5,13 @@
 function peadm::fail_on_transport (
   TargetSpec $nodes,
   String     $transport,
+  String     $message = 'This is not supported.',
 ) {
   $targets = get_targets($nodes)
   $targets.each |$target| {
     if $target.protocol == $transport {
       fail_plan(
-        "${target.name} uses ${transport} transport. This is not supported",
+        "${target.name} uses ${transport} transport: ${message}",
         'unexpected-transport',
         {
           'target'    => $target,

--- a/plans/subplans/modify_certificate.pp
+++ b/plans/subplans/modify_certificate.pp
@@ -11,10 +11,20 @@ plan peadm::subplans::modify_certificate (
   $target = get_target($targets)
   $primary_target = get_target($primary_host)
 
-  # This plan doesn't work to reissue the master cert over the orchestrator due
-  # to pe-puppetserver needing to restart
   if ($primary_target == $target) {
-    $primary_target.peadm::fail_on_transport('pcp')
+    $primary_target.peadm::fail_on_transport('pcp', @(HEREDOC/n))
+      \nThe "pcp" transport is not available for use with the Primary
+      as peadm::subplans::modify_certificate will cause a restart of the
+      PE Orchestration service.
+
+      Use the "local" transport if running this plan directly from
+      the Primary node, or the "ssh" transport if running this
+      plan from an external Bolt host.
+
+      For information on configuring transports, see:
+
+          https://www.puppet.com/docs/bolt/latest/bolt_transports_reference.html
+      |-HEREDOC
   }
 
   # Figure out some information from the existing certificate

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -83,7 +83,19 @@ plan peadm::upgrade (
 
   out::message('# Gathering information')
 
-  $primary_target.peadm::fail_on_transport('pcp')
+  $primary_target.peadm::fail_on_transport('pcp', @(HEREDOC/n))
+    \nThe "pcp" transport is not available for use with the Primary
+    as peadm::upgrade will cause a restart of the
+    PE Orchestration service.
+
+    Use the "local" transport if running this plan directly from
+    the Primary node, or the "ssh" transport if running this
+    plan from an external Bolt host.
+
+    For information on configuring transports, see:
+
+        https://www.puppet.com/docs/bolt/latest/bolt_transports_reference.html
+    |-HEREDOC
 
   $platform = run_task('peadm::precheck', $primary_target).first['platform']
 
@@ -141,9 +153,6 @@ plan peadm::upgrade (
   }
 
   peadm::plan_step('preparation') || {
-    # Support for running over the orchestrator transport relies on Bolt being
-    # executed from the primary using the local transport. For now, fail the plan
-    # if the orchestrator is being used for the primary.
     if $download_mode == 'bolthost' {
       # Download the PE tarball on the nodes that need it
       run_plan('peadm::util::retrieve_and_upload', $pe_installer_targets,

--- a/plans/util/retrieve_and_upload.pp
+++ b/plans/util/retrieve_and_upload.pp
@@ -5,6 +5,28 @@ plan peadm::util::retrieve_and_upload(
   String[1]  $local_path,
   String[1]  $upload_path,
 ) {
+  $nodes.peadm::fail_on_transport('pcp', @(HEREDOC/n))
+    \nThe "pcp" transport is not available for uploading PE installers as
+    the ".tar.gz" file is too large to send over the PE Orchestrator
+    as an argument to the "bolt_shim::upload" task.
+
+    To upgrade PE XL database nodes via PCP, use "download_mode = direct".
+    If Puppet download servers are not reachable over the internet,
+    upload the ".tar.gz" to an internal fileserver and use the
+    "pe_installer_source" parameter to retrieve it.
+
+    For information on configuring plan parameters, see:
+
+        https://forge.puppet.com/modules/puppetlabs/peadm/plans
+
+    Or, use the "ssh" transport for database nodes so that the
+    installer can be transferred via SCP.
+
+    For information on configuring transports, see:
+
+        https://www.puppet.com/docs/bolt/latest/bolt_transports_reference.html
+    |-HEREDOC
+
   $exists = without_default_logging() || {
     run_command("test -e '${local_path}'", 'local://localhost',
       _catch_errors => true,

--- a/spec/functions/fail_on_transport_spec.rb
+++ b/spec/functions/fail_on_transport_spec.rb
@@ -27,7 +27,11 @@ describe 'peadm::fail_on_transport' do
   # would require duplicating rspec-puppet code, and that's a far worse sin.
   # rubocop:disable Rspec/NamedSubject
   it 'raises an error when nodes use the specified transport' do
-    expect { subject.execute(nodes, 'pcp') }.to raise_error(Puppet::PreformattedError, %r{target\.example uses pcp transport})
+    expect { subject.execute(nodes, 'pcp') }.to raise_error(Puppet::PreformattedError, %r{target\.example uses pcp transport: This is not supported\.})
+  end
+
+  it 'raises an error with a custom explanation if one is provided' do
+    expect { subject.execute(nodes, 'pcp', 'It would be bad.') }.to raise_error(Puppet::PreformattedError, %r{target\.example uses pcp transport: It would be bad\.})
   end
 
   it 'raises no error when nodes do not use the specified transport' do

--- a/spec/plans/subplans/modify_certificate_spec.rb
+++ b/spec/plans/subplans/modify_certificate_spec.rb
@@ -39,5 +39,18 @@ describe 'peadm::subplans::modify_certificate' do
         expect(run_plan('peadm::subplans::modify_certificate', params)).to be_ok
       end
     end
+
+    context 'modifying the primary certificate' do
+      it 'fails if the primary is using the PCP transport' do
+        result = run_plan('peadm::subplans::modify_certificate',
+                          { 'targets'          => 'pcp://primary.example',
+                            'primary_host'     => 'pcp://primary.example',
+                            'primary_certname' => 'primary.example' })
+
+        expect(result).not_to be_ok
+        expect(result.value.kind).to eq('unexpected-transport')
+        expect(result.value.msg).to match(%r{The "pcp" transport is not available for use with the Primary})
+      end
+    end
   end
 end

--- a/spec/plans/upgrade_spec.rb
+++ b/spec/plans/upgrade_spec.rb
@@ -43,4 +43,16 @@ describe 'peadm::upgrade' do
                     'compiler_hosts' => 'compiler',
                     'version' => '2021.7.1')).to be_ok
   end
+
+  it 'fails if the primary uses the pcp transport' do
+    allow_standard_non_returning_calls
+
+    result = run_plan('peadm::upgrade',
+                      'primary_host' => 'pcp://primary.example',
+                      'version' => '2021.7.1')
+
+    expect(result).not_to be_ok
+    expect(result.value.kind).to eq('unexpected-transport')
+    expect(result.value.msg).to match(%r{The "pcp" transport is not available for use with the Primary})
+  end
 end

--- a/spec/plans/util/retrieve_and_upload_spec.rb
+++ b/spec/plans/util/retrieve_and_upload_spec.rb
@@ -41,4 +41,16 @@ describe 'peadm::util::retrieve_and_upload' do
 
     expect(run_plan('peadm::util::retrieve_and_upload', 'nodes' => 'primary', 'source' => '/tmp/source', 'upload_path' => '/tmp/upload', 'local_path' => '/tmp/download')).to be_ok
   end
+
+  it 'fails when nodes are configured to use the pcp transport' do
+    result = run_plan('peadm::util::retrieve_and_upload',
+                      { 'nodes'       => ['pcp://node.example'],
+                        'source'      => '/tmp/source',
+                        'upload_path' => '/tmp/upload',
+                        'local_path'  => '/tmp/download' })
+
+    expect(result).not_to be_ok
+    expect(result.value.kind).to eq('unexpected-transport')
+    expect(result.value.msg).to match(%r{The "pcp" transport is not available for uploading PE installers})
+  end
 end


### PR DESCRIPTION
This changeset updates `peadm::util::retrieve_and_upload` to fail if the PCP transport is in use. When PCP is in use, file uploads are done via the `bolt_shim::upload` task, which essentially reads the file into memory, encodes it, and then ships it over Orchestrator as an argument to the `bolt_shim::upload` task.

This method of file transfer is utterly inadequate for shipping files as large as the PE installer.

Additionally, the `fail_on_transport()` function is enhanced to accept an optional error message and existing usages of `fail_on_transport()` are updated with descriptive messages that explain why PCP is unavailable and how to work around it.

Unit tests for `fail_on_transport()` are also fully implemented.