### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @puppetlabs/solutions-architecture @puppetlabs/nimbus
+*       @puppetlabs/solutions-architecture @puppetlabs/nimbus @bastelfreak


### PR DESCRIPTION
Adding Trusted Contributors to the CODEOWNERS will allow them to meet our branch protection rules and merge pull requests. If you would rather keep that privilege for your own team, then you can decline this PR.