### PR TITLE
Updating github workflow release images

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -37,7 +37,7 @@ jobs:
         persist-credentials: false
 
     - name: "PDK Release prep"
-      uses: docker://puppet/iac_release:ci
+      uses: docker://puppet/puppet/pdk:2.6.1.0
       with:
         args: 'release prep --force'
       env:

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -37,7 +37,7 @@ jobs:
         persist-credentials: false
 
     - name: "PDK Release prep"
-      uses: docker://puppet/puppet/pdk:2.6.1.0
+      uses: docker://puppet/pdk:2.6.1.0
       with:
         args: 'release prep --force'
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,10 @@ jobs:
           ref: ${{ github.ref }}
           clean: true
       - name: "PDK Build"
-        uses: docker://puppet/pdk:nightly
+        uses: docker://puppet/puppet/pdk:2.6.1.0
         with:
           args: 'build'
       - name: "Push to Forge"
-        uses: docker://puppet/pdk:nightly
+        uses: docker://puppet/puppet/pdk:2.6.1.0
         with:
           args: 'release publish --forge-token ${{ secrets.FORGE_API_KEY }} --force'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,10 @@ jobs:
           ref: ${{ github.ref }}
           clean: true
       - name: "PDK Build"
-        uses: docker://puppet/puppet/pdk:2.6.1.0
+        uses: docker://puppet/pdk:2.6.1.0
         with:
           args: 'build'
       - name: "Push to Forge"
-        uses: docker://puppet/puppet/pdk:2.6.1.0
+        uses: docker://puppet/pdk:2.6.1.0
         with:
           args: 'release publish --forge-token ${{ secrets.FORGE_API_KEY }} --force'

--- a/.sync.yml
+++ b/.sync.yml
@@ -31,4 +31,4 @@ spec/spec_helper.rb:
 .github/workflows/auto_release.yml:
   unmanaged: true 
 .github/workflows/release.yml:
-  unmanaged: false
+  unmanaged: true


### PR DESCRIPTION
Currently our prep image was set to an old IAC image instead of a set PDK image for our supported version and our publish was set to latest instead of what PDK version our module is using. I have set both to be correct version

@binford2k @mcka1n this is some process and knowledge work I think we need to look at