### PR TITLE
(PE-35899) Remove HoneyComb from the PEADM Github Actions

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
 
 env:
-  HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6 
-  HONEYCOMB_DATASET: litmus tests
   CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -14,18 +12,6 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    
-    - name: "Honeycomb: Start recording"
-      uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
-      with:
-        apikey: ${{ env.HONEYCOMB_WRITEKEY }}
-        dataset: ${{ env.HONEYCOMB_DATASET }}
-        job-status: ${{ job.status }}
-
-    - name: "Honeycomb: start first step"
-      run: |
-        echo STEP_ID="auto-release" >> $GITHUB_ENV
-        echo STEP_START=$(date +%s) >> $GITHUB_ENV
     - name: "Checkout Source"
       if: ${{ github.repository_owner == 'puppetlabs' }}
       uses: actions/checkout@v2
@@ -83,8 +69,3 @@ jobs:
       run: |
         echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
         echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
- 
-    - name: "Honeycomb: Record finish step"
-      if: ${{ always() }}
-      run: |
-        buildevents step $TRACE_ID $STEP_ID $STEP_START 'Finished auto release workflow'

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -6,11 +6,6 @@ on:
   workflow_dispatch:
   pull_request:
 
-
-env:
-  HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
-  HONEYCOMB_DATASET: litmus tests
-
 jobs:
   setup_matrix:
     name: "Setup Test Matrix"
@@ -19,18 +14,6 @@ jobs:
       spec_matrix: ${{ steps.get-matrix.outputs.spec_matrix }}
 
     steps:
-    
-      - name: "Honeycomb: Start recording"
-        uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
-        with:
-          apikey: ${{ env.HONEYCOMB_WRITEKEY }}
-          dataset: ${{ env.HONEYCOMB_DATASET }}
-          job-status: ${{ job.status }}
-
-      - name: "Honeycomb: Start first step"
-        run: |
-          echo STEP_ID=setup-environment >> $GITHUB_ENV
-          echo STEP_START=$(date +%s) >> $GITHUB_ENV
       - name: Checkout Source
         uses: actions/checkout@v2
         if: ${{ github.repository_owner == 'puppetlabs' }}
@@ -46,31 +29,23 @@ jobs:
         if: ${{ github.repository_owner == 'puppetlabs' }}
         run: |
           echo ::group::bundler environment
-          buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
+          bundle env
           echo ::endgroup::
-      - name: "Honeycomb: Record Setup Environment time"
-        if: ${{ github.repository_owner == 'puppetlabs' }}
-        run: |
-          buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Environment'
-          echo STEP_ID=Setup-Acceptance-Test-Matrix >> $GITHUB_ENV
-          echo STEP_START=$(date +%s) >> $GITHUB_ENV
+
       - name: Run Static & Syntax Tests
         if: ${{ github.repository_owner == 'puppetlabs' }}
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'static_syntax_checks' -- bundle exec rake validate lint check rubocop
+          bundle exec rake validate lint check rubocop
 
       - name: Setup Spec Test Matrix
         id: get-matrix
         run: |
           if [ '${{ github.repository_owner }}' == 'puppetlabs' ]; then
-            buildevents cmd $TRACE_ID $STEP_ID matrix_from_metadata -- bundle exec matrix_from_metadata_v2
+            bundle exec matrix_from_metadata_v2
           else
             echo  "::set-output name=spec_matrix::{}"
           fi
-      - name: "Honeycomb: Record Setup Test Matrix time"
-        if: ${{ always() }}
-        run: |
-          buildevents step $TRACE_ID $STEP_ID $STEP_START 'Setup Test Matrix'
+
   Spec:
     name: "Spec Tests (Puppet: ${{matrix.puppet_version}}, Ruby Ver: ${{matrix.ruby_version}})"
     needs:
@@ -83,7 +58,6 @@ jobs:
       matrix: ${{fromJson(needs.setup_matrix.outputs.spec_matrix)}}
 
     env:
-      BUILDEVENT_FILE: '../buildevents.txt'
       PUPPET_GEM_VERSION: ${{ matrix.puppet_version }}
       FACTER_GEM_VERSION: 'https://github.com/puppetlabs/facter#main'
 
@@ -91,20 +65,6 @@ jobs:
       - run: |
           echo "SANITIZED_PUPPET_VERSION=$(echo '${{ matrix.puppet_version }}' | sed 's/~> //g')" >> $GITHUB_ENV
 
-      - run: |
-          echo 'puppet_version=${{ env.SANITIZED_PUPPET_VERSION }}' >> $BUILDEVENT_FILE
-      - name: "Honeycomb: Start first step"
-        run: |
-          echo "STEP_ID=${{ env.SANITIZED_PUPPET_VERSION }}-spec" >> $GITHUB_ENV
-          echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
-      - name: "Honeycomb: Start recording"
-        uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
-        with:
-          apikey: ${{ env.HONEYCOMB_WRITEKEY }}
-          dataset: ${{ env.HONEYCOMB_DATASET }}
-          job-status: ${{ job.status }}
-          matrix-key: ${{ env.SANITIZED_PUPPET_VERSION }}
       - name: Checkout Source
         uses: actions/checkout@v2
 
@@ -117,10 +77,10 @@ jobs:
       - name: Print bundle environment
         run: |
           echo ::group::bundler environment
-          buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
+            bundle env
           echo ::endgroup::
 
 
       - name: Run parallel_spec tests
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'rake parallel_spec Puppet ${{ matrix.puppet_version }}, Ruby ${{ matrix.ruby_version }}' -- bundle exec rake parallel_spec
+          bundle exec rake parallel_spec

--- a/.github/workflows/test-add-compiler.yaml
+++ b/.github/workflows/test-add-compiler.yaml
@@ -21,10 +21,6 @@ on:
         required: true
         default: 'false'
 
-env:
-  HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
-  HONEYCOMB_DATASET: litmus tests
-
 jobs:
   test-add-compiler:
     name: "PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }}"
@@ -32,7 +28,6 @@ jobs:
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true
-      BUILDEVENT_FILE: '../buildevents.txt'
       LANG: 'en_US.UTF-8'
     strategy:
       fail-fast: false
@@ -52,18 +47,6 @@ jobs:
           NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
           SSH_PASS: ${{ secrets.SSH_PASS }}
 
-      - name: "Honeycomb: Start recording"
-        uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
-        with:
-          apikey: ${{ env.HONEYCOMB_WRITEKEY }}
-          dataset: ${{ env.HONEYCOMB_DATASET }}
-          job-status: ${{ job.status }}
-
-      - name: "Honeycomb: Start first step"
-        run: |
-          echo STEP_ID=setup-test-cluster >> $GITHUB_ENV
-          echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
       - name: "Checkout Source"
         uses: actions/checkout@v2
 
@@ -77,16 +60,7 @@ jobs:
         if: ${{ github.repository_owner == 'puppetlabs' }}
         run: |
           echo ::group::info:bundler
-            buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
-          echo ::endgroup::
-
-      - name: "Honeycomb: Record environment setup time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Set up environment'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-provision >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
+            bundle env
           echo ::endgroup::
 
       - name: 'Provision test cluster (specified architecture with added DR)'
@@ -97,16 +71,15 @@ jobs:
             echo 'Host *'                      >  $HOME/.ssh/config
             echo '    ServerAliveInterval 150' >> $HOME/.ssh/config
             echo '    ServerAliveCountMax 2'   >> $HOME/.ssh/config
-            buildevents cmd $TRACE_ID $STEP_ID 'rake spec_prep' -- bundle exec rake spec_prep
+            bundle exec rake spec_prep
           echo ::endgroup::
 
           echo ::group::provision
-            buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::provision_test_cluster' -- \
-              bundle exec bolt plan run peadm_spec::provision_test_cluster \
-                --modulepath spec/fixtures/modules \
-                provider=provision_service \
-                image=${{ matrix.image }} \
-                architecture=${{ matrix.architecture }}-with-extra-compiler
+            bundle exec bolt plan run peadm_spec::provision_test_cluster \
+              --modulepath spec/fixtures/modules \
+              provider=provision_service \
+              image=${{ matrix.image }} \
+              architecture=${{ matrix.architecture }}-with-extra-compiler
           echo ::endgroup::
 
           echo ::group::info:request
@@ -117,42 +90,22 @@ jobs:
             sed -e 's/password: .*/password: "[redacted]"/' < spec/fixtures/litmus_inventory.yaml || true
           echo ::endgroup::
 
-      - name: "Honeycomb: Record provision time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Provision test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-install >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
-
       - name: 'Install PE on test cluster'
         timeout-minutes: 120
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::install_test_cluster' -- \
-            bundle exec bolt plan run peadm_spec::install_test_cluster \
-              --inventoryfile spec/fixtures/litmus_inventory.yaml \
-              --modulepath spec/fixtures/modules \
-              architecture=${{ matrix.architecture }} \
-              version=${{ matrix.version }}
-
-      - name: "Honeycomb: Record install time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Install PE on test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-tear_down >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
+          bundle exec bolt plan run peadm_spec::install_test_cluster \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            architecture=${{ matrix.architecture }} \
+            version=${{ matrix.version }}
 
       - name: 'Run add_compiler plan'
         timeout-minutes: 30
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::add_compiler' -- \
-            bundle exec bolt plan run peadm_spec::add_compiler -v \
-              --inventoryfile spec/fixtures/litmus_inventory.yaml \
-              --modulepath spec/fixtures/modules \
-              architecture=${{ matrix.architecture }}
+          bundle exec bolt plan run peadm_spec::add_compiler -v \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            architecture=${{ matrix.architecture }}
 
       - name: 'Wait as long as the file ${HOME}/pause file is present'
         if: ${{ always() && github.event.inputs.ssh-debugging == 'true' }}
@@ -169,17 +122,10 @@ jobs:
         run: |
           if [ -f spec/fixtures/litmus_inventory.yaml ]; then
             echo ::group::tear_down
-              buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
+              bundle exec rake 'litmus:tear_down'
             echo ::endgroup::
 
             echo ::group::info:request
               cat request.json || true; echo
             echo ::endgroup::
           fi
-
-      - name: "Honeycomb: Record tear down time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Tear down test cluster'
-          echo ::endgroup::

--- a/.github/workflows/test-add-replica.yaml
+++ b/.github/workflows/test-add-replica.yaml
@@ -21,10 +21,6 @@ on:
         required: true
         default: 'false'
 
-env:
-  HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
-  HONEYCOMB_DATASET: litmus tests
-
 jobs:
   test-add-replica:
     name: "PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }}"
@@ -32,7 +28,6 @@ jobs:
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true
-      BUILDEVENT_FILE: '../buildevents.txt'
       LANG: 'en_US.UTF-8'
     strategy:
       fail-fast: false
@@ -52,18 +47,6 @@ jobs:
           NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
           SSH_PASS: ${{ secrets.SSH_PASS }}
 
-      - name: "Honeycomb: Start recording"
-        uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
-        with:
-          apikey: ${{ env.HONEYCOMB_WRITEKEY }}
-          dataset: ${{ env.HONEYCOMB_DATASET }}
-          job-status: ${{ job.status }}
-
-      - name: "Honeycomb: Start first step"
-        run: |
-          echo STEP_ID=setup-test-cluster >> $GITHUB_ENV
-          echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
       - name: "Checkout Source"
         uses: actions/checkout@v2
 
@@ -77,16 +60,7 @@ jobs:
         if: ${{ github.repository_owner == 'puppetlabs' }}
         run: |
           echo ::group::info:bundler
-            buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
-          echo ::endgroup::
-
-      - name: "Honeycomb: Record environment setup time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Set up environment'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-provision >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
+            bundle env
           echo ::endgroup::
 
       - name: 'Provision test cluster (specified architecture with added DR)'
@@ -97,16 +71,15 @@ jobs:
             echo 'Host *'                      >  $HOME/.ssh/config
             echo '    ServerAliveInterval 150' >> $HOME/.ssh/config
             echo '    ServerAliveCountMax 2'   >> $HOME/.ssh/config
-            buildevents cmd $TRACE_ID $STEP_ID 'rake spec_prep' -- bundle exec rake spec_prep
+            bundle exec rake spec_prep
           echo ::endgroup::
 
           echo ::group::provision
-            buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::provision_test_cluster' -- \
-              bundle exec bolt plan run peadm_spec::provision_test_cluster \
-                --modulepath spec/fixtures/modules \
-                provider=provision_service \
-                image=${{ matrix.image }} \
-                architecture=${{ matrix.architecture }}-with-dr
+            bundle exec bolt plan run peadm_spec::provision_test_cluster \
+              --modulepath spec/fixtures/modules \
+              provider=provision_service \
+              image=${{ matrix.image }} \
+              architecture=${{ matrix.architecture }}-with-dr
           echo ::endgroup::
 
           echo ::group::info:request
@@ -117,41 +90,21 @@ jobs:
             sed -e 's/password: .*/password: "[redacted]"/' < spec/fixtures/litmus_inventory.yaml || true
           echo ::endgroup::
 
-      - name: "Honeycomb: Record provision time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Provision test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-install >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
-
       - name: 'Install PE on test cluster'
         timeout-minutes: 120
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::install_test_cluster' -- \
-            bundle exec bolt plan run peadm_spec::install_test_cluster \
-              --inventoryfile spec/fixtures/litmus_inventory.yaml \
-              --modulepath spec/fixtures/modules \
-              architecture=${{ matrix.architecture }} \
-              version=${{ matrix.version }}
-
-      - name: "Honeycomb: Record install time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Install PE on test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-tear_down >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
+          bundle exec bolt plan run peadm_spec::install_test_cluster \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            architecture=${{ matrix.architecture }} \
+            version=${{ matrix.version }}
 
       - name: 'Run add_replica plan'
         timeout-minutes: 30
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::add_replica' -- \
-            bundle exec bolt plan run peadm_spec::add_replica -v \
-              --inventoryfile spec/fixtures/litmus_inventory.yaml \
-              --modulepath spec/fixtures/modules
+          bundle exec bolt plan run peadm_spec::add_replica -v \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules
 
       - name: 'Wait as long as the file ${HOME}/pause file is present'
         if: ${{ always() && github.event.inputs.ssh-debugging == 'true' }}
@@ -168,17 +121,10 @@ jobs:
         run: |
           if [ -f spec/fixtures/litmus_inventory.yaml ]; then
             echo ::group::tear_down
-              buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
+              bundle exec rake 'litmus:tear_down'
             echo ::endgroup::
 
             echo ::group::info:request
               cat request.json || true; echo
             echo ::endgroup::
           fi
-
-      - name: "Honeycomb: Record tear down time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Tear down test cluster'
-          echo ::endgroup::

--- a/.github/workflows/test-backup-restore.yaml
+++ b/.github/workflows/test-backup-restore.yaml
@@ -21,10 +21,6 @@ on:
         required: true
         default: 'false'
 
-env:
-  HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
-  HONEYCOMB_DATASET: litmus tests
-
 jobs:
   test-backup-restore:
     name: "PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }}"
@@ -32,7 +28,6 @@ jobs:
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true
-      BUILDEVENT_FILE: '../buildevents.txt'
       LANG: 'en_US.UTF-8'
     strategy:
       fail-fast: false
@@ -52,18 +47,6 @@ jobs:
           NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
           SSH_PASS: ${{ secrets.SSH_PASS }}
 
-      - name: "Honeycomb: Start recording"
-        uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
-        with:
-          apikey: ${{ env.HONEYCOMB_WRITEKEY }}
-          dataset: ${{ env.HONEYCOMB_DATASET }}
-          job-status: ${{ job.status }}
-
-      - name: "Honeycomb: Start first step"
-        run: |
-          echo STEP_ID=setup-test-cluster >> $GITHUB_ENV
-          echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
       - name: "Checkout Source"
         uses: actions/checkout@v2
 
@@ -77,16 +60,7 @@ jobs:
         if: ${{ github.repository_owner == 'puppetlabs' }}
         run: |
           echo ::group::info:bundler
-            buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
-          echo ::endgroup::
-
-      - name: "Honeycomb: Record environment setup time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Set up environment'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-provision >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
+            bundle env
           echo ::endgroup::
 
       - name: 'Provision test cluster'
@@ -97,16 +71,15 @@ jobs:
             echo 'Host *'                      >  $HOME/.ssh/config
             echo '    ServerAliveInterval 150' >> $HOME/.ssh/config
             echo '    ServerAliveCountMax 2'   >> $HOME/.ssh/config
-            buildevents cmd $TRACE_ID $STEP_ID 'rake spec_prep' -- bundle exec rake spec_prep
+            bundle exec rake spec_prep
           echo ::endgroup::
 
           echo ::group::provision
-            buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::provision_test_cluster' -- \
-              bundle exec bolt plan run peadm_spec::provision_test_cluster \
-                --modulepath spec/fixtures/modules \
-                provider=provision_service \
-                image=${{ matrix.image }} \
-                architecture=${{ matrix.architecture }}
+            bundle exec bolt plan run peadm_spec::provision_test_cluster \
+              --modulepath spec/fixtures/modules \
+              provider=provision_service \
+              image=${{ matrix.image }} \
+              architecture=${{ matrix.architecture }}
           echo ::endgroup::
 
           echo ::group::info:request
@@ -117,33 +90,14 @@ jobs:
             sed -e 's/password: .*/password: "[redacted]"/' < spec/fixtures/litmus_inventory.yaml || true
           echo ::endgroup::
 
-      - name: "Honeycomb: Record provision time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Provision test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-install >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
-
       - name: 'Install PE on test cluster'
         timeout-minutes: 120
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::install_test_cluster' -- \
-            bundle exec bolt plan run peadm_spec::install_test_cluster \
-              --inventoryfile spec/fixtures/litmus_inventory.yaml \
-              --modulepath spec/fixtures/modules \
-              architecture=${{ matrix.architecture }} \
-              version=${{ matrix.version }}
-
-      - name: "Honeycomb: Record install time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Install PE on test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-tear_down >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
+          bundle exec bolt plan run peadm_spec::install_test_cluster \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            architecture=${{ matrix.architecture }} \
+            version=${{ matrix.version }}
 
       - name: 'Wait as long as the file ${HOME}/pause file is present'
         if: ${{ always() && github.event.inputs.ssh-debugging == 'true' }}
@@ -160,17 +114,10 @@ jobs:
         run: |
           if [ -f spec/fixtures/litmus_inventory.yaml ]; then
             echo ::group::tear_down
-              buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
+              bundle exec rake 'litmus:tear_down'
             echo ::endgroup::
 
             echo ::group::info:request
               cat request.json || true; echo
             echo ::endgroup::
           fi
-
-      - name: "Honeycomb: Record tear down time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Tear down test cluster'
-          echo ::endgroup::

--- a/.github/workflows/test-failover.yaml
+++ b/.github/workflows/test-failover.yaml
@@ -25,10 +25,6 @@ on:
         required: false
         default: 'debug'
 
-env:
-  HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
-  HONEYCOMB_DATASET: litmus tests
-
 jobs:
   test-failover:
     name: "PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }}"
@@ -36,7 +32,6 @@ jobs:
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true
-      BUILDEVENT_FILE: '../buildevents.txt'
       LANG: 'en_US.UTF-8'
     strategy:
       fail-fast: false
@@ -55,18 +50,6 @@ jobs:
           NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
           SSH_PASS: ${{ secrets.SSH_PASS }}
 
-      - name: "Honeycomb: Start recording"
-        uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
-        with:
-          apikey: ${{ env.HONEYCOMB_WRITEKEY }}
-          dataset: ${{ env.HONEYCOMB_DATASET }}
-          job-status: ${{ job.status }}
-
-      - name: "Honeycomb: Start first step"
-        run: |
-          echo STEP_ID=setup-test-cluster >> $GITHUB_ENV
-          echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
       - name: "Checkout Source"
         uses: actions/checkout@v2
 
@@ -80,16 +63,7 @@ jobs:
         if: ${{ github.repository_owner == 'puppetlabs' }}
         run: |
           echo ::group::info:bundler
-            buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
-          echo ::endgroup::
-
-      - name: "Honeycomb: Record environment setup time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Set up environment'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-provision >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
+            bundle env
           echo ::endgroup::
 
       - name: 'Provision test cluster (XL with spare replica)'
@@ -100,16 +74,15 @@ jobs:
             echo 'Host *'                      >  $HOME/.ssh/config
             echo '    ServerAliveInterval 150' >> $HOME/.ssh/config
             echo '    ServerAliveCountMax 2'   >> $HOME/.ssh/config
-            buildevents cmd $TRACE_ID $STEP_ID 'rake spec_prep' -- bundle exec rake spec_prep
+            bundle exec rake spec_prep
           echo ::endgroup::
 
           echo ::group::provision
-            buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::provision_test_cluster' -- \
-              bundle exec bolt plan run peadm_spec::provision_test_cluster \
-                --modulepath spec/fixtures/modules \
-                provider=provision_service \
-                image=${{ matrix.image }} \
-                architecture=${{ matrix.architecture }}-and-spare-replica
+            bundle exec bolt plan run peadm_spec::provision_test_cluster \
+              --modulepath spec/fixtures/modules \
+              provider=provision_service \
+              image=${{ matrix.image }} \
+              architecture=${{ matrix.architecture }}-and-spare-replica
           echo ::endgroup::
 
           echo ::group::info:request
@@ -120,49 +93,20 @@ jobs:
             sed -e 's/password: .*/password: "[redacted]"/' < spec/fixtures/litmus_inventory.yaml || true
           echo ::endgroup::
 
-      - name: "Honeycomb: Record provision time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Provision test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-install >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
-
       - name: 'Install PE on test cluster'
         timeout-minutes: 120
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::install_test_cluster' -- \
-            bundle exec bolt plan run peadm_spec::install_test_cluster --log_level ${{ github.event.inputs.log_level }} \
-              --inventoryfile spec/fixtures/litmus_inventory.yaml \
-              --modulepath spec/fixtures/modules \
-              architecture=${{ matrix.architecture }} \
-              version=${{ matrix.version }}
-
-      - name: "Honeycomb: Record install time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Install PE on test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-tear_down >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
+          bundle exec bolt plan run peadm_spec::install_test_cluster --log_level ${{ github.event.inputs.log_level }} \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            architecture=${{ matrix.architecture }} \
+            version=${{ matrix.version }}
 
       - name: 'Perform failover'
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::perform_failover' -- \
-            bundle exec bolt plan run peadm_spec::perform_failover --log_level ${{ github.event.inputs.log_level }} \
-              --inventoryfile spec/fixtures/litmus_inventory.yaml \
-              --modulepath spec/fixtures/modules
-
-      - name: "Honeycomb: Record falover time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Perform failover'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-tear_down >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
+          bundle exec bolt plan run peadm_spec::perform_failover --log_level ${{ github.event.inputs.log_level }} \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules
 
       - name: 'Wait as long as the file ${HOME}/pause file is present'
         if: ${{ always() && github.event.inputs.ssh-debugging == 'true' }}
@@ -193,22 +137,12 @@ jobs:
         if: ${{ success() && github.event.inputs.version_to_upgrade != '' }}
         timeout-minutes: 120
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::upgrade_test_cluster' -- \
-            bundle exec bolt plan run peadm_spec::upgrade_test_cluster --log_level ${{ github.event.inputs.log_level }} \
-              --inventoryfile spec/fixtures/litmus_inventory.yaml \
-              --modulepath spec/fixtures/modules \
-              architecture=${{ matrix.architecture }} \
-              download_mode='direct' \
-              version=${{ github.event.inputs.version_to_upgrade }}
-
-      - name: "Honeycomb: Record upgrade time"
-        if: ${{ success() && github.event.inputs.version_to_upgrade != '' }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Upgrade PE on test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.version_to_upgrade }}-tear_down >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
+          bundle exec bolt plan run peadm_spec::upgrade_test_cluster --log_level ${{ github.event.inputs.log_level }} \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            architecture=${{ matrix.architecture }} \
+            download_mode='direct' \
+            version=${{ github.event.inputs.version_to_upgrade }}
 
       - name: 'Tear down test cluster'
         if: ${{ always() }}
@@ -216,17 +150,10 @@ jobs:
         run: |
           if [ -f spec/fixtures/litmus_inventory.yaml ]; then
             echo ::group::tear_down
-              buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
+              bundle exec rake 'litmus:tear_down'
             echo ::endgroup::
 
             echo ::group::info:request
               cat request.json || true; echo
             echo ::endgroup::
           fi
-
-      - name: "Honeycomb: Record tear down time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Tear down test cluster'
-          echo ::endgroup::

--- a/.github/workflows/test-fips-install-matrix.yaml
+++ b/.github/workflows/test-fips-install-matrix.yaml
@@ -7,10 +7,6 @@ on:
     types: [review_requested]
   workflow_dispatch: {}
 
-env:
-  HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
-  HONEYCOMB_DATASET: litmus tests
-
 jobs:
   test-install:
     name: "PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }} with fips ${{ matrix.fips }}"
@@ -18,7 +14,6 @@ jobs:
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true
-      BUILDEVENT_FILE: '../buildevents.txt'
       LANG: 'en_US.UTF-8'
     strategy:
       fail-fast: false
@@ -36,18 +31,6 @@ jobs:
           - enable
 
     steps:
-      - name: "Honeycomb: Start recording"
-        uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
-        with:
-          apikey: ${{ env.HONEYCOMB_WRITEKEY }}
-          dataset: ${{ env.HONEYCOMB_DATASET }}
-          job-status: ${{ job.status }}
-
-      - name: "Honeycomb: Start first step"
-        run: |
-          echo STEP_ID=setup-test-cluster >> $GITHUB_ENV
-          echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
       - name: "Checkout Source"
         uses: actions/checkout@v2
 
@@ -61,16 +44,7 @@ jobs:
         if: ${{ github.repository_owner == 'puppetlabs' }}
         run: |
           echo ::group::info:bundler
-            buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
-          echo ::endgroup::
-
-      - name: "Honeycomb: Record environment setup time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Set up environment'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-fips_${{ matrix.fips }}-provision >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
+            bundle env
           echo ::endgroup::
 
       - name: 'Provision test cluster'
@@ -81,16 +55,15 @@ jobs:
             echo 'Host *'                      >  $HOME/.ssh/config
             echo '    ServerAliveInterval 150' >> $HOME/.ssh/config
             echo '    ServerAliveCountMax 2'   >> $HOME/.ssh/config
-            buildevents cmd $TRACE_ID $STEP_ID 'rake spec_prep' -- bundle exec rake spec_prep
+            bundle exec rake spec_prep
           echo ::endgroup::
 
           echo ::group::provision
-            buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::provision_test_cluster' -- \
-              bundle exec bolt plan run peadm_spec::provision_test_cluster \
-                --modulepath spec/fixtures/modules \
-                provider=provision_service \
-                image=${{ matrix.image }} \
-                architecture=${{ matrix.architecture }}
+            bundle exec bolt plan run peadm_spec::provision_test_cluster \
+              --modulepath spec/fixtures/modules \
+              provider=provision_service \
+              image=${{ matrix.image }} \
+              architecture=${{ matrix.architecture }}
           echo ::endgroup::
 
           echo ::group::info:request
@@ -101,34 +74,15 @@ jobs:
             sed -e 's/password: .*/password: "[redacted]"/' < spec/fixtures/litmus_inventory.yaml || true
           echo ::endgroup::
 
-      - name: "Honeycomb: Record provision time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Provision test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-fips_${{ matrix.fips }}-install >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
-
       - name: 'Install PE on test cluster'
         timeout-minutes: 120
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::install_test_cluster' -- \
-            bundle exec bolt plan run peadm_spec::install_test_cluster \
-              --inventoryfile spec/fixtures/litmus_inventory.yaml \
-              --modulepath spec/fixtures/modules \
-              architecture=${{ matrix.architecture }} \
-              version=${{ matrix.version }} \
-              fips=${{ matrix.fips }} 
-
-      - name: "Honeycomb: Record install time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Install PE on test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-fips_${{ matrix.fips }}-tear_down >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
+          bundle exec bolt plan run peadm_spec::install_test_cluster \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            architecture=${{ matrix.architecture }} \
+            version=${{ matrix.version }} \
+            fips=${{ matrix.fips }} 
 
       - name: 'Tear down test cluster'
         if: ${{ always() }}
@@ -136,17 +90,10 @@ jobs:
         run: |
           if [ -f spec/fixtures/litmus_inventory.yaml ]; then
             echo ::group::tear_down
-              buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
+              bundle exec rake 'litmus:tear_down'
             echo ::endgroup::
 
             echo ::group::info:request
               cat request.json || true; echo
             echo ::endgroup::
           fi
-
-      - name: "Honeycomb: Record tear down time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Tear down test cluster'
-          echo ::endgroup::

--- a/.github/workflows/test-install-latest-dev.yaml
+++ b/.github/workflows/test-install-latest-dev.yaml
@@ -25,10 +25,6 @@ on:
         required: true
         default: 'false'
 
-env:
-  HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
-  HONEYCOMB_DATASET: litmus tests
-
 jobs:
   test-install:
     name: "PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }}"
@@ -36,7 +32,6 @@ jobs:
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true
-      BUILDEVENT_FILE: '../buildevents.txt'
       LANG: 'en_US.UTF-8'
     strategy:
       fail-fast: false
@@ -54,18 +49,6 @@ jobs:
           NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
           SSH_PASS: ${{ secrets.SSH_PASS }}
 
-      - name: "Honeycomb: Start recording"
-        uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
-        with:
-          apikey: ${{ env.HONEYCOMB_WRITEKEY }}
-          dataset: ${{ env.HONEYCOMB_DATASET }}
-          job-status: ${{ job.status }}
-
-      - name: "Honeycomb: Start first step"
-        run: |
-          echo STEP_ID=setup-test-cluster >> $GITHUB_ENV
-          echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
       - name: "Checkout Source"
         uses: actions/checkout@v2
 
@@ -79,16 +62,7 @@ jobs:
         if: ${{ github.repository_owner == 'puppetlabs' }}
         run: |
           echo ::group::info:bundler
-            buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
-          echo ::endgroup::
-
-      - name: "Honeycomb: Record environment setup time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Set up environment'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-provision >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
+            bundle env
           echo ::endgroup::
 
       - name: 'Provision test cluster'
@@ -99,16 +73,15 @@ jobs:
             echo 'Host *'                      >  $HOME/.ssh/config
             echo '    ServerAliveInterval 150' >> $HOME/.ssh/config
             echo '    ServerAliveCountMax 2'   >> $HOME/.ssh/config
-            buildevents cmd $TRACE_ID $STEP_ID 'rake spec_prep' -- bundle exec rake spec_prep
+            bundle exec rake spec_prep
           echo ::endgroup::
 
           echo ::group::provision
-            buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::provision_test_cluster' -- \
-              bundle exec bolt plan run peadm_spec::provision_test_cluster \
-                --modulepath spec/fixtures/modules \
-                provider=provision_service \
-                image=${{ matrix.image }} \
-                architecture=${{ matrix.architecture }}
+            bundle exec bolt plan run peadm_spec::provision_test_cluster \
+              --modulepath spec/fixtures/modules \
+              provider=provision_service \
+              image=${{ matrix.image }} \
+              architecture=${{ matrix.architecture }}
           echo ::endgroup::
 
           echo ::group::info:request
@@ -117,15 +90,6 @@ jobs:
 
           echo ::group::info:inventory
             sed -e 's/password: .*/password: "[redacted]"/' < spec/fixtures/litmus_inventory.yaml || true
-          echo ::endgroup::
-
-      - name: "Honeycomb: Record provision time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Provision test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-install >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
           echo ::endgroup::
 
       - name: 'Activate twingate to obtain unreleased build'
@@ -141,23 +105,13 @@ jobs:
       - name: 'Install PE on test cluster'
         timeout-minutes: 120
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::install_test_cluster' -- \
-            bundle exec bolt plan run peadm_spec::install_test_cluster \
-              --inventoryfile spec/fixtures/litmus_inventory.yaml \
-              --modulepath spec/fixtures/modules \
-              permit_unsafe_versions=true \
-              download_mode="bolthost" \
-              architecture=${{ matrix.architecture }} \
-              pe_installer_source="https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/main/ci-ready/puppet-enterprise-${{ steps.latest.outputs.ver }}-el-8-x86_64.tar"
-
-      - name: "Honeycomb: Record install time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Install PE on test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-tear_down >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
+          bundle exec bolt plan run peadm_spec::install_test_cluster \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            permit_unsafe_versions=true \
+            download_mode="bolthost" \
+            architecture=${{ matrix.architecture }} \
+            pe_installer_source="https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/main/ci-ready/puppet-enterprise-${{ steps.latest.outputs.ver }}-el-8-x86_64.tar"
 
       - name: 'Wait as long as the file ${HOME}/pause file is present'
         if: ${{ always() && github.event.inputs.ssh-debugging == 'true' }}
@@ -174,17 +128,10 @@ jobs:
         run: |
           if [ -f spec/fixtures/litmus_inventory.yaml ]; then
             echo ::group::tear_down
-              buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
+              bundle exec rake 'litmus:tear_down'
             echo ::endgroup::
 
             echo ::group::info:request
               cat request.json || true; echo
             echo ::endgroup::
           fi
-
-      - name: "Honeycomb: Record tear down time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Tear down test cluster'
-          echo ::endgroup::

--- a/.github/workflows/test-install-latest-dev.yaml
+++ b/.github/workflows/test-install-latest-dev.yaml
@@ -93,7 +93,7 @@ jobs:
           echo ::endgroup::
 
       - name: 'Activate twingate to obtain unreleased build'
-        uses: timidri/twingate-github-action
+        uses: timidri/twingate-github-action@main
         with:
           service-key: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
 

--- a/.github/workflows/test-install-latest-xlarge-dev-nightly.yaml
+++ b/.github/workflows/test-install-latest-xlarge-dev-nightly.yaml
@@ -6,10 +6,6 @@ on:
     - cron: '0 3 * * *'
   workflow_dispatch:
 
-env:
-  HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
-  HONEYCOMB_DATASET: litmus tests
-
 jobs:
   test-install:
     name: "PE nightly using ${{ matrix.architecture }} on ${{ matrix.image }}"
@@ -17,7 +13,6 @@ jobs:
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true
-      BUILDEVENT_FILE: '../buildevents.txt'
       LANG: 'en_US.UTF-8'
     strategy:
       fail-fast: false
@@ -28,18 +23,6 @@ jobs:
           - 'almalinux-cloud/almalinux-8'
 
     steps:
-      - name: "Honeycomb: Start recording"
-        uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
-        with:
-          apikey: ${{ env.HONEYCOMB_WRITEKEY }}
-          dataset: ${{ env.HONEYCOMB_DATASET }}
-          job-status: ${{ job.status }}
-
-      - name: "Honeycomb: Start first step"
-        run: |
-          echo STEP_ID=setup-test-cluster >> $GITHUB_ENV
-          echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
       - name: "Checkout Source"
         uses: actions/checkout@v2
 
@@ -53,16 +36,7 @@ jobs:
         if: ${{ github.repository_owner == 'puppetlabs' }}
         run: |
           echo ::group::info:bundler
-            buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
-          echo ::endgroup::
-
-      - name: "Honeycomb: Record environment setup time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Set up environment'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-provision >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
+            bundle env
           echo ::endgroup::
 
       - name: 'Provision test cluster'
@@ -73,16 +47,15 @@ jobs:
             echo 'Host *'                      >  $HOME/.ssh/config
             echo '    ServerAliveInterval 150' >> $HOME/.ssh/config
             echo '    ServerAliveCountMax 2'   >> $HOME/.ssh/config
-            buildevents cmd $TRACE_ID $STEP_ID 'rake spec_prep' -- bundle exec rake spec_prep
+            bundle exec rake spec_prep
           echo ::endgroup::
 
           echo ::group::provision
-            buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::provision_test_cluster' -- \
-              bundle exec bolt plan run peadm_spec::provision_test_cluster \
-                --modulepath spec/fixtures/modules \
-                provider=provision_service \
-                image=${{ matrix.image }} \
-                architecture=${{ matrix.architecture }}
+            bundle exec bolt plan run peadm_spec::provision_test_cluster \
+              --modulepath spec/fixtures/modules \
+              provider=provision_service \
+              image=${{ matrix.image }} \
+              architecture=${{ matrix.architecture }}
           echo ::endgroup::
 
           echo ::group::info:request
@@ -91,15 +64,6 @@ jobs:
 
           echo ::group::info:inventory
             sed -e 's/password: .*/password: "[redacted]"/' < spec/fixtures/litmus_inventory.yaml || true
-          echo ::endgroup::
-
-      - name: "Honeycomb: Record provision time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Provision test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-install >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
           echo ::endgroup::
 
       - name: 'Activate twingate to obtain unreleased build'
@@ -115,23 +79,13 @@ jobs:
       - name: 'Install PE on test cluster'
         timeout-minutes: 120
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::install_test_cluster' -- \
-            bundle exec bolt plan run peadm_spec::install_test_cluster \
-              --inventoryfile spec/fixtures/litmus_inventory.yaml \
-              --modulepath spec/fixtures/modules \
-              permit_unsafe_versions=true \
-              download_mode="bolthost" \
-              architecture=${{ matrix.architecture }} \
-              pe_installer_source="https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/main/ci-ready/puppet-enterprise-${{ steps.latest.outputs.ver }}-el-8-x86_64.tar"
-
-      - name: "Honeycomb: Record install time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Install PE on test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-tear_down >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
+          bundle exec bolt plan run peadm_spec::install_test_cluster \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            permit_unsafe_versions=true \
+            download_mode="bolthost" \
+            architecture=${{ matrix.architecture }} \
+            pe_installer_source="https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/main/ci-ready/puppet-enterprise-${{ steps.latest.outputs.ver }}-el-8-x86_64.tar"
 
       - name: 'Wait as long as the file ${HOME}/pause file is present'
         if: ${{ always() && github.event.inputs.ssh-debugging == 'true' }}
@@ -148,17 +102,10 @@ jobs:
         run: |
           if [ -f spec/fixtures/litmus_inventory.yaml ]; then
             echo ::group::tear_down
-              buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
+              bundle exec rake 'litmus:tear_down'
             echo ::endgroup::
 
             echo ::group::info:request
               cat request.json || true; echo
             echo ::endgroup::
           fi
-
-      - name: "Honeycomb: Record tear down time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Tear down test cluster'
-          echo ::endgroup::

--- a/.github/workflows/test-install-matrix.yaml
+++ b/.github/workflows/test-install-matrix.yaml
@@ -7,10 +7,6 @@ on:
     types: [review_requested]
   workflow_dispatch: {}
 
-env:
-  HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
-  HONEYCOMB_DATASET: litmus tests
-
 jobs:
   test-install:
     name: "PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }}"
@@ -18,7 +14,6 @@ jobs:
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true
-      BUILDEVENT_FILE: '../buildevents.txt'
       LANG: 'en_US.UTF-8'
     strategy:
       fail-fast: false
@@ -34,18 +29,6 @@ jobs:
           - centos-7
           - almalinux-cloud/almalinux-8
     steps:
-      - name: "Honeycomb: Start recording"
-        uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
-        with:
-          apikey: ${{ env.HONEYCOMB_WRITEKEY }}
-          dataset: ${{ env.HONEYCOMB_DATASET }}
-          job-status: ${{ job.status }}
-
-      - name: "Honeycomb: Start first step"
-        run: |
-          echo STEP_ID=setup-test-cluster >> $GITHUB_ENV
-          echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
       - name: "Checkout Source"
         uses: actions/checkout@v2
 
@@ -59,16 +42,7 @@ jobs:
         if: ${{ github.repository_owner == 'puppetlabs' }}
         run: |
           echo ::group::info:bundler
-            buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
-          echo ::endgroup::
-
-      - name: "Honeycomb: Record environment setup time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Set up environment'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-provision >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
+            bundle env
           echo ::endgroup::
 
       - name: 'Provision test cluster'
@@ -79,17 +53,16 @@ jobs:
             echo 'Host *'                      >  $HOME/.ssh/config
             echo '    ServerAliveInterval 150' >> $HOME/.ssh/config
             echo '    ServerAliveCountMax 2'   >> $HOME/.ssh/config
-            buildevents cmd $TRACE_ID $STEP_ID 'rake spec_prep' -- bundle exec rake spec_prep
+            bundle exec rake spec_prep
           echo ::endgroup::
 
           echo ::group::provision
-            buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::provision_test_cluster' -- \
-              bundle exec bolt plan run peadm_spec::provision_test_cluster \
-                --modulepath spec/fixtures/modules \
-                provider=provision_service \
-                image=${{ matrix.image }} \
-                architecture=${{ matrix.architecture }} \
-                --log-level trace
+            bundle exec bolt plan run peadm_spec::provision_test_cluster \
+              --modulepath spec/fixtures/modules \
+              provider=provision_service \
+              image=${{ matrix.image }} \
+              architecture=${{ matrix.architecture }} \
+              --log-level trace
           echo ::endgroup::
 
           echo ::group::info:request
@@ -100,33 +73,14 @@ jobs:
             sed -e 's/password: .*/password: "[redacted]"/' < spec/fixtures/litmus_inventory.yaml || true
           echo ::endgroup::
 
-      - name: "Honeycomb: Record provision time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Provision test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-install >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
-
       - name: 'Install PE on test cluster'
         timeout-minutes: 120
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::install_test_cluster' -- \
-            bundle exec bolt plan run peadm_spec::install_test_cluster \
-              --inventoryfile spec/fixtures/litmus_inventory.yaml \
-              --modulepath spec/fixtures/modules \
-              architecture=${{ matrix.architecture }} \
-              version=${{ matrix.version }}
-
-      - name: "Honeycomb: Record install time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Install PE on test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-tear_down >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
+          bundle exec bolt plan run peadm_spec::install_test_cluster \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            architecture=${{ matrix.architecture }} \
+            version=${{ matrix.version }}
 
       - name: 'Tear down test cluster'
         if: ${{ always() }}
@@ -134,17 +88,10 @@ jobs:
         run: |
           if [ -f spec/fixtures/litmus_inventory.yaml ]; then
             echo ::group::tear_down
-              buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
+              bundle exec rake 'litmus:tear_down'
             echo ::endgroup::
 
             echo ::group::info:request
               cat request.json || true; echo
             echo ::endgroup::
           fi
-
-      - name: "Honeycomb: Record tear down time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Tear down test cluster'
-          echo ::endgroup::

--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -21,10 +21,6 @@ on:
         required: true
         default: 'false'
 
-env:
-  HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
-  HONEYCOMB_DATASET: litmus tests
-
 jobs:
   test-install:
     name: "PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }}"
@@ -32,7 +28,6 @@ jobs:
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true
-      BUILDEVENT_FILE: '../buildevents.txt'
       LANG: 'en_US.UTF-8'
     strategy:
       fail-fast: false
@@ -52,18 +47,6 @@ jobs:
           NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
           SSH_PASS: ${{ secrets.SSH_PASS }}
 
-      - name: "Honeycomb: Start recording"
-        uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
-        with:
-          apikey: ${{ env.HONEYCOMB_WRITEKEY }}
-          dataset: ${{ env.HONEYCOMB_DATASET }}
-          job-status: ${{ job.status }}
-
-      - name: "Honeycomb: Start first step"
-        run: |
-          echo STEP_ID=setup-test-cluster >> $GITHUB_ENV
-          echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
       - name: "Checkout Source"
         uses: actions/checkout@v2
 
@@ -77,16 +60,7 @@ jobs:
         if: ${{ github.repository_owner == 'puppetlabs' }}
         run: |
           echo ::group::info:bundler
-            buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
-          echo ::endgroup::
-
-      - name: "Honeycomb: Record environment setup time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Set up environment'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-provision >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
+            bundle env
           echo ::endgroup::
 
       - name: 'Provision test cluster'
@@ -97,16 +71,15 @@ jobs:
             echo 'Host *'                      >  $HOME/.ssh/config
             echo '    ServerAliveInterval 150' >> $HOME/.ssh/config
             echo '    ServerAliveCountMax 2'   >> $HOME/.ssh/config
-            buildevents cmd $TRACE_ID $STEP_ID 'rake spec_prep' -- bundle exec rake spec_prep
+            bundle exec rake spec_prep
           echo ::endgroup::
 
           echo ::group::provision
-            buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::provision_test_cluster' -- \
-              bundle exec bolt plan run peadm_spec::provision_test_cluster \
-                --modulepath spec/fixtures/modules \
-                provider=provision_service \
-                image=${{ matrix.image }} \
-                architecture=${{ matrix.architecture }}
+            bundle exec bolt plan run peadm_spec::provision_test_cluster \
+              --modulepath spec/fixtures/modules \
+              provider=provision_service \
+              image=${{ matrix.image }} \
+              architecture=${{ matrix.architecture }}
           echo ::endgroup::
 
           echo ::group::info:request
@@ -117,33 +90,14 @@ jobs:
             sed -e 's/password: .*/password: "[redacted]"/' < spec/fixtures/litmus_inventory.yaml || true
           echo ::endgroup::
 
-      - name: "Honeycomb: Record provision time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Provision test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-install >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
-
       - name: 'Install PE on test cluster'
         timeout-minutes: 120
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::install_test_cluster' -- \
-            bundle exec bolt plan run peadm_spec::install_test_cluster \
-              --inventoryfile spec/fixtures/litmus_inventory.yaml \
-              --modulepath spec/fixtures/modules \
-              architecture=${{ matrix.architecture }} \
-              version=${{ matrix.version }}
-
-      - name: "Honeycomb: Record install time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Install PE on test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-tear_down >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
+          bundle exec bolt plan run peadm_spec::install_test_cluster \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            architecture=${{ matrix.architecture }} \
+            version=${{ matrix.version }}
 
       - name: 'Wait as long as the file ${HOME}/pause file is present'
         if: ${{ always() && github.event.inputs.ssh-debugging == 'true' }}
@@ -160,17 +114,10 @@ jobs:
         run: |
           if [ -f spec/fixtures/litmus_inventory.yaml ]; then
             echo ::group::tear_down
-              buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
+              bundle exec rake 'litmus:tear_down'
             echo ::endgroup::
 
             echo ::group::info:request
               cat request.json || true; echo
             echo ::endgroup::
           fi
-
-      - name: "Honeycomb: Record tear down time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Tear down test cluster'
-          echo ::endgroup::

--- a/.github/workflows/test-upgrade-latest-dev.yaml
+++ b/.github/workflows/test-upgrade-latest-dev.yaml
@@ -30,10 +30,6 @@ on:
         required: true
         default: 'false'
 
-env:
-  HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
-  HONEYCOMB_DATASET: litmus tests
-
 jobs:
   test-upgrade:
     name: "PE ${{ matrix.version }} to latest dev using ${{ matrix.architecture }} on ${{ matrix.image }}"
@@ -41,7 +37,6 @@ jobs:
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true
-      BUILDEVENT_FILE: '../buildevents.txt'
       LANG: 'en_US.UTF-8'
     strategy:
       fail-fast: false
@@ -61,18 +56,6 @@ jobs:
           NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
           SSH_PASS: ${{ secrets.SSH_PASS }}
 
-      - name: "Honeycomb: Start recording"
-        uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
-        with:
-          apikey: ${{ env.HONEYCOMB_WRITEKEY }}
-          dataset: ${{ env.HONEYCOMB_DATASET }}
-          job-status: ${{ job.status }}
-
-      - name: "Honeycomb: Start first step"
-        run: |
-          echo STEP_ID=setup-test-cluster >> $GITHUB_ENV
-          echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
       - name: "Checkout Source"
         uses: actions/checkout@v2
 
@@ -86,16 +69,7 @@ jobs:
         if: ${{ github.repository_owner == 'puppetlabs' }}
         run: |
           echo ::group::info:bundler
-            buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
-          echo ::endgroup::
-
-      - name: "Honeycomb: Record environment setup time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Set up environment'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-provision >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
+            bundle env
           echo ::endgroup::
 
       - name: 'Provision test cluster'
@@ -106,11 +80,10 @@ jobs:
             echo 'Host *'                      >  $HOME/.ssh/config
             echo '    ServerAliveInterval 150' >> $HOME/.ssh/config
             echo '    ServerAliveCountMax 2'   >> $HOME/.ssh/config
-            buildevents cmd $TRACE_ID $STEP_ID 'rake spec_prep' -- bundle exec rake spec_prep
+            bundle exec rake spec_prep
           echo ::endgroup::
 
           echo ::group::provision
-            buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::provision_test_cluster' -- \
               bundle exec bolt plan run peadm_spec::provision_test_cluster \
                 --modulepath spec/fixtures/modules \
                 provider=provision_service \
@@ -126,33 +99,14 @@ jobs:
             sed -e 's/password: .*/password: "[redacted]"/' < spec/fixtures/litmus_inventory.yaml || true
           echo ::endgroup::
 
-      - name: "Honeycomb: Record provision time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Provision test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-install >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
-
       - name: 'Install PE on test cluster'
         timeout-minutes: 120
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::install_test_cluster' -- \
-            bundle exec bolt plan run peadm_spec::install_test_cluster \
-              --inventoryfile spec/fixtures/litmus_inventory.yaml \
-              --modulepath spec/fixtures/modules \
-              architecture=${{ matrix.architecture }} \
-              version=${{ matrix.version }}
-
-      - name: "Honeycomb: Record install time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Install PE on test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-tear_down >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
+          bundle exec bolt plan run peadm_spec::install_test_cluster \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            architecture=${{ matrix.architecture }} \
+            version=${{ matrix.version }}
 
       - name: 'Wait as long as the file ${HOME}/pause file is present'
         if: ${{ always() && github.event.inputs.ssh-debugging == 'true' }}
@@ -176,23 +130,13 @@ jobs:
       - name: 'Upgrade PE on test cluster'
         timeout-minutes: 120
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::upgrade_test_cluster' -- \
-            bundle exec bolt plan run peadm_spec::upgrade_test_cluster \
-              --inventoryfile spec/fixtures/litmus_inventory.yaml \
-              --modulepath spec/fixtures/modules \
-              permit_unsafe_versions=true \
-              download_mode="bolthost" \
-              architecture=${{ matrix.architecture }} \
-              pe_installer_source="https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/main/ci-ready/puppet-enterprise-${{ steps.latest.outputs.ver }}-el-8-x86_64.tar"
-
-      - name: "Honeycomb: Record upgrade time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Upgrade PE on test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.version_to_upgrade }}-tear_down >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
+          bundle exec bolt plan run peadm_spec::upgrade_test_cluster \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            permit_unsafe_versions=true \
+            download_mode="bolthost" \
+            architecture=${{ matrix.architecture }} \
+            pe_installer_source="https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/main/ci-ready/puppet-enterprise-${{ steps.latest.outputs.ver }}-el-8-x86_64.tar"
 
       - name: 'Tear down test cluster'
         if: ${{ always() }}
@@ -200,17 +144,10 @@ jobs:
         run: |
           if [ -f spec/fixtures/litmus_inventory.yaml ]; then
             echo ::group::tear_down
-              buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
+              bundle exec rake 'litmus:tear_down'
             echo ::endgroup::
 
             echo ::group::info:request
               cat request.json || true; echo
             echo ::endgroup::
           fi
-
-      - name: "Honeycomb: Record tear down time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Tear down test cluster'
-          echo ::endgroup::

--- a/.github/workflows/test-upgrade-latest-xlarge-dev-nightly.yaml
+++ b/.github/workflows/test-upgrade-latest-xlarge-dev-nightly.yaml
@@ -5,10 +5,6 @@ on:
   schedule:
     - cron: '0 3 * * *'
 
-env:
-  HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
-  HONEYCOMB_DATASET: litmus tests
-
 jobs:
   test-upgrade:
     name: "PE ${{ matrix.version }} to nightly dev using ${{ matrix.architecture }} on ${{ matrix.image }}"
@@ -16,7 +12,6 @@ jobs:
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true
-      BUILDEVENT_FILE: '../buildevents.txt'
       LANG: 'en_US.UTF-8'
     strategy:
       fail-fast: false
@@ -29,18 +24,6 @@ jobs:
           - 'almalinux-cloud/almalinux-8'
 
     steps:
-      - name: "Honeycomb: Start recording"
-        uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
-        with:
-          apikey: ${{ env.HONEYCOMB_WRITEKEY }}
-          dataset: ${{ env.HONEYCOMB_DATASET }}
-          job-status: ${{ job.status }}
-
-      - name: "Honeycomb: Start first step"
-        run: |
-          echo STEP_ID=setup-test-cluster >> $GITHUB_ENV
-          echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
       - name: "Checkout Source"
         uses: actions/checkout@v2
 
@@ -54,16 +37,7 @@ jobs:
         if: ${{ github.repository_owner == 'puppetlabs' }}
         run: |
           echo ::group::info:bundler
-            buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
-          echo ::endgroup::
-
-      - name: "Honeycomb: Record environment setup time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Set up environment'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-provision >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
+            bundle env
           echo ::endgroup::
 
       - name: 'Provision test cluster'
@@ -74,16 +48,15 @@ jobs:
             echo 'Host *'                      >  $HOME/.ssh/config
             echo '    ServerAliveInterval 150' >> $HOME/.ssh/config
             echo '    ServerAliveCountMax 2'   >> $HOME/.ssh/config
-            buildevents cmd $TRACE_ID $STEP_ID 'rake spec_prep' -- bundle exec rake spec_prep
+            bundle exec rake spec_prep
           echo ::endgroup::
 
           echo ::group::provision
-            buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::provision_test_cluster' -- \
-              bundle exec bolt plan run peadm_spec::provision_test_cluster \
-                --modulepath spec/fixtures/modules \
-                provider=provision_service \
-                image=${{ matrix.image }} \
-                architecture=${{ matrix.architecture }}
+            bundle exec bolt plan run peadm_spec::provision_test_cluster \
+              --modulepath spec/fixtures/modules \
+              provider=provision_service \
+              image=${{ matrix.image }} \
+              architecture=${{ matrix.architecture }}
           echo ::endgroup::
 
           echo ::group::info:request
@@ -94,33 +67,14 @@ jobs:
             sed -e 's/password: .*/password: "[redacted]"/' < spec/fixtures/litmus_inventory.yaml || true
           echo ::endgroup::
 
-      - name: "Honeycomb: Record provision time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Provision test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-install >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
-
       - name: 'Install PE on test cluster'
         timeout-minutes: 120
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::install_test_cluster' -- \
-            bundle exec bolt plan run peadm_spec::install_test_cluster \
-              --inventoryfile spec/fixtures/litmus_inventory.yaml \
-              --modulepath spec/fixtures/modules \
-              architecture=${{ matrix.architecture }} \
-              version=${{ matrix.version }}
-
-      - name: "Honeycomb: Record install time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Install PE on test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-tear_down >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
+          bundle exec bolt plan run peadm_spec::install_test_cluster \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            architecture=${{ matrix.architecture }} \
+            version=${{ matrix.version }}
 
       - name: 'Activate twingate to obtain unreleased build'
         uses: timidri/twingate-github-action@main
@@ -135,23 +89,13 @@ jobs:
       - name: 'Upgrade PE on test cluster'
         timeout-minutes: 120
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::upgrade_test_cluster' -- \
-            bundle exec bolt plan run peadm_spec::upgrade_test_cluster \
-              --inventoryfile spec/fixtures/litmus_inventory.yaml \
-              --modulepath spec/fixtures/modules \
-              permit_unsafe_versions=true \
-              download_mode="bolthost" \
-              architecture=${{ matrix.architecture }} \
-              pe_installer_source="https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/main/ci-ready/puppet-enterprise-${{ steps.latest.outputs.ver }}-el-8-x86_64.tar"
-
-      - name: "Honeycomb: Record upgrade time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Upgrade PE on test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.version_to_upgrade }}-tear_down >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
+          bundle exec bolt plan run peadm_spec::upgrade_test_cluster \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            permit_unsafe_versions=true \
+            download_mode="bolthost" \
+            architecture=${{ matrix.architecture }} \
+            pe_installer_source="https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/main/ci-ready/puppet-enterprise-${{ steps.latest.outputs.ver }}-el-8-x86_64.tar"
 
       - name: 'Tear down test cluster'
         if: ${{ always() }}
@@ -159,17 +103,10 @@ jobs:
         run: |
           if [ -f spec/fixtures/litmus_inventory.yaml ]; then
             echo ::group::tear_down
-              buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
+              bundle exec rake 'litmus:tear_down'
             echo ::endgroup::
 
             echo ::group::info:request
               cat request.json || true; echo
             echo ::endgroup::
           fi
-
-      - name: "Honeycomb: Record tear down time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Tear down test cluster'
-          echo ::endgroup::

--- a/.github/workflows/test-upgrade-matrix.yaml
+++ b/.github/workflows/test-upgrade-matrix.yaml
@@ -7,10 +7,6 @@ on:
     types: [review_requested]
   workflow_dispatch: {}
 
-env:
-  HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
-  HONEYCOMB_DATASET: litmus tests
-
 jobs:
   test-upgrade:
     name: "PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }}"
@@ -18,7 +14,6 @@ jobs:
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true
-      BUILDEVENT_FILE: '../buildevents.txt'
       LANG: 'en_US.UTF-8'
     strategy:
       fail-fast: false
@@ -43,18 +38,6 @@ jobs:
           NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
           SSH_PASS: ${{ secrets.SSH_PASS }}
 
-      - name: "Honeycomb: Start recording"
-        uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
-        with:
-          apikey: ${{ env.HONEYCOMB_WRITEKEY }}
-          dataset: ${{ env.HONEYCOMB_DATASET }}
-          job-status: ${{ job.status }}
-
-      - name: "Honeycomb: Start first step"
-        run: |
-          echo STEP_ID=setup-test-cluster >> $GITHUB_ENV
-          echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
       - name: "Checkout Source"
         uses: actions/checkout@v2
 
@@ -68,16 +51,7 @@ jobs:
         if: ${{ github.repository_owner == 'puppetlabs' }}
         run: |
           echo ::group::info:bundler
-            buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
-          echo ::endgroup::
-
-      - name: "Honeycomb: Record environment setup time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Set up environment'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-provision >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
+            bundle env
           echo ::endgroup::
 
       - name: 'Provision test cluster'
@@ -88,16 +62,15 @@ jobs:
             echo 'Host *'                      >  $HOME/.ssh/config
             echo '    ServerAliveInterval 150' >> $HOME/.ssh/config
             echo '    ServerAliveCountMax 2'   >> $HOME/.ssh/config
-            buildevents cmd $TRACE_ID $STEP_ID 'rake spec_prep' -- bundle exec rake spec_prep
+            bundle exec rake spec_prep
           echo ::endgroup::
 
           echo ::group::provision
-            buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::provision_test_cluster' -- \
-              bundle exec bolt plan run peadm_spec::provision_test_cluster \
-                --modulepath spec/fixtures/modules \
-                provider=provision_service \
-                image=${{ matrix.image }} \
-                architecture=${{ matrix.architecture }}
+            bundle exec bolt plan run peadm_spec::provision_test_cluster \
+              --modulepath spec/fixtures/modules \
+              provider=provision_service \
+              image=${{ matrix.image }} \
+              architecture=${{ matrix.architecture }}
           echo ::endgroup::
 
           echo ::group::info:request
@@ -108,33 +81,14 @@ jobs:
             sed -e 's/password: .*/password: "[redacted]"/' < spec/fixtures/litmus_inventory.yaml || true
           echo ::endgroup::
 
-      - name: "Honeycomb: Record provision time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Provision test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-install >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
-
       - name: 'Install PE on test cluster'
         timeout-minutes: 120
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::install_test_cluster' -- \
-            bundle exec bolt plan run peadm_spec::install_test_cluster \
-              --inventoryfile spec/fixtures/litmus_inventory.yaml \
-              --modulepath spec/fixtures/modules \
-              architecture=${{ matrix.architecture }} \
-              version=${{ matrix.version }}
-
-      - name: "Honeycomb: Record install time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Install PE on test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-tear_down >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
+          bundle exec bolt plan run peadm_spec::install_test_cluster \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            architecture=${{ matrix.architecture }} \
+            version=${{ matrix.version }}
 
       - name: 'Wait as long as the file ${HOME}/pause file is present'
         if: ${{ always() && github.event.inputs.ssh-debugging == 'true' }}
@@ -148,22 +102,12 @@ jobs:
       - name: 'Upgrade PE on test cluster'
         timeout-minutes: 120
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::upgrade_test_cluster' -- \
-            bundle exec bolt plan run peadm_spec::upgrade_test_cluster \
-              --inventoryfile spec/fixtures/litmus_inventory.yaml \
-              --modulepath spec/fixtures/modules \
-              architecture=${{ matrix.architecture }} \
-              download_mode=${{ matrix.download_mode }} \
-              version=${{ matrix.version_to_upgrade }}
-
-      - name: "Honeycomb: Record upgrade time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Upgrade PE on test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.version_to_upgrade }}-tear_down >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
+          bundle exec bolt plan run peadm_spec::upgrade_test_cluster \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            architecture=${{ matrix.architecture }} \
+            download_mode=${{ matrix.download_mode }} \
+            version=${{ matrix.version_to_upgrade }}
 
       - name: 'Tear down test cluster'
         if: ${{ always() }}
@@ -171,17 +115,10 @@ jobs:
         run: |
           if [ -f spec/fixtures/litmus_inventory.yaml ]; then
             echo ::group::tear_down
-              buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
+              bundle exec rake 'litmus:tear_down'
             echo ::endgroup::
 
             echo ::group::info:request
               cat request.json || true; echo
             echo ::endgroup::
           fi
-
-      - name: "Honeycomb: Record tear down time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Tear down test cluster'
-          echo ::endgroup::

--- a/.github/workflows/test-upgrade.yaml
+++ b/.github/workflows/test-upgrade.yaml
@@ -33,10 +33,6 @@ on:
         required: true
         default: 'false'
 
-env:
-  HONEYCOMB_WRITEKEY: 7f3c63a70eecc61d635917de46bea4e6
-  HONEYCOMB_DATASET: litmus tests
-
 jobs:
   test-upgrade:
     name: "PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }}"
@@ -44,7 +40,6 @@ jobs:
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true
-      BUILDEVENT_FILE: '../buildevents.txt'
       LANG: 'en_US.UTF-8'
     strategy:
       fail-fast: false
@@ -68,18 +63,6 @@ jobs:
           NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
           SSH_PASS: ${{ secrets.SSH_PASS }}
 
-      - name: "Honeycomb: Start recording"
-        uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
-        with:
-          apikey: ${{ env.HONEYCOMB_WRITEKEY }}
-          dataset: ${{ env.HONEYCOMB_DATASET }}
-          job-status: ${{ job.status }}
-
-      - name: "Honeycomb: Start first step"
-        run: |
-          echo STEP_ID=setup-test-cluster >> $GITHUB_ENV
-          echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
       - name: "Checkout Source"
         uses: actions/checkout@v2
 
@@ -93,16 +76,7 @@ jobs:
         if: ${{ github.repository_owner == 'puppetlabs' }}
         run: |
           echo ::group::info:bundler
-            buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
-          echo ::endgroup::
-
-      - name: "Honeycomb: Record environment setup time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Set up environment'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-provision >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
+            bundle env
           echo ::endgroup::
 
       - name: 'Provision test cluster'
@@ -113,11 +87,10 @@ jobs:
             echo 'Host *'                      >  $HOME/.ssh/config
             echo '    ServerAliveInterval 150' >> $HOME/.ssh/config
             echo '    ServerAliveCountMax 2'   >> $HOME/.ssh/config
-            buildevents cmd $TRACE_ID $STEP_ID 'rake spec_prep' -- bundle exec rake spec_prep
+            bundle exec rake spec_prep
           echo ::endgroup::
 
           echo ::group::provision
-            buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::provision_test_cluster' -- \
               bundle exec bolt plan run peadm_spec::provision_test_cluster \
                 --modulepath spec/fixtures/modules \
                 provider=provision_service \
@@ -133,33 +106,14 @@ jobs:
             sed -e 's/password: .*/password: "[redacted]"/' < spec/fixtures/litmus_inventory.yaml || true
           echo ::endgroup::
 
-      - name: "Honeycomb: Record provision time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Provision test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-install >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
-
       - name: 'Install PE on test cluster'
         timeout-minutes: 120
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::install_test_cluster' -- \
-            bundle exec bolt plan run peadm_spec::install_test_cluster \
-              --inventoryfile spec/fixtures/litmus_inventory.yaml \
-              --modulepath spec/fixtures/modules \
-              architecture=${{ matrix.architecture }} \
-              version=${{ matrix.version }}
-
-      - name: "Honeycomb: Record install time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Install PE on test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.image }}-tear_down >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
+          bundle exec bolt plan run peadm_spec::install_test_cluster \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            architecture=${{ matrix.architecture }} \
+            version=${{ matrix.version }}
 
       - name: 'Wait as long as the file ${HOME}/pause file is present'
         if: ${{ always() && github.event.inputs.ssh-debugging == 'true' }}
@@ -173,22 +127,12 @@ jobs:
       - name: 'Upgrade PE on test cluster'
         timeout-minutes: 120
         run: |
-          buildevents cmd $TRACE_ID $STEP_ID 'bolt plan run peadm_spec::upgrade_test_cluster' -- \
-            bundle exec bolt plan run peadm_spec::upgrade_test_cluster \
-              --inventoryfile spec/fixtures/litmus_inventory.yaml \
-              --modulepath spec/fixtures/modules \
-              architecture=${{ matrix.architecture }} \
-              download_mode=${{ matrix.download_mode }} \
-              version=${{ matrix.version_to_upgrade }}
-
-      - name: "Honeycomb: Record upgrade time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Upgrade PE on test cluster'
-            echo STEP_ID=${{ matrix.architecture }}-${{ matrix.version_to_upgrade }}-tear_down >> $GITHUB_ENV
-            echo STEP_START=$(date +%s) >> $GITHUB_ENV
-          echo ::endgroup::
+          bundle exec bolt plan run peadm_spec::upgrade_test_cluster \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            architecture=${{ matrix.architecture }} \
+            download_mode=${{ matrix.download_mode }} \
+            version=${{ matrix.version_to_upgrade }}
 
       - name: 'Tear down test cluster'
         if: ${{ always() }}
@@ -196,17 +140,10 @@ jobs:
         run: |
           if [ -f spec/fixtures/litmus_inventory.yaml ]; then
             echo ::group::tear_down
-              buildevents cmd $TRACE_ID $STEP_ID 'rake litmus:tear_down' -- bundle exec rake 'litmus:tear_down'
+              bundle exec rake 'litmus:tear_down'
             echo ::endgroup::
 
             echo ::group::info:request
               cat request.json || true; echo
             echo ::endgroup::
           fi
-
-      - name: "Honeycomb: Record tear down time"
-        if: ${{ always() }}
-        run: |
-          echo ::group::honeycomb
-            buildevents step $TRACE_ID $STEP_ID $STEP_START 'Tear down test cluster'
-          echo ::endgroup::


### PR DESCRIPTION
Removed HoneyComb from each of the Github Actions workflows, as we are not using it in our modules any longer.

