### PR TITLE
switch to dev tools container and update changelog generator

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -34,9 +34,9 @@ jobs:
         persist-credentials: false
 
     - name: "PDK Release prep"
-      uses: docker://puppet/pdk:2.6.1.0
+      uses: docker://puppet/puppet-dev-tools:4.x
       with:
-        args: 'release prep --force'
+        args: 'pdk release prep --force --debug'
       env:
         CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.sync.yml
+++ b/.sync.yml
@@ -7,7 +7,7 @@ Gemfile:
   optional:
     ':development':
       - gem: 'github_changelog_generator'
-        version: '1.15.2' # Locked due to 1.16 no longer working for ruby lower than 3
+        version: '1.16.4' # Pinned to latest bug fix version
       - gem: 'octokit'
         version: '4.21.0' # Locked due to https://github.com/octokit/octokit.rb/issues/1391
 Rakefile:


### PR DESCRIPTION
Prior to this commit the base PDK docker image was being used, this container did not have any build tools present, so any gem that required building dependencies would cause validation checks to fail

Updated to dev-tools-container which is maintained by product, this has the required dev tools, this allows us to update to the latest change log generator gem, which has many bug fixes 