### PR TITLE
(PE-36944) Changing when when CI mend will be triggered/executed

### DIFF
--- a/.github/workflows/mend.yml
+++ b/.github/workflows/mend.yml
@@ -9,13 +9,11 @@ on:
   workflow_dispatch:
 
 jobs:
-
   mend:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
     runs-on: "ubuntu-latest"
 
     steps:
-
       - name: "checkout"
         uses: "actions/checkout@v3"
         with:


### PR DESCRIPTION
## Summary
Fixing the nightly and on demand vuln scan. Also run on a pr merge

## Additional Context
Wasn't scanning at all

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [x] Not needed