### PR TITLE
Fix for plan peadm::add_compiler over pcp transport

### DIFF
--- a/plans/add_compiler.pp
+++ b/plans/add_compiler.pp
@@ -72,7 +72,7 @@ plan peadm::add_compiler(
 
   # Install agent (if required) and regenerate agent certificate to add required data with peadm::subplans::component_install
   run_plan('peadm::subplans::component_install', $compiler_target,
-    primary_host       => $primary_host,
+    primary_host       => $primary_target,
     avail_group_letter => $avail_group_letter,
     dns_alt_names      => $dns_alt_names,
     role               => 'pe_compiler',

--- a/plans/add_compiler.pp
+++ b/plans/add_compiler.pp
@@ -70,7 +70,7 @@ plan peadm::add_compiler(
   # Reload pe-postgresql.service
   run_command('systemctl reload pe-postgresql.service', $primary_postgresql_target)
 
-  # Install agent (if required) and regenerate agent certificate with peadm::subplans::component_install
+  # Install agent (if required) and regenerate agent certificate to add required data with peadm::subplans::component_install
   run_plan('peadm::subplans::component_install', $compiler_target,
     primary_host       => $primary_host,
     avail_group_letter => $avail_group_letter,
@@ -90,7 +90,7 @@ plan peadm::add_compiler(
   # On <primary_postgresql_host> run the puppet agent
   run_task('peadm::puppet_runonce', $primary_postgresql_target)
 
-  # On replica puppetdb
+  # On replica puppetdb run the puppet agent
   run_task('peadm::puppet_runonce', $replica_puppetdb_target)
 
   # On <primary_postgresql_host> start puppet.service

--- a/plans/add_compiler.pp
+++ b/plans/add_compiler.pp
@@ -88,10 +88,10 @@ plan peadm::add_compiler(
   run_task('peadm::puppet_runonce', $compiler_target)
 
   # On <primary_postgresql_host> run the puppet agent
-  run_task('peadm::puppet_runonce', peadm::flatten_compact([
-        $primary_postgresql_target,
-        $replica_puppetdb_target,
-  ]))
+  run_task('peadm::puppet_runonce', $primary_postgresql_target)
+
+  # On replica puppetdb
+  run_task('peadm::puppet_runonce', $replica_puppetdb_target)
 
   # On <primary_postgresql_host> start puppet.service
   run_command('systemctl start puppet.service', peadm::flatten_compact([

--- a/plans/subplans/prepare_agent.pp
+++ b/plans/subplans/prepare_agent.pp
@@ -87,6 +87,7 @@ plan peadm::subplans::prepare_agent (
   run_plan('peadm::modify_certificate', $agent_target,
     primary_host     => $primary_target,
     add_extensions   => $certificate_extensions,
+    dns_alt_names    => $dns_alt_names,
     force_regenerate => $force_regenerate
   )
 }

--- a/spec/plans/add_compiler_spec.rb
+++ b/spec/plans/add_compiler_spec.rb
@@ -36,19 +36,17 @@ describe 'peadm::add_compiler' do
 
     it 'runs successfully when no alt-names are specified' do
       allow_standard_non_returning_calls
+
       expect_task('peadm::get_peadm_config').always_return(cfg)
-      expect_plan('peadm::modify_certificate').always_return('mock' => 'mock')
-      expect_task('peadm::agent_install')
-        .with_params({ 'server'        => 'primary',
-                       'install_flags' => [
-                         '--puppet-service-ensure', 'stopped',
-                         'main:certname=compiler'
-                       ] })
-
-      # {"install_flags"=>
-      #   ["--puppet-service-ensure", "stopped",
-      #   "extension_requests:1.3.6.1.4.1.34380.1.3.13=pe_compiler", "extension_requests:1.3.6.1.4.1.34380.1.1.9813=A", "main:certname=compiler"], "server"=>"primary"}
-
+      # TODO: Due to difficulty mocking get_targets, with_params modifier has been commented out
+      expect_plan('peadm::subplans::component_install')
+        # .with_params({
+        #   'targets'            => 'compiler',
+        #   'primary_host'       => 'primary',
+        #   'avail_group_letter' => 'A',
+        #   'dns_alt_names'      => nil,
+        #   'role'               => 'pe_compiler'
+        # })
       expect_plan('peadm::util::copy_file').be_called_times(1)
       expect(run_plan('peadm::add_compiler', params)).to be_ok
     end
@@ -61,14 +59,15 @@ describe 'peadm::add_compiler' do
       it 'runs successfully when alt-names are specified' do
         allow_standard_non_returning_calls
         expect_task('peadm::get_peadm_config').always_return(cfg)
-        expect_plan('peadm::modify_certificate').always_return('mock' => 'mock')
-        expect_task('peadm::agent_install')
-          .with_params({ 'server'        => 'primary',
-                         'install_flags' => [
-                           'main:dns_alt_names=foo,bar',
-                           '--puppet-service-ensure', 'stopped',
-                           'main:certname=compiler'
-                         ] })
+        # TODO: Due to difficulty mocking get_targets, with_params modifier has been commented out
+        expect_plan('peadm::subplans::component_install')
+          # .with_params({
+          #   'targets'            => 'compiler',
+          #   'primary_host'       => 'primary',
+          #   'avail_group_letter' => 'A',
+          #   'dns_alt_names'      => 'foo,bar',
+          #   'role'               => 'pe_compiler'
+          # })
         expect_plan('peadm::util::copy_file').be_called_times(1)
         expect(run_plan('peadm::add_compiler', params2)).to be_ok
       end

--- a/spec/plans/add_compiler_spec.rb
+++ b/spec/plans/add_compiler_spec.rb
@@ -38,15 +38,17 @@ describe 'peadm::add_compiler' do
       allow_standard_non_returning_calls
 
       expect_task('peadm::get_peadm_config').always_return(cfg)
+
       # TODO: Due to difficulty mocking get_targets, with_params modifier has been commented out
       expect_plan('peadm::subplans::component_install')
-        # .with_params({
-        #   'targets'            => 'compiler',
-        #   'primary_host'       => 'primary',
-        #   'avail_group_letter' => 'A',
-        #   'dns_alt_names'      => nil,
-        #   'role'               => 'pe_compiler'
-        # })
+      # .with_params({
+      #   'targets'            => 'compiler',
+      #   'primary_host'       => 'primary',
+      #   'avail_group_letter' => 'A',
+      #   'dns_alt_names'      => nil,
+      #   'role'               => 'pe_compiler'
+      # })
+
       expect_plan('peadm::util::copy_file').be_called_times(1)
       expect(run_plan('peadm::add_compiler', params)).to be_ok
     end
@@ -59,15 +61,17 @@ describe 'peadm::add_compiler' do
       it 'runs successfully when alt-names are specified' do
         allow_standard_non_returning_calls
         expect_task('peadm::get_peadm_config').always_return(cfg)
+
         # TODO: Due to difficulty mocking get_targets, with_params modifier has been commented out
         expect_plan('peadm::subplans::component_install')
-          # .with_params({
-          #   'targets'            => 'compiler',
-          #   'primary_host'       => 'primary',
-          #   'avail_group_letter' => 'A',
-          #   'dns_alt_names'      => 'foo,bar',
-          #   'role'               => 'pe_compiler'
-          # })
+        # .with_params({
+        #   'targets'            => 'compiler',
+        #   'primary_host'       => 'primary',
+        #   'avail_group_letter' => 'A',
+        #   'dns_alt_names'      => 'foo,bar',
+        #   'role'               => 'pe_compiler'
+        # })
+
         expect_plan('peadm::util::copy_file').be_called_times(1)
         expect(run_plan('peadm::add_compiler', params2)).to be_ok
       end


### PR DESCRIPTION
The plan `peadm::add_compiler` has been updated to make use of the `peadm::subplans::component_install` so that it doesn't error when run over PCP transport.  This also makes the management of the agent installation consistent with `peadm::add_database` and `peadm::add_replica` plans.

In addition, updates were made to `peadm::subplans::component_install` as the trusted facts set for compilers are different to other Puppet infrastructure roles and updates were made to `peadm::subplan::agent_install` to add dns-alt-names to the certificate if provided. 

Closes #355 