### PR TITLE
(PE-38814) add_compiler - Making primary_postgresql_host and avail_group_letter optional

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1571,9 +1571,11 @@ The following parameters are available in the `peadm::add_compiler` plan:
 
 ##### <a name="-peadm--add_compiler--avail_group_letter"></a>`avail_group_letter`
 
-Data type: `Enum['A', 'B']`
+Data type: `Optional[Enum['A', 'B']]`
 
 _ Either A or B; whichever of the two letter designations the compiler is being assigned to
+
+Default value: `'A'`
 
 ##### <a name="-peadm--add_compiler--compiler_host"></a>`compiler_host`
 
@@ -1597,9 +1599,11 @@ _ The hostname and certname of the primary Puppet server
 
 ##### <a name="-peadm--add_compiler--primary_postgresql_host"></a>`primary_postgresql_host`
 
-Data type: `Peadm::SingleTargetSpec`
+Data type: `Optional[Peadm::SingleTargetSpec]`
 
 _ The hostname and certname of the PE-PostgreSQL server with availability group $avail_group_letter
+
+Default value: `undef`
 
 ### <a name="peadm--add_database"></a>`peadm::add_database`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1571,7 +1571,7 @@ The following parameters are available in the `peadm::add_compiler` plan:
 
 ##### <a name="-peadm--add_compiler--avail_group_letter"></a>`avail_group_letter`
 
-Data type: `Optional[Enum['A', 'B']]`
+Data type: `Enum['A', 'B']`
 
 _ Either A or B; whichever of the two letter designations the compiler is being assigned to
 

--- a/plans/add_compiler.pp
+++ b/plans/add_compiler.pp
@@ -7,19 +7,36 @@
 # @param primary_host _ The hostname and certname of the primary Puppet server
 # @param primary_postgresql_host _ The hostname and certname of the PE-PostgreSQL server with availability group $avail_group_letter
 plan peadm::add_compiler(
-  Enum['A', 'B'] $avail_group_letter,
+  Optional[Enum['A', 'B']] $avail_group_letter = 'A' ,
   Optional[String[1]] $dns_alt_names = undef,
   Peadm::SingleTargetSpec $compiler_host,
   Peadm::SingleTargetSpec $primary_host,
-  Peadm::SingleTargetSpec $primary_postgresql_host,
+  Optional[Peadm::SingleTargetSpec] $primary_postgresql_host = undef,
 ) {
   $compiler_target           = peadm::get_targets($compiler_host, 1)
   $primary_target            = peadm::get_targets($primary_host, 1)
-  $primary_postgresql_target = peadm::get_targets($primary_postgresql_host, 1)
 
   # Get current peadm config to determine where to setup additional rules for
   # compiler's secondary PuppetDB instances
   $peadm_config = run_task('peadm::get_peadm_config', $primary_target).first.value
+
+  if $primary_postgresql_host == undef {
+    # get the external PostgreSQL host for the specified availability group
+    $external_postgresql_host = $avail_group_letter ? {
+      'A'     => $peadm_config['params']['primary_postgresql_host'],
+      default => $peadm_config['params']['replica_postgresql_host'],
+    }
+
+    # If the external_postgresql_host is undef, use the server for that availability group
+    $postgresql_host = $external_postgresql_host ? {
+      undef   => $peadm_config['role-letter']['server'][$avail_group_letter],
+      default => $external_postgresql_host,
+    }
+
+    $primary_postgresql_target = peadm::get_targets($postgresql_host, 1)
+  } else {
+    $primary_postgresql_target = peadm::get_targets($primary_postgresql_host, 1)
+  }
 
   # Return the opposite server than the compiler to be added so it can be
   # configured with the appropriate rules for Puppet Server access from

--- a/plans/add_compiler.pp
+++ b/plans/add_compiler.pp
@@ -7,7 +7,7 @@
 # @param primary_host _ The hostname and certname of the primary Puppet server
 # @param primary_postgresql_host _ The hostname and certname of the PE-PostgreSQL server with availability group $avail_group_letter
 plan peadm::add_compiler(
-  Optional[Enum['A', 'B']] $avail_group_letter = 'A' ,
+  Enum['A', 'B'] $avail_group_letter = 'A' ,
   Optional[String[1]] $dns_alt_names = undef,
   Peadm::SingleTargetSpec $compiler_host,
   Peadm::SingleTargetSpec $primary_host,
@@ -31,6 +31,10 @@ plan peadm::add_compiler(
     $postgresql_host = $external_postgresql_host ? {
       undef   => $peadm_config['role-letter']['server'][$avail_group_letter],
       default => $external_postgresql_host,
+    }
+
+    if $postgresql_host == undef {
+      fail_plan("No PostgreSQL host found for availability group ${avail_group_letter}")
     }
 
     $primary_postgresql_target = peadm::get_targets($postgresql_host, 1)

--- a/spec/plans/add_compiler_spec.rb
+++ b/spec/plans/add_compiler_spec.rb
@@ -18,22 +18,30 @@ describe 'peadm::add_compiler' do
       }
     end
 
+    let(:params_with_avail_group_b) do
+      params.merge({ 'avail_group_letter' => 'B' })
+    end
+
+    let(:params_with_primary_postgresql_host) do
+      params.merge({ 'primary_postgresql_host' => 'custom_postgresql' })
+    end
+
     let(:cfg) do
       {
-        "params" => {
-          "primary_host" => "primary",
-          "replica_host" => nil,
-          "primary_postgresql_host" => nil,
-          "replica_postgresql_host" => nil
+        'params' => {
+          'primary_host' => 'primary',
+          'replica_host' => nil,
+          'primary_postgresql_host' => nil,
+          'replica_postgresql_host' => nil
         },
-        "role-letter" => {
-          "server" => {
-            "A" => "server_a",
-            "B" => nil
+        'role-letter' => {
+          'server' => {
+            'A' => 'server_a',
+            'B' => nil
           },
-          "postgresql": {
-            "A" => nil,
-            "B" => nil
+          'postgresql': {
+            'A' => nil,
+            'B' => nil
           }
         }
       }
@@ -52,10 +60,6 @@ describe 'peadm::add_compiler' do
       expect(run_plan('peadm::add_compiler', params)).to be_ok
     end
 
-    let(:params_with_avail_group_b) do
-      params.merge({ 'avail_group_letter' => 'B' })
-    end
-
     it 'handles different avail_group_letter values' do
       allow_standard_non_returning_calls
       cfg['role-letter']['server']['B'] = 'server_b'
@@ -69,10 +73,6 @@ describe 'peadm::add_compiler' do
       expect_task('peadm::puppet_runonce').with_targets(['server_a'])
       expect_task('peadm::puppet_runonce').with_targets(['server_b'])
       expect(run_plan('peadm::add_compiler', params_with_avail_group_b)).to be_ok
-    end
-
-    let(:params_with_primary_postgresql_host) do
-      params.merge({ 'primary_postgresql_host' => 'custom_postgresql' })
     end
 
     it 'handles specified primary_postgresql_host' do

--- a/spec/plans/add_compiler_spec.rb
+++ b/spec/plans/add_compiler_spec.rb
@@ -5,8 +5,9 @@ describe 'peadm::add_compiler' do
 
   def allow_standard_non_returning_calls
     allow_apply
-    allow_any_task
     allow_any_command
+    execute_no_plan
+    allow_out_message
   end
 
   describe 'basic functionality' do
@@ -14,67 +15,123 @@ describe 'peadm::add_compiler' do
       {
         'primary_host' => 'primary',
         'compiler_host' => 'compiler',
-        'avail_group_letter' => 'A',
-        'primary_postgresql_host' => 'primary_postgresql',
       }
     end
 
     let(:cfg) do
       {
-        'params' => {
-          'primary_host' => 'primary'
+        "params" => {
+          "primary_host" => "primary",
+          "replica_host" => nil,
+          "primary_postgresql_host" => nil,
+          "replica_postgresql_host" => nil
         },
-        'role-letter' => {
-          'server' => {
-            'A' => 'server_a',
-            'B' => 'server_b'
+        "role-letter" => {
+          "server" => {
+            "A" => "server_a",
+            "B" => nil
+          },
+          "postgresql": {
+            "A" => nil,
+            "B" => nil
           }
         }
       }
     end
-    let(:certdata) { { 'certname' => 'primary', 'extensions' => { '1.3.6.1.4.1.34380.1.1.9813' => 'A' } } }
 
     it 'runs successfully when no alt-names are specified' do
       allow_standard_non_returning_calls
 
       expect_task('peadm::get_peadm_config').always_return(cfg)
+      expect_task('peadm::get_psql_version').with_targets(['server_a'])
 
-      # TODO: Due to difficulty mocking get_targets, with_params modifier has been commented out
       expect_plan('peadm::subplans::component_install')
-      # .with_params({
-      #   'targets'            => 'compiler',
-      #   'primary_host'       => 'primary',
-      #   'avail_group_letter' => 'A',
-      #   'dns_alt_names'      => nil,
-      #   'role'               => 'pe_compiler'
-      # })
-
       expect_plan('peadm::util::copy_file').be_called_times(1)
+      expect_task('peadm::puppet_runonce').with_targets(['compiler'])
+      expect_task('peadm::puppet_runonce').with_targets(['server_a'])
       expect(run_plan('peadm::add_compiler', params)).to be_ok
     end
 
-    context 'with alt-names' do
-      let(:params2) do
-        params.merge({ 'dns_alt_names' => 'foo,bar' })
-      end
+    let(:params_with_avail_group_b) do
+      params.merge({ 'avail_group_letter' => 'B' })
+    end
 
-      it 'runs successfully when alt-names are specified' do
-        allow_standard_non_returning_calls
-        expect_task('peadm::get_peadm_config').always_return(cfg)
+    it 'handles different avail_group_letter values' do
+      allow_standard_non_returning_calls
+      cfg['role-letter']['server']['B'] = 'server_b'
 
-        # TODO: Due to difficulty mocking get_targets, with_params modifier has been commented out
-        expect_plan('peadm::subplans::component_install')
-        # .with_params({
-        #   'targets'            => 'compiler',
-        #   'primary_host'       => 'primary',
-        #   'avail_group_letter' => 'A',
-        #   'dns_alt_names'      => 'foo,bar',
-        #   'role'               => 'pe_compiler'
-        # })
+      expect_task('peadm::get_peadm_config').always_return(cfg)
+      expect_task('peadm::get_psql_version').with_targets(['server_b'])
 
-        expect_plan('peadm::util::copy_file').be_called_times(1)
-        expect(run_plan('peadm::add_compiler', params2)).to be_ok
-      end
+      expect_plan('peadm::subplans::component_install')
+      expect_plan('peadm::util::copy_file').be_called_times(1)
+      expect_task('peadm::puppet_runonce').with_targets(['compiler'])
+      expect_task('peadm::puppet_runonce').with_targets(['server_a'])
+      expect_task('peadm::puppet_runonce').with_targets(['server_b'])
+      expect(run_plan('peadm::add_compiler', params_with_avail_group_b)).to be_ok
+    end
+
+    let(:params_with_primary_postgresql_host) do
+      params.merge({ 'primary_postgresql_host' => 'custom_postgresql' })
+    end
+
+    it 'handles specified primary_postgresql_host' do
+      allow_standard_non_returning_calls
+
+      expect_task('peadm::get_peadm_config').always_return(cfg)
+      expect_task('peadm::get_psql_version').with_targets(['custom_postgresql'])
+
+      expect_plan('peadm::subplans::component_install')
+      expect_plan('peadm::util::copy_file').be_called_times(1)
+      expect_task('peadm::puppet_runonce').with_targets(['compiler'])
+      expect_task('peadm::puppet_runonce').with_targets(['custom_postgresql'])
+      expect(run_plan('peadm::add_compiler', params_with_primary_postgresql_host)).to be_ok
+    end
+
+    it 'handles external postgresql host group A' do
+      allow_standard_non_returning_calls
+      cfg['params']['primary_postgresql_host'] = 'external_postgresql'
+      cfg['params']['replica_postgresql_host'] = 'external_postgresql'
+
+      expect_task('peadm::get_peadm_config').always_return(cfg)
+      expect_task('peadm::get_psql_version').with_targets(['external_postgresql'])
+
+      expect_plan('peadm::subplans::component_install')
+      expect_plan('peadm::util::copy_file').be_called_times(1)
+      expect_task('peadm::puppet_runonce').with_targets(['compiler'])
+      expect_task('peadm::puppet_runonce').with_targets(['external_postgresql'])
+      expect(run_plan('peadm::add_compiler', params)).to be_ok
+    end
+
+    it 'handles external postgresql host group A with replica' do
+      allow_standard_non_returning_calls
+      cfg['params']['primary_postgresql_host'] = 'external_postgresql'
+      cfg['role-letter']['server']['B'] = 'replica'
+
+      expect_task('peadm::get_peadm_config').always_return(cfg)
+      expect_task('peadm::get_psql_version').with_targets(['external_postgresql'])
+
+      expect_plan('peadm::subplans::component_install')
+      expect_plan('peadm::util::copy_file').be_called_times(1)
+      expect_task('peadm::puppet_runonce').with_targets(['compiler'])
+      expect_task('peadm::puppet_runonce').with_targets(['external_postgresql'])
+      expect_task('peadm::puppet_runonce').with_targets(['replica'])
+      expect(run_plan('peadm::add_compiler', params)).to be_ok
+    end
+
+    it 'handles external postgresql host group B' do
+      allow_standard_non_returning_calls
+      cfg['params']['replica_postgresql_host'] = 'replica_external_postgresql'
+
+      expect_task('peadm::get_peadm_config').always_return(cfg)
+      expect_task('peadm::get_psql_version').with_targets(['replica_external_postgresql'])
+
+      expect_plan('peadm::subplans::component_install')
+      expect_plan('peadm::util::copy_file').be_called_times(1)
+      expect_task('peadm::puppet_runonce').with_targets(['compiler'])
+      expect_task('peadm::puppet_runonce').with_targets(['replica_external_postgresql'])
+      expect_task('peadm::puppet_runonce').with_targets(['server_a'])
+      expect(run_plan('peadm::add_compiler', params_with_avail_group_b)).to be_ok
     end
   end
 end


### PR DESCRIPTION
## Summary
Making the following parameters optional:

- primary_postgresql_host, if not provided will be determined through get_peadm_config
- avail_group_letter, is defaulting to A

## Additional Context
Add any additional context about the problem here.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [x] Yes
- [ ] Not needed

#### Have you updated the documentation?
- [x] Yes, I've updated the appropriate docs
- [ ] Not needed