### PR TITLE
add parameter in_progress_timeout; double default

### DIFF
--- a/tasks/puppet_runonce.json
+++ b/tasks/puppet_runonce.json
@@ -4,6 +4,11 @@
     "noop": {
       "type": "Optional[Boolean]",
       "description": "If true, run Puppet in no-op mode"
+    },
+    "in_progress_timeout": {
+      "type": "Integer",
+      "description": "How many seconds to wait for a puppet run, that is already in progress",
+      "default": 600
     }
   },
   "input_method": "environment",

--- a/tasks/puppet_runonce.sh
+++ b/tasks/puppet_runonce.sh
@@ -6,13 +6,13 @@
 # Parse noop parameter
 [ "$PT_noop" = "true" ] && NOOP_FLAG="--noop" || unset NOOP_FLAG
 
-# Wait for up to five minutes for an in-progress Puppet agent run to complete
+# Wait for an in-progress Puppet agent run to complete
 # TODO: right now the check is just for lock file existence. Improve the check
 #       to account for situations where the lockfile is stale.
 echo -n "Check for and wait up to 5 minutes for in-progress run to complete"
 lockfile=$(/opt/puppetlabs/bin/puppet config print agent_catalog_run_lockfile)
 n=0
-until [ $n -ge 300 ]
+until [ $n -ge "$PT_in_progress_timeout" ]
 do
   [ ! -e "$lockfile" ] && break
   echo -n .


### PR DESCRIPTION
## Summary
Prior to this PR the task puppet_runonce had a builtin timeout of 300 secs. This can be too short in some environments, so it should be configurable. Therefore this PR introduces a new parameter in_progress_timeout which has a default of 600 secs.

## Additional Context
I had problems with the too-short timeout of 300 secs during update of puppet servers.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [x] Not needed