### PR TITLE
Pin WhatsARanjit/node_manager to version 0.7.5

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,16 +5,18 @@ fixtures:
     service: "puppetlabs/service"
     package: "puppetlabs/package"
     reboot: "puppetlabs/reboot"
+    node_manager:
+      repo: "WhatsARanjit/node_manager"
+      ref: "0.7.5"
   repositories:
-    facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
-    puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
-    provision: 'https://github.com/puppetlabs/provision.git'
-    stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
-    node_manager: 'https://github.com/WhatsARanjit/puppet-node_manager'
-    apply_helpers: 'https://github.com/puppetlabs/puppetlabs-apply_helpers'
-    bolt_shim: 'https://github.com/puppetlabs/puppetlabs-bolt_shim'
-    format: 'https://github.com/voxpupuli/puppet-format'
-    container_inventory: 'https://gitlab.com/nwops/bolt-container_inventory'
+    facts: "https://github.com/puppetlabs/puppetlabs-facts.git"
+    puppet_agent: "https://github.com/puppetlabs/puppetlabs-puppet_agent.git"
+    provision: "https://github.com/puppetlabs/provision.git"
+    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
+    apply_helpers: "https://github.com/puppetlabs/puppetlabs-apply_helpers"
+    bolt_shim: "https://github.com/puppetlabs/puppetlabs-bolt_shim"
+    format: "https://github.com/voxpupuli/puppet-format"
+    container_inventory: "https://gitlab.com/nwops/bolt-container_inventory"
   symlinks:
     "peadm": "#{source_dir}"
     "peadm_spec": "#{source_dir}/spec/acceptance/peadm_spec"

--- a/spec/docker/bolt-project.yaml
+++ b/spec/docker/bolt-project.yaml
@@ -1,12 +1,13 @@
 ---
 name: peadm_docker_examples
-modules: 
+modules:
   - name: nwops/container_inventory
     version_requirement: ">= 0.1.1"
   - name: puppetlabs/stdlib
     version_requirement: ">= 6.5.0 < 8.0.0"
   - puppetlabs/ruby_task_helper
-  - WhatsARanjit/node_manager
+  - name: WhatsARanjit/node_manager
+    version_requirement: "0.7.5"
   - puppetlabs/apply_helpers
   - puppetlabs/bolt_shim
   - puppet/format


### PR DESCRIPTION
## Summary
This PR pins the dependency WhatsARanjit/node_manager to version 0.7.5 from the Puppet Forge.
This resolves an issue during PEADM upgrades where PEADM fails to correct the node group definition
for "PE Infrastructure Agent" to become an OR instead of an AND.

## Additional Context
Add any additional context about the problem here.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [ ] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [ ] Not needed
