### PR TITLE
(MAINT) release_prep gem group added

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,10 @@ group :system_tests do
   gem "puppet_litmus", '~> 1.0', require: false, platforms: [:ruby, :x64_mingw]
   gem "serverspec", '~> 2.41',   require: false
 end
+group :release_prep do
+  gem "puppet-strings", '~> 4.0',         require: false
+  gem "puppetlabs_spec_helper", '~> 6.0', require: false
+end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']
 facter_version = ENV['FACTER_GEM_VERSION']


### PR DESCRIPTION
## Summary
release_prep gem group added to facilitate release prep github action for new module version release

## Additional Context

## Related Issues (if any)

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [x] Not needed