### PR TITLE
add environment parameter to puppet_runonce task

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1340,6 +1340,12 @@ Run the Puppet agent one time
 
 #### Parameters
 
+##### `environment`
+
+Data type: `Optional[String]`
+
+If set, run Puppet in specified code environment
+
 ##### `noop`
 
 Data type: `Optional[Boolean]`

--- a/tasks/puppet_runonce.json
+++ b/tasks/puppet_runonce.json
@@ -1,6 +1,10 @@
 {
   "description": "Run the Puppet agent one time",
   "parameters": {
+    "environment": {
+      "type": "Optional[String]",
+      "description": "If set, run Puppet in specified code environment"
+    },
     "noop": {
       "type": "Optional[Boolean]",
       "description": "If true, run Puppet in no-op mode"

--- a/tasks/puppet_runonce.sh
+++ b/tasks/puppet_runonce.sh
@@ -6,6 +6,9 @@
 # Parse noop parameter
 [ "$PT_noop" = "true" ] && NOOP_FLAG="--noop" || unset NOOP_FLAG
 
+# Parse environment parameter
+[ -n "$PT_environment" ] && ENV_FLAG="--environment $PT_environment" || unset ENV_FLAG
+
 # Wait for up to five minutes for an in-progress Puppet agent run to complete
 # TODO: right now the check is just for lock file existence. Improve the check
 #       to account for situations where the lockfile is stale.
@@ -35,6 +38,7 @@ echo
   --no-use_cached_catalog \
   --detailed-exitcodes \
   --color false \
+  $ENV_FLAG \
   $NOOP_FLAG
 
 # Only exit non-zero if an error occurred. Changes (detailed exit code 2) are


### PR DESCRIPTION
During provisioning it can be necessary to run agents in a sanitized environment that will make production environment operational:
- install hiera gems
- install report processors

