### PR TITLE
keyserver port 80 less likely to be blocked

### DIFF
--- a/tasks/download.json
+++ b/tasks/download.json
@@ -17,7 +17,7 @@
     "key_server": {
       "type": "String",
       "description": "The GPG keyserver to retrieve GPG keys from",
-      "default": "hkp://keyserver.ubuntu.com:11371"
+      "default": "hkp://keyserver.ubuntu.com:80"
     }
   },
   "input_method": "environment",


### PR DESCRIPTION
security teams frequently overlook allowing the standard pgpkeyserver port
fortunately the ubuntu keyserver also responds on port 80