### PR TITLE
(PE-36172) Fixing issues related to stdlib changes

### DIFF
--- a/.github/workflows/test-install-latest-xlarge-dev-nightly.yaml
+++ b/.github/workflows/test-install-latest-xlarge-dev-nightly.yaml
@@ -5,6 +5,11 @@ on:
   schedule:
     - cron: '0 3 * * *'
   workflow_dispatch:
+    inputs:
+      ssh-debugging:
+        description: 'Boolean; whether or not to pause for ssh debugging'
+        required: true
+        default: 'false'
 
 jobs:
   test-install:
@@ -23,6 +28,13 @@ jobs:
           - 'almalinux-cloud/almalinux-8'
 
     steps:
+      - name: 'Start SSH session'
+        if: ${{ github.event.inputs.ssh-debugging == 'true' }}
+        uses: luchihoratiu/debug-via-ssh@main
+        with:
+          NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
+          SSH_PASS: ${{ secrets.SSH_PASS }}
+
       - name: "Checkout Source"
         uses: actions/checkout@v2
 

--- a/functions/determine_status.pp
+++ b/functions/determine_status.pp
@@ -48,12 +48,12 @@
 function peadm::determine_status(Array $status_data, Boolean $use_colors = true) >> Hash {
   # convert the data into a hash with the sevice names as the keys
   $hash_data = $status_data.reduce({}) | $res, $data | {
-    $res.merge({ $data[service] => $data })
+    stdlib::merge($res, { $data[service] => $data })
   }
   $out = $hash_data.reduce({}) | $res, $svc_data | {
     $service_name = $svc_data[0]
     $server = $svc_data[1][server]
-    $res.merge("${service_name}/${$server}" => $svc_data[1][state] == 'running')
+    stdlib::merge($res, { "${service_name}/${server}" => $svc_data[1][state] == 'running' })
   }
   $bad_status = $out.filter | $item | { ! $item[1] }
   $passed_status = $out.filter | $item | { $item[1] }

--- a/functions/generate_pe_conf.pp
+++ b/functions/generate_pe_conf.pp
@@ -14,7 +14,7 @@ function peadm::generate_pe_conf (
 
   # Remove anything that is undef, then output to JSON (and therefore HOCON,
   # because HOCON is a superset of JSON)
-  $settings.filter |$key,$value| {
+  stdlib::to_json_pretty($settings.filter |$key,$value| {
     $value != undef
-  }.to_json_pretty()
-}
+  })
+  }

--- a/metadata.json
+++ b/metadata.json
@@ -77,7 +77,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.2 < 8.0.0"
+      "version_requirement": ">= 6.0.2 < 9.0.0"
     }
   ],
   "pdk-version": "2.6.1",

--- a/plans/add_database.pp
+++ b/plans/add_database.pp
@@ -199,7 +199,7 @@ plan peadm::add_database(
 
   run_task('peadm::mkdir_p_file', $postgresql_target,
     path    => '/etc/puppetlabs/enterprise/conf.d/pe.conf',
-    content => ($pe_conf.parsejson()).to_json_pretty(),
+    content => stdlib::to_json_pretty($pe_conf.parsejson()),
   )
 
   # Start frontend compiler services so catalogs can once again be compiled by

--- a/plans/status.pp
+++ b/plans/status.pp
@@ -21,8 +21,8 @@ plan peadm::status(
   $stack_status = $results.reduce({}) | $res, $item | {
     $data = $item.value[output]
     $stack_name = $item.target.peadm::certname()
-    $status = peadm::determine_status($data, $colors).merge(stack_name => $stack_name )
-    $res.merge({ $stack_name => $status })
+    $status = stdlib::merge(peadm::determine_status($data, $colors), { stack_name => $stack_name })
+    stdlib::merge($res, { $stack_name => $status })
   }
 
   $overall_degraded_stacks = $stack_status.filter | $item | { $item[1][status] =~ /degraded/ }
@@ -45,7 +45,7 @@ plan peadm::status(
   $passed_table_rows = $overall_passed_stacks.map | $item | { [$item[0], $item[1][status]] }
 
   # produce array of degraded or failed services
-  $bad_svc_rows = $overall_failed_stacks.merge($overall_degraded_stacks).map | $item | {
+  $bad_svc_rows = stdlib::merge($overall_failed_stacks, $overall_degraded_stacks).map | $item | {
     $item[1][failed].map | $svc | {
       [$item[0], *$svc[0].split('/'), peadm::convert_status($svc[1], undef, $colors)]
     }

--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -396,7 +396,7 @@ plan peadm::subplans::install (
 
     run_task('peadm::mkdir_p_file', $target,
       path    => '/etc/puppetlabs/enterprise/conf.d/pe.conf',
-      content => ($pe_conf.parsejson() - $puppetdb_database_temp_config).to_json_pretty(),
+      content => stdlib::to_json_pretty($pe_conf.parsejson() - $puppetdb_database_temp_config),
     )
   }
 

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -197,14 +197,14 @@ plan peadm::upgrade (
         path => '/etc/puppetlabs/enterprise/conf.d/pe.conf',
       ).first['content']
 
-      $pe_conf = ($current_pe_conf ? {
+      $pe_conf = stdlib::to_json_pretty($current_pe_conf ? {
           undef   => {},
-          default => $current_pe_conf.parsehocon(),
+          default => stdlib::parsehocon($current_pe_conf),
         } + {
           'console_admin_password'                => 'not used',
           'puppet_enterprise::puppet_master_host' => $primary_target.peadm::certname(),
           'puppet_enterprise::database_host'      => $target.peadm::certname(),
-      } + $profile_database_puppetdb_hosts).to_json_pretty()
+      } + $profile_database_puppetdb_hosts)
 
       write_file($pe_conf, '/etc/puppetlabs/enterprise/conf.d/pe.conf', $target)
     }

--- a/plans/util/insert_csr_extension_requests.pp
+++ b/plans/util/insert_csr_extension_requests.pp
@@ -22,7 +22,7 @@ plan peadm::util::insert_csr_extension_requests (
 
     run_task('peadm::mkdir_p_file', $target,
       path    => '/etc/puppetlabs/puppet/csr_attributes.yaml',
-      content => $csr_file_data.to_yaml,
+      content => stdlib::to_yaml($csr_file_data),
     )
   }
 }


### PR DESCRIPTION
As stdlib had updated, some methods that we are using had been deprecated. I've updated to_json_pretty, merge, to_yaml, parsehocon as well as adjusted the metadata to include Puppet8 meaning that it will now be included in the test matrix.