### PR TITLE
(PE-36836) Twingate retry connection

### DIFF
--- a/.github/workflows/test-install-latest-dev.yaml
+++ b/.github/workflows/test-install-latest-dev.yaml
@@ -5,25 +5,25 @@ on:
   workflow_dispatch:
     inputs:
       image:
-        description: 'GCP image for test cluster'
+        description: "GCP image for test cluster"
         required: true
-        default: 'almalinux-cloud/almalinux-8'
+        default: "almalinux-cloud/almalinux-8"
       architecture:
         type: choice
         required: true
-        default: 'standard'
-        description: 'PE architecture to test'
-        options: 
-        - standard
-        - standard-with-dr
-        - large
-        - large-with-dr
-        - extra-large
-        - extra-large-with-dr
+        default: "standard"
+        description: "PE architecture to test"
+        options:
+          - standard
+          - standard-with-dr
+          - large
+          - large-with-dr
+          - extra-large
+          - extra-large-with-dr
       ssh-debugging:
-        description: 'Boolean; whether or not to pause for ssh debugging'
+        description: "Boolean; whether or not to pause for ssh debugging"
         required: true
-        default: 'false'
+        default: "false"
 
 jobs:
   test-install:
@@ -32,7 +32,7 @@ jobs:
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true
-      LANG: 'en_US.UTF-8'
+      LANG: "en_US.UTF-8"
     strategy:
       fail-fast: false
       matrix:
@@ -42,7 +42,7 @@ jobs:
           - "${{ github.event.inputs.image }}"
 
     steps:
-      - name: 'Start SSH session'
+      - name: "Start SSH session"
         if: ${{ github.event.inputs.ssh-debugging == 'true' }}
         uses: luchihoratiu/debug-via-ssh@main
         with:
@@ -65,7 +65,7 @@ jobs:
             bundle env
           echo ::endgroup::
 
-      - name: 'Provision test cluster'
+      - name: "Provision test cluster"
         timeout-minutes: 15
         run: |
           echo ::group::prepare
@@ -92,17 +92,17 @@ jobs:
             sed -e 's/password: .*/password: "[redacted]"/' < spec/fixtures/litmus_inventory.yaml || true
           echo ::endgroup::
 
-      - name: 'Activate twingate to obtain unreleased build'
-        uses: timidri/twingate-github-action@main
+      - name: "Activate twingate to obtain unreleased build"
+        uses: comfucios/twingate-github-action@main
         with:
           service-key: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
 
-      - name: 'Get latest build name'
+      - name: "Get latest build name"
         id: latest
         run: |
           echo "::set-output name=ver::$(curl -q https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/main/ci-ready/LATEST)"
 
-      - name: 'Install PE on test cluster'
+      - name: "Install PE on test cluster"
         timeout-minutes: 120
         run: |
           bundle exec bolt plan run peadm_spec::install_test_cluster \
@@ -113,16 +113,16 @@ jobs:
             architecture=${{ matrix.architecture }} \
             pe_installer_source="https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/main/ci-ready/puppet-enterprise-${{ steps.latest.outputs.ver }}-el-8-x86_64.tar"
 
-      - name: 'Wait as long as the file ${HOME}/pause file is present'
+      - name: "Wait as long as the file ${HOME}/pause file is present"
         if: ${{ always() && github.event.inputs.ssh-debugging == 'true' }}
         run: |
           while [ -f "${HOME}/pause" ] ; do
             echo "${HOME}/pause present, sleeping for 60 seconds..."
             sleep 60
-          done 
+          done
           echo "${HOME}/pause absent, continuing workflow."
 
-      - name: 'Tear down test cluster'
+      - name: "Tear down test cluster"
         if: ${{ always() }}
         continue-on-error: true
         run: |

--- a/.github/workflows/test-install-latest-xlarge-dev-nightly.yaml
+++ b/.github/workflows/test-install-latest-xlarge-dev-nightly.yaml
@@ -3,13 +3,13 @@ name: "Install latest dev test nightly"
 
 on:
   schedule:
-    - cron: '0 3 * * *'
+    - cron: "0 3 * * *"
   workflow_dispatch:
     inputs:
       ssh-debugging:
-        description: 'Boolean; whether or not to pause for ssh debugging'
+        description: "Boolean; whether or not to pause for ssh debugging"
         required: true
-        default: 'false'
+        default: "false"
 
 jobs:
   test-install:
@@ -18,17 +18,17 @@ jobs:
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true
-      LANG: 'en_US.UTF-8'
+      LANG: "en_US.UTF-8"
     strategy:
       fail-fast: false
       matrix:
         architecture:
-          - 'extra-large-with-dr'
+          - "extra-large-with-dr"
         image:
-          - 'almalinux-cloud/almalinux-8'
+          - "almalinux-cloud/almalinux-8"
 
     steps:
-      - name: 'Start SSH session'
+      - name: "Start SSH session"
         if: ${{ github.event.inputs.ssh-debugging == 'true' }}
         uses: luchihoratiu/debug-via-ssh@main
         with:
@@ -51,7 +51,7 @@ jobs:
             bundle env
           echo ::endgroup::
 
-      - name: 'Provision test cluster'
+      - name: "Provision test cluster"
         timeout-minutes: 15
         run: |
           echo ::group::prepare
@@ -78,17 +78,17 @@ jobs:
             sed -e 's/password: .*/password: "[redacted]"/' < spec/fixtures/litmus_inventory.yaml || true
           echo ::endgroup::
 
-      - name: 'Activate twingate to obtain unreleased build'
-        uses: timidri/twingate-github-action@main
+      - name: "Activate twingate to obtain unreleased build"
+        uses: comfucios/twingate-github-action@main
         with:
           service-key: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
 
-      - name: 'Get latest build name'
+      - name: "Get latest build name"
         id: latest
         run: |
           echo "::set-output name=ver::$(curl -q https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/main/ci-ready/LATEST)"
 
-      - name: 'Install PE on test cluster'
+      - name: "Install PE on test cluster"
         timeout-minutes: 120
         run: |
           bundle exec bolt plan run peadm_spec::install_test_cluster \
@@ -99,16 +99,16 @@ jobs:
             architecture=${{ matrix.architecture }} \
             pe_installer_source="https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/main/ci-ready/puppet-enterprise-${{ steps.latest.outputs.ver }}-el-8-x86_64.tar"
 
-      - name: 'Wait as long as the file ${HOME}/pause file is present'
+      - name: "Wait as long as the file ${HOME}/pause file is present"
         if: ${{ always() && github.event.inputs.ssh-debugging == 'true' }}
         run: |
           while [ -f "${HOME}/pause" ] ; do
             echo "${HOME}/pause present, sleeping for 60 seconds..."
             sleep 60
-          done 
+          done
           echo "${HOME}/pause absent, continuing workflow."
 
-      - name: 'Tear down test cluster'
+      - name: "Tear down test cluster"
         if: ${{ always() }}
         continue-on-error: true
         run: |

--- a/.github/workflows/test-upgrade-latest-dev.yaml
+++ b/.github/workflows/test-upgrade-latest-dev.yaml
@@ -5,30 +5,30 @@ on:
   workflow_dispatch:
     inputs:
       image:
-        description: 'GCP image for test cluster'
+        description: "GCP image for test cluster"
         required: true
-        default: 'almalinux-cloud/almalinux-8'
+        default: "almalinux-cloud/almalinux-8"
       architecture:
         type: choice
         required: true
-        default: 'standard'
-        description: 'PE architecture to test'
-        options: 
-        - standard
-        - standard-with-dr
-        - large
-        - large-with-dr
-        - extra-large
-        - extra-large-with-dr
+        default: "standard"
+        description: "PE architecture to test"
+        options:
+          - standard
+          - standard-with-dr
+          - large
+          - large-with-dr
+          - extra-large
+          - extra-large-with-dr
       version:
         type: string
         required: true
-        description: 'The initial version of PE to install before upgrade'
-        default: '2021.7.4'
+        description: "The initial version of PE to install before upgrade"
+        default: "2021.7.4"
       ssh-debugging:
-        description: 'Boolean; whether or not to pause for ssh debugging'
+        description: "Boolean; whether or not to pause for ssh debugging"
         required: true
-        default: 'false'
+        default: "false"
 
 jobs:
   test-upgrade:
@@ -37,7 +37,7 @@ jobs:
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true
-      LANG: 'en_US.UTF-8'
+      LANG: "en_US.UTF-8"
     strategy:
       fail-fast: false
       matrix:
@@ -49,7 +49,7 @@ jobs:
           - "${{ github.event.inputs.image }}"
 
     steps:
-      - name: 'Start SSH session'
+      - name: "Start SSH session"
         if: ${{ github.event.inputs.ssh-debugging == 'true' }}
         uses: luchihoratiu/debug-via-ssh@main
         with:
@@ -72,7 +72,7 @@ jobs:
             bundle env
           echo ::endgroup::
 
-      - name: 'Provision test cluster'
+      - name: "Provision test cluster"
         timeout-minutes: 15
         run: |
           echo ::group::prepare
@@ -99,7 +99,7 @@ jobs:
             sed -e 's/password: .*/password: "[redacted]"/' < spec/fixtures/litmus_inventory.yaml || true
           echo ::endgroup::
 
-      - name: 'Install PE on test cluster'
+      - name: "Install PE on test cluster"
         timeout-minutes: 120
         run: |
           bundle exec bolt plan run peadm_spec::install_test_cluster \
@@ -108,26 +108,26 @@ jobs:
             architecture=${{ matrix.architecture }} \
             version=${{ matrix.version }}
 
-      - name: 'Wait as long as the file ${HOME}/pause file is present'
+      - name: "Wait as long as the file ${HOME}/pause file is present"
         if: ${{ always() && github.event.inputs.ssh-debugging == 'true' }}
         run: |
           while [ -f "${HOME}/pause" ] ; do
             echo "${HOME}/pause present, sleeping for 60 seconds..."
             sleep 60
-          done 
+          done
           echo "${HOME}/pause absent, continuing workflow."
 
-      - name: 'Activate twingate to obtain unreleased build'
-        uses: timidri/twingate-github-action@main
+      - name: "Activate twingate to obtain unreleased build"
+        uses: comfucios/twingate-github-action@main
         with:
           service-key: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
 
-      - name: 'Get latest build name'
+      - name: "Get latest build name"
         id: latest
         run: |
           echo "::set-output name=ver::$(curl -q https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/main/ci-ready/LATEST)"
 
-      - name: 'Upgrade PE on test cluster'
+      - name: "Upgrade PE on test cluster"
         timeout-minutes: 120
         run: |
           bundle exec bolt plan run peadm_spec::upgrade_test_cluster \
@@ -138,7 +138,7 @@ jobs:
             architecture=${{ matrix.architecture }} \
             pe_installer_source="https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/main/ci-ready/puppet-enterprise-${{ steps.latest.outputs.ver }}-el-8-x86_64.tar"
 
-      - name: 'Tear down test cluster'
+      - name: "Tear down test cluster"
         if: ${{ always() }}
         continue-on-error: true
         run: |

--- a/.github/workflows/test-upgrade-latest-xlarge-dev-nightly.yaml
+++ b/.github/workflows/test-upgrade-latest-xlarge-dev-nightly.yaml
@@ -3,7 +3,7 @@ name: "Upgrade to latest dev test nightly"
 
 on:
   schedule:
-    - cron: '0 3 * * *'
+    - cron: "0 3 * * *"
 
 jobs:
   test-upgrade:
@@ -12,16 +12,16 @@ jobs:
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true
-      LANG: 'en_US.UTF-8'
+      LANG: "en_US.UTF-8"
     strategy:
       fail-fast: false
       matrix:
         architecture:
-          - 'extra-large-with-dr'
+          - "extra-large-with-dr"
         version:
-          - '2021.7.4'
+          - "2021.7.4"
         image:
-          - 'almalinux-cloud/almalinux-8'
+          - "almalinux-cloud/almalinux-8"
 
     steps:
       - name: "Checkout Source"
@@ -40,7 +40,7 @@ jobs:
             bundle env
           echo ::endgroup::
 
-      - name: 'Provision test cluster'
+      - name: "Provision test cluster"
         timeout-minutes: 15
         run: |
           echo ::group::prepare
@@ -67,7 +67,7 @@ jobs:
             sed -e 's/password: .*/password: "[redacted]"/' < spec/fixtures/litmus_inventory.yaml || true
           echo ::endgroup::
 
-      - name: 'Install PE on test cluster'
+      - name: "Install PE on test cluster"
         timeout-minutes: 120
         run: |
           bundle exec bolt plan run peadm_spec::install_test_cluster \
@@ -76,17 +76,17 @@ jobs:
             architecture=${{ matrix.architecture }} \
             version=${{ matrix.version }}
 
-      - name: 'Activate twingate to obtain unreleased build'
-        uses: timidri/twingate-github-action@main
+      - name: "Activate twingate to obtain unreleased build"
+        uses: comfucios/twingate-github-action@main
         with:
           service-key: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
 
-      - name: 'Get latest build name'
+      - name: "Get latest build name"
         id: latest
         run: |
           echo "::set-output name=ver::$(curl -q https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/main/ci-ready/LATEST)"
 
-      - name: 'Upgrade PE on test cluster'
+      - name: "Upgrade PE on test cluster"
         timeout-minutes: 120
         run: |
           bundle exec bolt plan run peadm_spec::upgrade_test_cluster \
@@ -97,7 +97,7 @@ jobs:
             architecture=${{ matrix.architecture }} \
             pe_installer_source="https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/main/ci-ready/puppet-enterprise-${{ steps.latest.outputs.ver }}-el-8-x86_64.tar"
 
-      - name: 'Tear down test cluster'
+      - name: "Tear down test cluster"
         if: ${{ always() }}
         continue-on-error: true
         run: |


### PR DESCRIPTION
## Summary
My old twingate PR for their GH action wasn't merged, so went and created a retry myself. I also raised a new pr (https://github.com/Twingate/github-action/pull/4) with them. In the meantime, we can use my fork.


## Additional Context
Sometimes twingate isn't connected and because of lack of retry, fails CI.

## Related Issues (if any)
Closing the old PR (https://github.com/puppetlabs/puppetlabs-peadm/pull/362) with me reverting to use twingate official action.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [x] Not needed