### PR TITLE
(PE-35908) Optimize the full CI test to only trigger on code

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -5,6 +5,26 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
   pull_request:
+    paths:
+      - '.github/workflows/**/*'
+      - 'spec/**/*'
+      - 'lib/**/*'
+      - 'tasks/**/*'
+      - 'functions/**/*'
+      - 'types/**/*'
+      - 'plans/**/*'
+      - 'hiera/**/*'
+      - 'manifests/**/*'
+      - 'templates/**/*'
+      - 'files/**/*'
+      - 'metadata.json'
+      - 'Rakefile'
+      - 'Gemfile'
+      - 'provision.yaml'
+      - '.rspec'
+      - '.rubocop.yml'
+      - '.puppet-lint.rc'
+      - '.fixtures.yml'
 
 jobs:
   setup_matrix:

--- a/.github/workflows/test-fips-install-matrix.yaml
+++ b/.github/workflows/test-fips-install-matrix.yaml
@@ -3,6 +3,26 @@ name: "Install fips test matrix"
 
 on:
   pull_request:
+    paths:
+      - '.github/workflows/**/*'
+      - 'spec/**/*'
+      - 'lib/**/*'
+      - 'tasks/**/*'
+      - 'functions/**/*'
+      - 'types/**/*'
+      - 'plans/**/*'
+      - 'hiera/**/*'
+      - 'manifests/**/*'
+      - 'templates/**/*'
+      - 'files/**/*'
+      - 'metadata.json'
+      - 'Rakefile'
+      - 'Gemfile'
+      - 'provision.yaml'
+      - '.rspec'
+      - '.rubocop.yml'
+      - '.puppet-lint.rc'
+      - '.fixtures.yml'
     branches: [main]
     types: [review_requested]
   workflow_dispatch: {}
@@ -83,7 +103,7 @@ jobs:
             --modulepath spec/fixtures/modules \
             architecture=${{ matrix.architecture }} \
             version=${{ matrix.version }} \
-            fips=${{ matrix.fips }} 
+            fips=${{ matrix.fips }}
 
       - name: 'Tear down test cluster'
         if: ${{ always() }}

--- a/.github/workflows/test-install-matrix.yaml
+++ b/.github/workflows/test-install-matrix.yaml
@@ -3,6 +3,26 @@ name: "Install test matrix"
 
 on:
   pull_request:
+    paths:
+      - '.github/workflows/**/*'
+      - 'spec/**/*'
+      - 'lib/**/*'
+      - 'tasks/**/*'
+      - 'functions/**/*'
+      - 'types/**/*'
+      - 'plans/**/*'
+      - 'hiera/**/*'
+      - 'manifests/**/*'
+      - 'templates/**/*'
+      - 'files/**/*'
+      - 'metadata.json'
+      - 'Rakefile'
+      - 'Gemfile'
+      - 'provision.yaml'
+      - '.rspec'
+      - '.rubocop.yml'
+      - '.puppet-lint.rc'
+      - '.fixtures.yml'
     branches: [main]
     types: [review_requested]
   workflow_dispatch: {}

--- a/.github/workflows/test-upgrade-matrix.yaml
+++ b/.github/workflows/test-upgrade-matrix.yaml
@@ -3,6 +3,27 @@ name: "Upgrade test matrix"
 
 on:
   pull_request:
+    paths:
+      - '.github/workflows/**/*'
+      - 'spec/**/*'
+      - 'lib/**/*'
+      - 'tasks/**/*'
+      - 'functions/**/*'
+      - 'types/**/*'
+      - 'plans/**/*'
+      - 'hiera/**/*'
+      - 'manifests/**/*'
+      - 'templates/**/*'
+      - 'files/**/*'
+      - 'metadata.json'
+      - 'Rakefile'
+      - 'Gemfile'
+      - 'provision.yaml'
+      - '.rspec'
+      - '.rubocop.yml'
+      - '.puppet-lint.rc'
+      - '.fixtures.yml'
+
     branches: [main]
     types: [review_requested]
   workflow_dispatch: {}
@@ -96,7 +117,7 @@ jobs:
           while [ -f "${HOME}/pause" ] ; do
             echo "${HOME}/pause present, sleeping for 60 seconds..."
             sleep 60
-          done 
+          done
           echo "${HOME}/pause absent, continuing workflow."
 
       - name: 'Upgrade PE on test cluster'


### PR DESCRIPTION
As the title says, we only need to run our tests only when code is changed in the repo. Hence, I added all the paths that have code files in them to be checked on pull_requests.