### PR TITLE
PE-38768 classify compilers task added

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -56,6 +56,7 @@
 * [`backup_classification`](#backup_classification): A task to call the classification api and write to file
 * [`cert_data`](#cert_data): Return certificate data related to the Puppet agent
 * [`cert_valid_status`](#cert_valid_status): Check primary for valid state of a certificate
+* [`classify_compilers`](#classify_compilers): Classify compilers as legacy or non-legacy
 * [`code_manager`](#code_manager): Perform various code manager actions
 * [`code_sync_status`](#code_sync_status): A task to confirm code is in sync accross the cluster for clusters with code manager configured
 * [`divert_code_manager`](#divert_code_manager): Divert the code manager live-dir setting
@@ -1055,6 +1056,20 @@ Check primary for valid state of a certificate
 Data type: `String`
 
 The certifcate name to check validation of
+
+### <a name="classify_compilers"></a>`classify_compilers`
+
+Classify compilers as legacy or non-legacy
+
+**Supports noop?** false
+
+#### Parameters
+
+##### `compiler_hosts`
+
+Data type: `Array[String]`
+
+List of FQDNs of compilers
 
 ### <a name="code_manager"></a>`code_manager`
 

--- a/manifests/setup/legacy_compiler_group.pp
+++ b/manifests/setup/legacy_compiler_group.pp
@@ -33,7 +33,7 @@ class peadm::setup::legacy_compiler_group (
     ],
     classes => {
       'puppet_enterprise::profile::master'   => {
-        'puppetdb_host' => [$peadm::setup::legacy_compiler_group::internal_compiler_b_pool_address].filter |$_| { $_ }, # Fixed namespacing
+        'puppetdb_host' => [$peadm::setup::legacy_compiler_group::internal_compiler_b_pool_address].filter |$_| { $_ },
         'puppetdb_port' => [8081],
       },
     },
@@ -55,7 +55,7 @@ class peadm::setup::legacy_compiler_group (
     ],
     classes => {
       'puppet_enterprise::profile::master'   => {
-        'puppetdb_host' => [$peadm::setup::legacy_compiler_group::internal_compiler_b_pool_address].filter |$_| { $_ }, # Fixed namespacing
+        'puppetdb_host' => [$peadm::setup::legacy_compiler_group::internal_compiler_b_pool_address].filter |$_| { $_ },
         'puppetdb_port' => [8081],
       },
     },

--- a/manifests/setup/legacy_compiler_group.pp
+++ b/manifests/setup/legacy_compiler_group.pp
@@ -1,7 +1,6 @@
 # @api private
 class peadm::setup::legacy_compiler_group (
-  String[1] $primary_host,
-  String $internal_compiler_b_pool_address
+  String[1] $primary_host
 ) {
   Node_group {
     purge_behavior => none,

--- a/manifests/setup/legacy_compiler_group.pp
+++ b/manifests/setup/legacy_compiler_group.pp
@@ -1,6 +1,7 @@
 # @api private
 class peadm::setup::legacy_compiler_group (
-  String[1] $primary_host
+  String[1] $primary_host,
+  String $internal_compiler_b_pool_address
 ) {
   Node_group {
     purge_behavior => none,
@@ -32,7 +33,7 @@ class peadm::setup::legacy_compiler_group (
     ],
     classes => {
       'puppet_enterprise::profile::master'   => {
-        'puppetdb_host' => [$internal_compiler_b_pool_address].filter |$_| { $_ },
+        'puppetdb_host' => [$peadm::setup::legacy_compiler_group::internal_compiler_b_pool_address].filter |$_| { $_ }, # Fixed namespacing
         'puppetdb_port' => [8081],
       },
     },
@@ -54,7 +55,7 @@ class peadm::setup::legacy_compiler_group (
     ],
     classes => {
       'puppet_enterprise::profile::master'   => {
-        'puppetdb_host' => [$internal_compiler_b_pool_address].filter |$_| { $_ },
+        'puppetdb_host' => [$peadm::setup::legacy_compiler_group::internal_compiler_b_pool_address].filter |$_| { $_ }, # Fixed namespacing
         'puppetdb_port' => [8081],
       },
     },

--- a/manifests/setup/legacy_compiler_group.pp
+++ b/manifests/setup/legacy_compiler_group.pp
@@ -55,7 +55,7 @@ class peadm::setup::legacy_compiler_group (
     ],
     classes => {
       'puppet_enterprise::profile::master'   => {
-        'puppetdb_host' => [$peadm::setup::legacy_compiler_group::internal_compiler_b_pool_address].filter |$_| { $_ },
+        'puppetdb_host' => [$peadm::setup::legacy_compiler_group::internal_compiler_a_pool_address].filter |$_| { $_ },
         'puppetdb_port' => [8081],
       },
     },

--- a/manifests/setup/node_manager.pp
+++ b/manifests/setup/node_manager.pp
@@ -253,7 +253,7 @@ class peadm::setup::node_manager (
     ],
     classes => {
       'puppet_enterprise::profile::master'   => {
-        'puppetdb_host' => [$internal_compiler_b_pool_address].filter |$_| { $_ },
+        'puppetdb_host' => [$internal_compiler_a_pool_address].filter |$_| { $_ },
         'puppetdb_port' => [8081],
       },
     },

--- a/tasks/classify_compilers.json
+++ b/tasks/classify_compilers.json
@@ -1,0 +1,15 @@
+{
+  "description": "Classify compilers as legacy or non-legacy",
+  "parameters": {
+    "compiler_hosts": {
+      "type": "Array[String]",
+      "description": "List of FQDNs of compilers"
+    }
+  },
+  "implementations": [
+    {
+      "name": "classify_compilers.rb",
+      "requirements": ["shell"]
+    }
+  ]
+}

--- a/tasks/classify_compilers.rb
+++ b/tasks/classify_compilers.rb
@@ -18,24 +18,20 @@ legacy_compilers = []
 non_legacy_compilers = []
 
 compiler_hosts.each do |compiler|
-  begin
-    cmd = "puppet infra status --host #{compiler} --format=json"
-    stdout, stderr, status = Open3.capture3(cmd)
+  cmd = "puppet infra status --host #{compiler} --format=json"
+  stdout, stderr, status = Open3.capture3(cmd)
 
-    if status.success?
-      services = JSON.parse(stdout)
-      classification = classify_compiler(services)
+  if status.success?
+    services = JSON.parse(stdout)
+    classification = classify_compiler(services)
 
-      if classification == :legacy
-        legacy_compilers << compiler
-      else
-        non_legacy_compilers << compiler
-      end
+    if classification == :legacy
+      legacy_compilers << compiler
     else
-      STDERR.puts "Error running command for #{compiler}: #{stderr}"
+      non_legacy_compilers << compiler
     end
-  rescue => e
-    STDERR.puts "Error processing #{compiler}: #{e.message}"
+  else
+    STDERR.puts "Error running command for #{compiler}: #{stderr}"
   end
 end
 

--- a/tasks/classify_compilers.rb
+++ b/tasks/classify_compilers.rb
@@ -1,0 +1,47 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'open3'
+
+def classify_compiler(services)
+  if services.any? { |service| service['type'] == 'puppetdb' }
+    :non_legacy
+  else
+    :legacy
+  end
+end
+
+params = JSON.parse(STDIN.read)
+compiler_hosts = params['compiler_hosts']
+
+legacy_compilers = []
+non_legacy_compilers = []
+
+compiler_hosts.each do |compiler|
+  begin
+    cmd = "puppet infra status --host #{compiler} --format=json"
+    stdout, stderr, status = Open3.capture3(cmd)
+
+    if status.success?
+      services = JSON.parse(stdout)
+      classification = classify_compiler(services)
+
+      if classification == :legacy
+        legacy_compilers << compiler
+      else
+        non_legacy_compilers << compiler
+      end
+    else
+      STDERR.puts "Error running command for #{compiler}: #{stderr}"
+    end
+  rescue => e
+    STDERR.puts "Error processing #{compiler}: #{e.message}"
+  end
+end
+
+result = {
+  'legacy_compilers' => legacy_compilers,
+  'compilers' => non_legacy_compilers
+}
+
+puts result.to_json


### PR DESCRIPTION
Task added to classify a list of compilers as legacy or non legacy

Example usage:

`bolt task run peadm::classify_compilers -t oncoming-ram.delivery.puppetlabs.net --params '{"compiler_hosts": ["ideal-lament.delivery.puppetlabs.net", "tool-propaganda.delivery.puppetlabs.net", "saner-daughter.delivery.puppetlabs.net", "kindly-intruder.delivery.puppetlabs.net", "murky-tombstone.delivery.puppetlabs.net"]}'`

![image](https://github.com/user-attachments/assets/579ecbec-9511-4709-b6ac-9ab27deeecf0)