### PR TITLE
(PE-36173) PE-ADM Merge Twingate change back to main

### DIFF
--- a/.github/workflows/test-install-latest-dev.yaml
+++ b/.github/workflows/test-install-latest-dev.yaml
@@ -13,7 +13,7 @@ on:
         required: true
         default: 'standard'
         description: 'PE architecture to test'
-        options: 
+        options:
         - standard
         - standard-with-dr
         - large
@@ -93,7 +93,7 @@ jobs:
           echo ::endgroup::
 
       - name: 'Activate twingate to obtain unreleased build'
-        uses: timidri/twingate-github-action@main
+        uses: twingate/github-action@v1 # Change the version to the release that contains the sleep command
         with:
           service-key: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
 
@@ -119,7 +119,7 @@ jobs:
           while [ -f "${HOME}/pause" ] ; do
             echo "${HOME}/pause present, sleeping for 60 seconds..."
             sleep 60
-          done 
+          done
           echo "${HOME}/pause absent, continuing workflow."
 
       - name: 'Tear down test cluster'

--- a/.github/workflows/test-install-latest-xlarge-dev-nightly.yaml
+++ b/.github/workflows/test-install-latest-xlarge-dev-nightly.yaml
@@ -79,7 +79,7 @@ jobs:
           echo ::endgroup::
 
       - name: 'Activate twingate to obtain unreleased build'
-        uses: timidri/twingate-github-action@main
+        uses: twingate/github-action@v1 # Change the version to the release that contains the sleep command
         with:
           service-key: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
 
@@ -105,7 +105,7 @@ jobs:
           while [ -f "${HOME}/pause" ] ; do
             echo "${HOME}/pause present, sleeping for 60 seconds..."
             sleep 60
-          done 
+          done
           echo "${HOME}/pause absent, continuing workflow."
 
       - name: 'Tear down test cluster'

--- a/.github/workflows/test-upgrade-latest-dev.yaml
+++ b/.github/workflows/test-upgrade-latest-dev.yaml
@@ -13,7 +13,7 @@ on:
         required: true
         default: 'standard'
         description: 'PE architecture to test'
-        options: 
+        options:
         - standard
         - standard-with-dr
         - large
@@ -114,11 +114,11 @@ jobs:
           while [ -f "${HOME}/pause" ] ; do
             echo "${HOME}/pause present, sleeping for 60 seconds..."
             sleep 60
-          done 
+          done
           echo "${HOME}/pause absent, continuing workflow."
 
       - name: 'Activate twingate to obtain unreleased build'
-        uses: timidri/twingate-github-action@main
+        uses: twingate/github-action@v1 # Change the version to the release that contains the sleep command
         with:
           service-key: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
 

--- a/.github/workflows/test-upgrade-latest-xlarge-dev-nightly.yaml
+++ b/.github/workflows/test-upgrade-latest-xlarge-dev-nightly.yaml
@@ -77,7 +77,7 @@ jobs:
             version=${{ matrix.version }}
 
       - name: 'Activate twingate to obtain unreleased build'
-        uses: timidri/twingate-github-action@main
+        uses: twingate/github-action@v1 # Change the version to the release that contains the sleep command
         with:
           service-key: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
 


### PR DESCRIPTION
When and if the following PR is merged, we can start using the twingate action directly from the official repository.
PR: https://github.com/Twingate/github-action/pull/3

This pr might need to be updated to use the version which includes our changes.