### PR TITLE
(MAINT) Stop CI from triggering twice

### DIFF
--- a/.github/workflows/test-fips-install-matrix.yaml
+++ b/.github/workflows/test-fips-install-matrix.yaml
@@ -24,7 +24,6 @@ on:
       - '.puppet-lint.rc'
       - '.fixtures.yml'
     branches: [main]
-    types: [review_requested]
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/test-install-matrix.yaml
+++ b/.github/workflows/test-install-matrix.yaml
@@ -24,7 +24,6 @@ on:
       - '.puppet-lint.rc'
       - '.fixtures.yml'
     branches: [main]
-    types: [review_requested]
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/test-upgrade-matrix.yaml
+++ b/.github/workflows/test-upgrade-matrix.yaml
@@ -25,7 +25,6 @@ on:
       - '.fixtures.yml'
 
     branches: [main]
-    types: [review_requested]
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
CI was triggering both on open and review request when you were creating a PR