### PR TITLE
agent_install: Enable Agent upgrades

### DIFF
--- a/tasks/agent_install.sh
+++ b/tasks/agent_install.sh
@@ -3,8 +3,7 @@
 set -e
 
 if [ -x "/opt/puppetlabs/bin/puppet" ]; then
-  echo "ERROR: Puppet agent is already installed. Re-install, re-configuration, or upgrade not supported. Please uninstall the agent before running this task."
-  exit 1
+  echo "WARNING: Puppet agent is already installed. Re-install, re-configuration, or upgrade not supported and might fail."
 fi
 
 flags=$(echo $PT_install_flags | sed -e 's/^\["*//' -e 's/"*\]$//' -e 's/", *"/ /g')


### PR DESCRIPTION
The install.bash script from PE supports agent updates and upgrades since a long time. I don't see a reason why the task in peadm should abort if it isn't a new installation. I understand if the support team doesn't want to take responsibility for upgrades/updates, but I think we shouldn't block users/SDP consultants using it.