### PR TITLE
add parameter for setting final state of infrastructure agents after upgrade

### DIFF
--- a/plans/subplans/configure.pp
+++ b/plans/subplans/configure.pp
@@ -150,7 +150,7 @@ plan peadm::subplans::configure (
     )
   }
 
-  # Ensure Puppet agent service is running now that configuration is complete
+  # Configure Puppet agent service status now that configuration is complete
   $systemctl_state = $final_agent_state ? {
     'running' => 'start',
     'stopped' => 'stop'


### PR DESCRIPTION
Previously similar parameter was add to install/configure plans to accommodate necessary customizations