### PR TITLE
Adding /etc/puppetlabs/enterprise/conf.d/pe.conf

### DIFF
--- a/plans/add_database.pp
+++ b/plans/add_database.pp
@@ -190,6 +190,18 @@ plan peadm::add_database(
     }
   }
 
+  # The pe.conf file needs to be in place or future upgrades will fail.
+  $pe_conf = peadm::generate_pe_conf({
+      'console_admin_password'                => 'not used',
+      'puppet_enterprise::puppet_master_host' => $primary_host.peadm::certname(),
+      'puppet_enterprise::database_host'      => $postgresql_target.peadm::certname(),
+  })
+
+  run_task('peadm::mkdir_p_file', $postgresql_target,
+    path    => '/etc/puppetlabs/enterprise/conf.d/pe.conf',
+    content => ($pe_conf.parsejson()).to_json_pretty(),
+  )
+  
   # Start frontend compiler services so catalogs can once again be compiled by
   # agents
   run_command('systemctl start pe-puppetserver.service pe-puppetdb.service', $compilers)

--- a/plans/add_database.pp
+++ b/plans/add_database.pp
@@ -201,7 +201,7 @@ plan peadm::add_database(
     path    => '/etc/puppetlabs/enterprise/conf.d/pe.conf',
     content => ($pe_conf.parsejson()).to_json_pretty(),
   )
-  
+
   # Start frontend compiler services so catalogs can once again be compiled by
   # agents
   run_command('systemctl start pe-puppetserver.service pe-puppetdb.service', $compilers)

--- a/plans/status.pp
+++ b/plans/status.pp
@@ -91,7 +91,7 @@ plan peadm::status(
       $summary_json = {
         'summary' => {
           'status' => $overall_status,
-          'stacks' => $stack_table_rows.hash,
+          'stacks' => Hash($stack_table_rows),
         },
         'failed' => $failed,
         'operational' => $passed,


### PR DESCRIPTION
When a database is added outside of the peadm::install plan, the /etc/puppetlabs/enterprise/conf.d/ directory structure is not created. When the peadm::upgrade plan is run, it fails because it can't write the pe.conf file because the directory doesn't exist. The contents of the file aren't that important, they get rewritten when the upgrade runs. This change just ensures the directory is there for it.