### PR TITLE
Only run heavy workflows on PR review_requestsd

### DIFF
--- a/.github/workflows/test-fips-install-matrix.yaml
+++ b/.github/workflows/test-fips-install-matrix.yaml
@@ -3,6 +3,7 @@ name: "Install fips test matrix"
 
 on:
   pull_request:
+    types: [review_requested]
     paths:
       - ".github/workflows/**/*"
       - "spec/**/*"

--- a/.github/workflows/test-install-matrix.yaml
+++ b/.github/workflows/test-install-matrix.yaml
@@ -3,6 +3,7 @@ name: "Install test matrix"
 
 on:
   pull_request:
+    types: [review_requested]
     paths:
       - ".github/workflows/**/*"
       - "spec/**/*"

--- a/.github/workflows/test-upgrade-matrix.yaml
+++ b/.github/workflows/test-upgrade-matrix.yaml
@@ -3,6 +3,7 @@ name: "Upgrade test matrix"
 
 on:
   pull_request:
+    types: [review_requested]
     paths:
       - '.github/workflows/**/*'
       - 'spec/**/*'


### PR DESCRIPTION
## Summary
This PR changes the workflows `test-install-matrix`, `test-upgrade-matrix` and `test-fips-install-matrix.yaml` to only run on PR if a review is requested. Previously the workflows were started on every commit to a PR, even if that PR is in draft state.

## Additional Context
Add any additional context about the problem here.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [x ] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [x] Not needed