### PR TITLE
Adding amazonlinux to pre-check

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -47,6 +47,12 @@
   ],
   "operatingsystem_support": [
     {
+      "operatingsystem": "Amazon",
+      "operatingsystemrelease": [
+        "2"
+      ]
+    },
+    {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "7",

--- a/tasks/precheck.sh
+++ b/tasks/precheck.sh
@@ -11,7 +11,7 @@ elif grep -qi redhat /etc/os-release && [[ "$(cat /proc/sys/crypto/fips_enabled)
   osfamily="redhatfips"
 else
   osfamily="el"
-  if grep -qi amazon /etc/os-release && grep -qi "VERSION_ID=\"2\"" /etc/os-release; then
+  if grep -qi amazon /etc/os-release && grep -qi 'VERSION_ID="2"' /etc/os-release; then
     version=7
   fi
 fi

--- a/tasks/precheck.sh
+++ b/tasks/precheck.sh
@@ -11,6 +11,9 @@ elif grep -qi redhat /etc/os-release && [[ "$(cat /proc/sys/crypto/fips_enabled)
   osfamily="redhatfips"
 else
   osfamily="el"
+  if grep -qi amazon /etc/os-release && grep -qi "VERSION_ID=\"2\"" /etc/os-release; then
+    version=7
+  fi
 fi
 
 # OS-specific modifications


### PR DESCRIPTION
## Summary
PE supports AmazonLinux 2 but using the EL7 tarball. This adds the update to the pre-check to allow it to download that package.

## Additional Context
Currently the pre-check returns el but value of 2 from the VERSION_ID and it needs to return 7 in order to download the appropriate package.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [ ] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [ ] Not needed