### PR TITLE
(PE-38736) Adding puppet run after primary upgrade

### DIFF
--- a/.github/workflows/test-upgrade-matrix.yaml
+++ b/.github/workflows/test-upgrade-matrix.yaml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   test-upgrade:
-    name: "PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }}"
+    name: "PE ${{ matrix.version }} to ${{ matrix.version_to_upgrade }} ${{ matrix.architecture }} on ${{ matrix.image }}"
     runs-on: ubuntu-20.04
     env:
       BOLT_GEM: true
@@ -43,12 +43,19 @@ jobs:
           - 'extra-large-with-dr'
         version:
           - '2019.8.12'
+          - '2021.7.8'
         version_to_upgrade:
           - '2021.7.8'
+          - '2023.7.0'
         image:
           - 'almalinux-cloud/almalinux-8'
         download_mode:
           - 'direct'
+        exclude:
+          - version: '2019.8.12'
+            version_to_upgrade: '2023.7.0'
+          - version: '2021.7.8'
+            version_to_upgrade: '2021.7.8' 
 
     steps:
       - name: 'Start SSH session'

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -263,6 +263,9 @@ plan peadm::upgrade (
           $primary_target,
           $primary_postgresql_target,
     ]))
+
+    # Running again to ensure that the primary is fully upgraded
+    run_task('peadm::puppet_runonce', $primary_target)
   }
 
   peadm::plan_step('upgrade-node-groups') || {


### PR DESCRIPTION
Running into issue that not all services relating to Orchestrator are fully started after upgrade to 2023.7. ie pe-host-action-collector. This is then meaning that the upgrade of the other hosts cant be completed.

Added 2023 to upgrade matrix. Including 2021 to 2023, excluding 2021 to 2021 and 2019 to 2023

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [x] Yes
- [ ] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [x] Not needed