### PR TITLE
peadm::install: Depend code-manager setup on r10k remote presence, not r10k ssh key

### DIFF
--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -136,10 +136,10 @@ plan peadm::subplans::install (
   $r10k_private_key = peadm::file_or_content('r10k_private_key', $r10k_private_key_file, $r10k_private_key_content)
 
   # enable code manager if:
-  # * it isn't explicitly disabled *and* the user provided r10k repo+key
+  # * it isn't explicitly disabled *and* the user provided r10k repo (key is optional, repo could be a local absolute path or https URL)
   # * a replica is present
   # * one or multiple compiler are present
-  $_code_manager_auto_configure = if $r10k_private_key and $code_manager_auto_configure {
+  $_code_manager_auto_configure = if $r10k_remote and $code_manager_auto_configure {
     true
   } elsif $replica_host {
     true


### PR DESCRIPTION
We've logic in place that checks if the user provided an r10k remote key and then automatically enable code-manager. This doesn't make sense because the key is optional. We need to depend on a r10k URL. The URL can be an absolute path to a local repo or an https url, both don't require a remote key.

Fixes a bug I introcued in https://github.com/puppetlabs/puppetlabs-peadm/pull/352/files#r1373941616