### PR TITLE
(MAINT) CI fix, PE console requires a minimum password of 12 characters

### DIFF
--- a/examples/provision/extra-large-ha.json
+++ b/examples/provision/extra-large-ha.json
@@ -1,6 +1,6 @@
 {
   "version": "2021.7.0",
-  "console_password": "puppetlabs",
+  "console_password": "puppetLabs123!",
   "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
   "replica_host": "pe-master-1830cd-1.us-west1-b.c.reidmv-peadm.internal",
   "primary_postgresql_host": "pe-psql-1830cd-0.us-west1-a.c.reidmv-peadm.internal",

--- a/examples/provision/extra-large.json
+++ b/examples/provision/extra-large.json
@@ -1,6 +1,6 @@
 {
   "version": "2021.7.0",
-  "console_password": "puppetlabs",
+  "console_password": "puppetLabs123!",
   "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
 
   "primary_postgresql_host": "pe-psql-1830cd-0.us-west1-a.c.reidmv-peadm.internal",

--- a/examples/provision/large-ha.json
+++ b/examples/provision/large-ha.json
@@ -1,6 +1,6 @@
 {
   "version": "2021.7.0",
-  "console_password": "puppetlabs",
+  "console_password": "puppetLabs123!",
   "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
   "replica_host": "pe-master-1830cd-1.us-west1-b.c.reidmv-peadm.internal",
 

--- a/examples/provision/large.json
+++ b/examples/provision/large.json
@@ -1,6 +1,6 @@
 {
   "version": "2021.7.0",
-  "console_password": "puppetlabs",
+  "console_password": "puppetLabs123!",
   "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
 
 

--- a/examples/provision/minimal.json
+++ b/examples/provision/minimal.json
@@ -1,5 +1,5 @@
 {
   "version": "2021.7.0",
-  "console_password": "puppetlabs",
+  "console_password": "puppetLabs123!",
   "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal"
 }

--- a/examples/provision/standard-ha.json
+++ b/examples/provision/standard-ha.json
@@ -1,6 +1,6 @@
 {
   "version": "2021.7.0",
-  "console_password": "puppetlabs",
+  "console_password": "puppetLabs123!",
   "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
   "replica_host": "pe-master-1830cd-1.us-west1-b.c.reidmv-peadm.internal",
 

--- a/examples/provision/standard.json
+++ b/examples/provision/standard.json
@@ -1,6 +1,6 @@
 {
   "version": "2021.7.0",
-  "console_password": "puppetlabs",
+  "console_password": "puppetLabs123!",
   "primary_host": "pe-master-1830cd-0.us-west1-a.c.reidmv-peadm.internal",
 
 

--- a/spec/acceptance/peadm_spec/plans/install_test_cluster.pp
+++ b/spec/acceptance/peadm_spec/plans/install_test_cluster.pp
@@ -25,7 +25,7 @@ plan peadm_spec::install_test_cluster (
   }
 
   $common_params = {
-    console_password       => 'puppetlabs',
+    console_password       => 'puppetLabs123!',
     download_mode          => $download_mode,
     code_manager_auto_configure => $code_manager_auto_configure,
     version                => $version,
@@ -35,28 +35,28 @@ plan peadm_spec::install_test_cluster (
 
   $arch_params =
     case $architecture {
-    'standard': { {
+    'standard': {{
         primary_host => $t.filter |$n| { $n.vars['role'] == 'primary' },
     } }
-    'standard-with-dr': { {
+    'standard-with-dr': {{
         primary_host   => $t.filter |$n| { $n.vars['role'] == 'primary' },
         replica_host   => $t.filter |$n| { $n.vars['role'] == 'replica' },
     } }
-    'large': { {
+    'large': {{
         primary_host   => $t.filter |$n| { $n.vars['role'] == 'primary' },
         compiler_hosts => $t.filter |$n| { $n.vars['role'] == 'compiler' },
     } }
-    'large-with-dr': { {
+    'large-with-dr': {{
         primary_host   => $t.filter |$n| { $n.vars['role'] == 'primary' },
         replica_host   => $t.filter |$n| { $n.vars['role'] == 'replica' },
         compiler_hosts => $t.filter |$n| { $n.vars['role'] == 'compiler' },
     } }
-    'extra-large': { {
+    'extra-large': {{
         primary_host            => $t.filter |$n| { $n.vars['role'] == 'primary' },
         primary_postgresql_host => $t.filter |$n| { $n.vars['role'] == 'primary-pdb-postgresql' },
         compiler_hosts          => $t.filter |$n| { $n.vars['role'] == 'compiler' },
     } }
-    'extra-large-with-dr': { {
+    'extra-large-with-dr': {{
         primary_host             => $t.filter |$n| { $n.vars['role'] == 'primary' },
         primary_postgresql_host  => $t.filter |$n| { $n.vars['role'] == 'primary-pdb-postgresql' },
         replica_host             => $t.filter |$n| { $n.vars['role'] == 'replica' },

--- a/spec/docker/extra-large-ha/params.json
+++ b/spec/docker/extra-large-ha/params.json
@@ -6,7 +6,7 @@
   "compiler_hosts": [
     "pe-xl-compiler-0.puppet.vm"
   ],
-  "console_password": "puppetlabs",
+  "console_password": "puppetLabs123!",
   "dns_alt_names": [
     "puppet",
     "pe-xl-core-0.puppet.vm",

--- a/spec/docker/extra-large/params.json
+++ b/spec/docker/extra-large/params.json
@@ -4,7 +4,7 @@
   "compiler_hosts": [
     "pe-xl-compiler-0.puppet.vm"
   ],
-  "console_password": "puppetlabs",
+  "console_password": "puppetLabs123!",
   "dns_alt_names": [
     "puppet",
     "pe-xl-core-0.puppet.vm"

--- a/spec/docker/large-ha/params.json
+++ b/spec/docker/large-ha/params.json
@@ -4,7 +4,7 @@
   "compiler_hosts": [
     "pe-lg-compiler-0.puppet.vm"
   ],
-  "console_password": "puppetlabs",
+  "console_password": "puppetLabs123!",
   "dns_alt_names": [
     "puppet",
     "pe-lg.puppet.vm"

--- a/spec/docker/large/params.json
+++ b/spec/docker/large/params.json
@@ -3,7 +3,7 @@
   "compiler_hosts": [
     "pe-lg-compiler-0.puppet.vm"
   ],
-  "console_password": "puppetlabs",
+  "console_password": "puppetLabs123!",
   "dns_alt_names": [
     "puppet",
     "pe-lg.puppet.vm"

--- a/spec/docker/standard-ha/params.json
+++ b/spec/docker/standard-ha/params.json
@@ -1,7 +1,7 @@
 {
   "primary_host": "pe-std.puppet.vm",
   "replica_host": "pe-std-replica.puppet.vm",
-  "console_password": "puppetlabs",
+  "console_password": "puppetLabs123!",
   "dns_alt_names": [
     "puppet",
     "pe-std.puppet.vm"

--- a/spec/docker/standard/params.json
+++ b/spec/docker/standard/params.json
@@ -1,6 +1,6 @@
 {
   "primary_host": "pe-std.puppet.vm",
-  "console_password": "puppetlabs",
+  "console_password": "puppetLabs123!",
   "dns_alt_names": [
     "puppet",
     "pe-std.puppet.vm"

--- a/spec/plans/install_spec.rb
+++ b/spec/plans/install_spec.rb
@@ -7,7 +7,7 @@ describe 'peadm::install' do
     it 'runs successfully with the minimum required parameters' do
       expect_plan('peadm::subplans::install')
       expect_plan('peadm::subplans::configure')
-      expect(run_plan('peadm::install', 'primary_host' => 'primary', 'console_password' => 'puppetlabs', 'version' => '2021.7.7')).to be_ok
+      expect(run_plan('peadm::install', 'primary_host' => 'primary', 'console_password' => 'puppetLabs123!', 'version' => '2021.7.7')).to be_ok
     end
   end
 end

--- a/spec/plans/subplans/install_spec.rb
+++ b/spec/plans/subplans/install_spec.rb
@@ -40,7 +40,7 @@ describe 'peadm::subplans::install' do
   it 'minimum variables to run' do
     params = {
       'primary_host'     => 'primary',
-      'console_password' => 'puppetlabs',
+      'console_password' => 'puppetLabs123!',
       'version'          => '2019.8.12',
     }
 
@@ -50,7 +50,7 @@ describe 'peadm::subplans::install' do
   it 'installs 2023.4 without r10k_known_hosts' do
     params = {
       'primary_host'             => 'primary',
-      'console_password'         => 'puppetlabs',
+      'console_password'         => 'puppetLabs123!',
       'version'                  => '2023.4.0',
       'r10k_remote'              => 'git@github.com:puppetlabs/nothing',
       'r10k_private_key_content' => '-----BEGINfoo',
@@ -62,7 +62,7 @@ describe 'peadm::subplans::install' do
   it 'installs 2023.4+ with r10k_private_key and r10k_known_hosts' do
     params = {
       'primary_host'             => 'primary',
-      'console_password'         => 'puppetlabs',
+      'console_password'         => 'puppetLabs123!',
       'version'                  => '2023.4.0',
       'r10k_remote'              => 'git@github.com:puppetlabs/nothing',
       'r10k_private_key_content' => '-----BEGINfoo',


### PR DESCRIPTION
## Summary
The new version of PE requires a 12 characters minimum password. 

## Additional Context
CI is failing because we used a password with less than 12 characters

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [x] Not needed