### PR TITLE
.fixtures.yml: Fix URL for bolt-container_inventory

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -13,7 +13,7 @@ fixtures:
     apply_helpers: "https://github.com/puppetlabs/puppetlabs-apply_helpers"
     bolt_shim: "https://github.com/puppetlabs/puppetlabs-bolt_shim"
     format: "https://github.com/voxpupuli/puppet-format"
-    container_inventory: "https://gitlab.com/nwops/bolt-container_inventory"
+    container_inventory: "https://gitlab.com/nwops/bolt-container_inventory.git"
     node_manager: "https://github.com/puppetlabs/puppetlabs-node_manager.git"
   symlinks:
     "peadm": "#{source_dir}"


### PR DESCRIPTION
Without this, we get the following warning during the spec_prep rake task:

```
warning: redirecting to https://gitlab.com/nwops/bolt-container_inventory.git/
```

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [ ] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [ ] Not needed