### PR TITLE
Add function to check if nodes are reachable via bolt

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -20,6 +20,7 @@
 * [`peadm::assert_supported_pe_version`](#peadm--assert_supported_pe_version): Assert that the PE version given is supported by PEAdm
 * [`peadm::bolt_version`](#peadm--bolt_version)
 * [`peadm::certname`](#peadm--certname): Return the certname of the given target-like input
+* [`peadm::check_availability`](#peadm--check_availability): check if a group of targets are reachable for bolt
 * [`peadm::check_version_and_known_hosts`](#peadm--check_version_and_known_hosts): Checks PE verison and warns about setting r10k_known_hosts
 * [`peadm::convert_hash`](#peadm--convert_hash): converts two arrays into hash
 * [`peadm::convert_status`](#peadm--convert_status): Transforms a value in a human readable status with or without colors
@@ -265,6 +266,30 @@ Variant[Target,
 ```
 
 
+
+### <a name="peadm--check_availability"></a>`peadm::check_availability`
+
+Type: Puppet Language
+
+check if a group of targets are reachable for bolt
+
+#### `peadm::check_availability(TargetSpec $targets, Boolean $output_details = true)`
+
+The peadm::check_availability function.
+
+Returns: `Integer` counter for unavailable nodes
+
+##### `targets`
+
+Data type: `TargetSpec`
+
+list of targets that are going to be checked
+
+##### `output_details`
+
+Data type: `Boolean`
+
+flag to enable/disable error output for failed nodes
 
 ### <a name="peadm--check_version_and_known_hosts"></a>`peadm::check_version_and_known_hosts`
 

--- a/functions/check_availability.pp
+++ b/functions/check_availability.pp
@@ -1,0 +1,22 @@
+#
+# @summary check if a group of targets are reachable for bolt
+#
+# @param targets list of targets that are going to be checked
+# @param output_details flag to enable/disable error output for failed nodes
+#
+# @return counter for unavailable nodes
+#
+# @author Tim Meusel <tim@bastelfreak.de>
+#
+function peadm::check_availability(
+  TargetSpec $targets,
+  Boolean $output_details = true
+) >> Integer {
+  $check_result = wait_until_available($targets, wait_time => 2, _catch_errors => true)
+  unless $check_result.ok {
+    $end_message = "${check_result.error_set.count} targets are not reachable, stopping plan"
+    fail_plan($end_message, 'peadm/unreachable-nodes', error_set => $check_result.error_set)
+  }
+
+  return $check_result.error_set.count
+}

--- a/plans/convert.pp
+++ b/plans/convert.pp
@@ -56,6 +56,7 @@ plan peadm::convert (
   )
 
   out::message('# Gathering information')
+  peadm::check_availability($all_targets)
 
   # Get trusted fact information for all compilers. Use peadm::certname() as
   # the hash key because the apply block below will break trying to parse the

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -76,6 +76,15 @@ plan peadm::install (
 ) {
   peadm::assert_supported_bolt_version()
 
+  out::message('# Gathering information')
+  $all_targets = peadm::flatten_compact([
+      $primary_host,
+      $replica_host,
+      $replica_postgresql_host,
+      $compiler_hosts,
+      $primary_postgresql_host,
+  ])
+  peadm::check_availability($all_targets)
   peadm::assert_supported_pe_version($version, $permit_unsafe_versions)
 
   $install_result = run_plan('peadm::subplans::install',

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -98,6 +98,7 @@ plan peadm::upgrade (
   ])
 
   out::message('# Gathering information')
+  peadm::check_availability($all_targets)
 
   # lint:ignore:strict_indent
   $primary_target.peadm::fail_on_transport('pcp', @(HEREDOC/n))

--- a/spec/plans/install_spec.rb
+++ b/spec/plans/install_spec.rb
@@ -5,6 +5,7 @@ describe 'peadm::install' do
 
   describe 'basic functionality' do
     it 'runs successfully with the minimum required parameters' do
+      allow_out_message
       expect_plan('peadm::subplans::install')
       expect_plan('peadm::subplans::configure')
       expect(run_plan('peadm::install', 'primary_host' => 'primary', 'console_password' => 'puppetlabs', 'version' => '2021.7.7')).to be_ok


### PR DESCRIPTION
At the moment the plans assume that all nodes are available. I had a few customer setups where one of the compilers wasn't reachable during a convert/upgrade. To not put the PE infra into an undefined state, it makes sense to check the availability before running the plans.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [ ] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [ ] Not needed