### PR TITLE
change default pe tarball paths

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1552,6 +1552,7 @@ The following parameters are available in the `peadm::install` plan:
 * [`license_key_file`](#-peadm--install--license_key_file)
 * [`license_key_content`](#-peadm--install--license_key_content)
 * [`stagingdir`](#-peadm--install--stagingdir)
+* [`uploaddir`](#-peadm--install--uploaddir)
 * [`download_mode`](#-peadm--install--download_mode)
 * [`permit_unsafe_versions`](#-peadm--install--permit_unsafe_versions)
 * [`token_lifetime`](#-peadm--install--token_lifetime)
@@ -1748,6 +1749,14 @@ Data type: `Optional[String]`
 
 Default value: `undef`
 
+##### <a name="-peadm--install--uploaddir"></a>`uploaddir`
+
+Data type: `Optional[String]`
+
+
+
+Default value: `undef`
+
 ##### <a name="-peadm--install--download_mode"></a>`download_mode`
 
 Data type: `Enum['direct', 'bolthost']`
@@ -1913,6 +1922,7 @@ The following parameters are available in the `peadm::upgrade` plan:
 * [`version`](#-peadm--upgrade--version)
 * [`token_file`](#-peadm--upgrade--token_file)
 * [`stagingdir`](#-peadm--upgrade--stagingdir)
+* [`uploaddir`](#-peadm--upgrade--uploaddir)
 * [`download_mode`](#-peadm--upgrade--download_mode)
 * [`permit_unsafe_versions`](#-peadm--upgrade--permit_unsafe_versions)
 * [`begin_at_step`](#-peadm--upgrade--begin_at_step)
@@ -2026,7 +2036,15 @@ Data type: `String`
 
 
 
-Default value: `'/tmp'`
+Default value: `'/var/tmp'`
+
+##### <a name="-peadm--upgrade--uploaddir"></a>`uploaddir`
+
+Data type: `String`
+
+
+
+Default value: `'/var/tmp'`
 
 ##### <a name="-peadm--upgrade--download_mode"></a>`download_mode`
 

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -61,6 +61,7 @@ plan peadm::install (
 
   # Other
   Optional[String]           $stagingdir             = undef,
+  Optional[String]           $uploaddir              = undef,
   Enum['running', 'stopped'] $final_agent_state      = 'running',
   Enum['direct', 'bolthost'] $download_mode          = 'bolthost',
   Boolean                    $permit_unsafe_versions = false,
@@ -101,6 +102,7 @@ plan peadm::install (
 
     # Other
     stagingdir                     => $stagingdir,
+    uploaddir                      => $uploaddir,
     download_mode                  => $download_mode,
     permit_unsafe_versions         => $permit_unsafe_versions,
     token_lifetime                 => $token_lifetime,

--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -56,7 +56,8 @@ plan peadm::subplans::install (
   Optional[String]     $license_key_content = undef,
 
   # Other
-  String                $stagingdir             = '/tmp',
+  String                $stagingdir             = '/var/tmp',
+  String                $uploaddir              = '/var/tmp',
   Enum[direct,bolthost] $download_mode          = 'bolthost',
   Boolean               $permit_unsafe_versions = false,
   String                $token_lifetime         = '1y',
@@ -211,7 +212,7 @@ plan peadm::subplans::install (
     $pe_tarball_source = "https://s3.amazonaws.com/pe-builds/released/${version}/${pe_tarball_name}"
   }
 
-  $upload_tarball_path = "/tmp/${pe_tarball_name}"
+  $upload_tarball_path = "${uploaddir}/${pe_tarball_name}"
 
   if $download_mode == 'bolthost' {
     # Download the PE tarball and send it to the nodes that need it

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -41,7 +41,8 @@ plan peadm::upgrade (
 
   # Other
   Optional[String]           $token_file             = undef,
-  String                     $stagingdir             = '/tmp',
+  String                     $stagingdir             = '/var/tmp',
+  String                     $uploaddir              = '/var/tmp',
   Enum['running', 'stopped'] $final_agent_state      = 'running',
   Enum[direct,bolthost]      $download_mode          = 'bolthost',
   Boolean                    $permit_unsafe_versions = false,
@@ -112,7 +113,7 @@ plan peadm::upgrade (
     $pe_tarball_source = "https://s3.amazonaws.com/pe-builds/released/${_version}/${pe_tarball_name}"
   }
 
-  $upload_tarball_path = "/tmp/${pe_tarball_name}"
+  $upload_tarball_path = "${uploaddir}/${pe_tarball_name}"
 
   peadm::assert_supported_bolt_version()
 


### PR DESCRIPTION
Changes stagingdir default to /var/tmp and adds uploaddir param for the same purpose on targets. Using /tmp for very large files can be problematic as it is memory backed and typically not limited by default. With ~1.4G used by the PE installer, unexpected bolt failures on systems with low to no swap occur (high performance or containers).