### PR TITLE
puppetlabs/stdlib: Require 9.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 8.6.0 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     },
     {
       "name": "WhatsARanjit/node_manager",


### PR DESCRIPTION
https://github.com/puppetlabs/puppetlabs-peadm/commit/8016fbea77e32255b3ff89d80f38e82e3b72e8d2 introduced a few functions calls that are only available in stdlib 9 and newer.