### PR TITLE
(MAINT) - Re-add ruby tests

### DIFF
--- a/.github/workflows/module_ci.yml
+++ b/.github/workflows/module_ci.yml
@@ -84,7 +84,7 @@ jobs:
       - name: "Run Static & Syntax Tests"
         run: |
           bundle exec rake syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
-         # bundle exec dependency-checker metadata.json --override WhatsARanjit/node_manager,0.7.5
+          bundle exec dependency-checker metadata.json --override WhatsARanjit/node_manager,0.7.5
           
 
       - name: "Run tests"


### PR DESCRIPTION
## Summary
Ruby tests have been temporarily removed until a new node manager version is available.

## Additional Context
Tests were broken due to a version of node manager not being available. 

## Related Issues (if any)
[Mention any related issues or pull requests.](https://github.com/puppetlabs/puppetlabs-peadm/pull/438)

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Not needed

#### Have you updated the documentation?
- [ ] Not needed