### PR TITLE
Locking changelog_generator gem version

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -7,6 +7,7 @@ Gemfile:
   optional:
     ':development':
       - gem: 'github_changelog_generator'
+        version: '1.15.2' # Locked due to 1.16 no longer working for ruby lower than 3
       - gem: 'octokit'
         version: '4.21.0' # Locked due to https://github.com/octokit/octokit.rb/issues/1391
 Rakefile:


### PR DESCRIPTION
Locking changelog_generator version due to dropped support with ruby 2 in 1.16