### PR TITLE
Allow code manager auto configure to be passed as param

### DIFF
--- a/plans/install.pp
+++ b/plans/install.pp
@@ -49,7 +49,7 @@ plan peadm::install (
   Optional[Peadm::Ldap_config]      $ldap_config                      = undef,
 
   # Code Manager
-  Boolean                           $code_manager_auto_configure = true,
+  Optional[Boolean]                 $code_manager_auto_configure = true,
   Optional[String]                  $r10k_remote              = undef,
   Optional[String]                  $r10k_private_key_file    = undef,
   Optional[Peadm::Pem]              $r10k_private_key_content = undef,

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -49,6 +49,7 @@ plan peadm::install (
   Optional[Peadm::Ldap_config]      $ldap_config                      = undef,
 
   # Code Manager
+  Boolean                           $code_manager_auto_configure = true,
   Optional[String]                  $r10k_remote              = undef,
   Optional[String]                  $r10k_private_key_file    = undef,
   Optional[Peadm::Pem]              $r10k_private_key_content = undef,
@@ -89,6 +90,7 @@ plan peadm::install (
     pe_conf_data                   => $pe_conf_data,
 
     # Code Manager
+    code_manager_auto_configure => $code_manager_auto_configure,
     r10k_remote                    => $r10k_remote,
     r10k_private_key_file          => $r10k_private_key_file,
     r10k_private_key_content       => $r10k_private_key_content,

--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -46,6 +46,7 @@ plan peadm::subplans::install (
   Hash                 $pe_conf_data        = {},
 
   # Code Manager
+  Boolean              $code_manager_auto_configure,
   Optional[String]     $r10k_remote              = undef,
   Optional[String]     $r10k_private_key_file    = undef,
   Optional[Peadm::Pem] $r10k_private_key_content = undef,
@@ -163,7 +164,7 @@ plan peadm::subplans::install (
       'puppet_enterprise::puppet_master_host'                           => $primary_target.peadm::certname(),
       'pe_install::puppet_master_dnsaltnames'                           => $dns_alt_names,
       'puppet_enterprise::puppetdb_database_host'                       => $primary_postgresql_target.peadm::certname(),
-      'puppet_enterprise::profile::master::code_manager_auto_configure' => true,
+      'puppet_enterprise::profile::master::code_manager_auto_configure' => $code_manager_auto_configure,
       'puppet_enterprise::profile::master::r10k_remote'                 => $r10k_remote,
       'puppet_enterprise::profile::master::r10k_private_key'            => $r10k_private_key ? {
         undef   => undef,

--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -46,7 +46,7 @@ plan peadm::subplans::install (
   Hash                 $pe_conf_data        = {},
 
   # Code Manager
-  Optional[Boolean]              $code_manager_auto_configure,
+  Optional[Boolean]    $code_manager_auto_configure = true,
   Optional[String]     $r10k_remote              = undef,
   Optional[String]     $r10k_private_key_file    = undef,
   Optional[Peadm::Pem] $r10k_private_key_content = undef,

--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -46,7 +46,7 @@ plan peadm::subplans::install (
   Hash                 $pe_conf_data        = {},
 
   # Code Manager
-  Boolean              $code_manager_auto_configure,
+  Optional[Boolean]              $code_manager_auto_configure,
   Optional[String]     $r10k_remote              = undef,
   Optional[String]     $r10k_private_key_file    = undef,
   Optional[Peadm::Pem] $r10k_private_key_content = undef,

--- a/spec/acceptance/peadm_spec/plans/install_test_cluster.pp
+++ b/spec/acceptance/peadm_spec/plans/install_test_cluster.pp
@@ -1,6 +1,7 @@
 plan peadm_spec::install_test_cluster (
   String[1]                 $architecture,
   String                    $download_mode          = 'direct',
+  Optional[Boolean]         $code_manager_auto_configure = undef,
   Optional[String[1]]       $version                = undef,
   Optional[String[1]]       $pe_installer_source    = undef,
   Boolean                   $permit_unsafe_versions = false,
@@ -26,6 +27,7 @@ plan peadm_spec::install_test_cluster (
   $common_params = {
     console_password       => 'puppetlabs',
     download_mode          => $download_mode,
+    code_manager_auto_configure => $code_manager_auto_configure,
     version                => $version,
     pe_installer_source    => $pe_installer_source,
     permit_unsafe_versions => $permit_unsafe_versions,


### PR DESCRIPTION
When using the module in workflows for testing the install_test_cluster plan is called. This PR adds the ability to pass the param code_manager_auto_configure to the plan and set it to false. It should still be set to true by default if nothing is passed. 

Setting it to true was causing issues with installing modules for testing.