### PR TITLE
(PE-37232) Remove puppet debug dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -13,7 +13,6 @@ fixtures:
     node_manager: 'https://github.com/WhatsARanjit/puppet-node_manager'
     apply_helpers: 'https://github.com/puppetlabs/puppetlabs-apply_helpers'
     bolt_shim: 'https://github.com/puppetlabs/puppetlabs-bolt_shim'
-    debug: 'https://github.com/nwops/puppet-debug'
     format: 'https://github.com/voxpupuli/puppet-format'
     container_inventory: 'https://gitlab.com/nwops/bolt-container_inventory'
   symlinks:


### PR DESCRIPTION
[Jira ticket ](https://perforce.atlassian.net/browse/PE-37232)

Remove puppet debug as it is not currently being used in the PEADM repo. 

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [ ] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [ ] Not needed