### PR TITLE
(PE-38770) Install Plan accepts legacy_compilers key

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -137,7 +137,7 @@ Type: Puppet Language
 
 Assert that the architecture given is a supported one
 
-#### `peadm::assert_supported_architecture(TargetSpec $primary_host, Variant[TargetSpec, Undef] $replica_host = undef, Variant[TargetSpec, Undef] $primary_postgresql_host = undef, Variant[TargetSpec, Undef] $replica_postgresql_host = undef, Variant[TargetSpec, Undef] $compiler_hosts = undef)`
+#### `peadm::assert_supported_architecture(TargetSpec $primary_host, Variant[TargetSpec, Undef] $replica_host = undef, Variant[TargetSpec, Undef] $primary_postgresql_host = undef, Variant[TargetSpec, Undef] $replica_postgresql_host = undef, Variant[TargetSpec, Undef] $compiler_hosts = undef, Variant[TargetSpec, Undef] $legacy_compilers = undef)`
 
 The peadm::assert_supported_architecture function.
 
@@ -168,6 +168,12 @@ Data type: `Variant[TargetSpec, Undef]`
 
 
 ##### `compiler_hosts`
+
+Data type: `Variant[TargetSpec, Undef]`
+
+
+
+##### `legacy_compilers`
 
 Data type: `Variant[TargetSpec, Undef]`
 
@@ -1826,6 +1832,7 @@ The following parameters are available in the `peadm::install` plan:
 * [`primary_host`](#-peadm--install--primary_host)
 * [`replica_host`](#-peadm--install--replica_host)
 * [`compiler_hosts`](#-peadm--install--compiler_hosts)
+* [`legacy_compilers`](#-peadm--install--legacy_compilers)
 * [`primary_postgresql_host`](#-peadm--install--primary_postgresql_host)
 * [`replica_postgresql_host`](#-peadm--install--replica_postgresql_host)
 * [`console_password`](#-peadm--install--console_password)
@@ -1937,6 +1944,14 @@ Data type: `Optional[Peadm::SingleTargetSpec]`
 Default value: `undef`
 
 ##### <a name="-peadm--install--compiler_hosts"></a>`compiler_hosts`
+
+Data type: `Optional[TargetSpec]`
+
+
+
+Default value: `undef`
+
+##### <a name="-peadm--install--legacy_compilers"></a>`legacy_compilers`
 
 Data type: `Optional[TargetSpec]`
 

--- a/documentation/install.md
+++ b/documentation/install.md
@@ -1,68 +1,67 @@
-# Install Puppet Enterprise using the peadm module
+# Install Puppet Enterprise using the PEADM module
 
-The peadm module can be used to install Puppet Enterprise on new infrastructure. Supported architectures include Standard, Large, and Extra Large.
+The PEADM module can be used to install Puppet Enterprise on new infrastructure. Supported architectures include Standard, Large, and Extra Large.
 
-The peadm install plan creates a base install. Once a base cluster is installed, you may need to continue and perform additional configuration and adjustments to reach your target state, depending on your use case.
+The PEADM install plan creates a base install. Once a base cluster is installed, you may need to continue and perform additional configuration and adjustments to reach your target state, depending on your use case.
 
 ## Reference Architectures
 
-When installing a new PE cluster using peadm, there are several different host parameters which can be specified. At a minimum, you must always specify the primary parameter. Depending on which architecture you are deploying, other host parameters may be needed as well. The following is a list of the architectures peadm can install and the required parameters.
+When installing a new PE cluster using PEADM, several different host parameters can be specified. At a minimum, you must always specify the primary parameter. Depending on which architecture you are deploying, other host parameters may be needed as well. The following is a list of the architectures PEADM can install and the required parameters.
 
-* Standard
-    - primary
-* Standard with DR
-    - primary
-    - primary-replica
-* Large
-    - primary
-    - compilers
-* Large with DR
-    - primary
-    - primary-replica
-    - compilers
-* Extra Large
-    - primary
-    - pdb-database
-    - compilers (optional)
-* Extra Large with DR
-    - primary
-    - primary-replica
-    - pdb-database
-    - pdb-database-replica
-    - compilers (optional)
+- Standard
+  - primary
+- Standard with DR
+  - primary
+  - primary-replica
+- Large
+  - primary
+  - compilers
+- Large with DR
+  - primary
+  - primary-replica
+  - compilers
+- Extra Large
+  - primary
+  - pdb-database
+  - compilers (optional)
+- Extra Large with DR
+  - primary
+  - primary-replica
+  - pdb-database
+  - pdb-database-replica
+  - compilers (optional)
 
-Supplying a combination of host parameters which does not match one of the supported architectures above will result in an unsupported architecture error.
+Supplying a combination of host parameters that do not match one of the supported architectures above will result in an unsupported architecture error.
 
 ## Requirements
 
-* Puppet must not be installed on any of the target PE cluster hosts prior to beginning install.
+Puppets must not be installed on any of the target PE cluster hosts prior to beginning installation.
 
 ## Usage
 
 ### Bolt 3 usage
+
 We will name the bolt project `large_ha_peadm` in this example but the project name can be anything.
 
 1. Install Bolt on a jumphost. This can be the primary, or any other system. (via package)
 2. Run `mkdir large_ha_peadm && cd large_ha_peadm && bolt project init large_ha_peadm --modules puppetlabs-peadm`
-4. Create an inventory file with connection information. Example included below.
-5. Create a parameters file. Example included below.
-6. Run `bolt plan run peadm::install --params @params.json ` after the inventory and params files are created.
-
+3. Create an inventory file with connection information. Example included below.
+4. Create a parameters file. Example included below.
+5. Run `bolt plan run peadm::install --params @params.json ` after the inventory and params files are created.
 
 ### Bolt 2 usage
 
-1. Install Bolt on a jumphost. This can be the primary, or any other system.
-2. Download or git clone the peadm module and put it somewhere on the jumphost. e.g. ~/modules/peadm.
-3. Download or git clone the module dependencies, and put them somewhere on the jumphost. e.g. ~/modules/stdlib, ~/modules/node\_manager, etc.
-4. Create an inventory file with connection information. Example included below.
-5. Create a parameters file. Example included below.
-6. Run the peadm::install plan with the inputs created. Example:
+1.  Install Bolt on a jumphost. This can be the primary or any other system.
+2.  Download or git clone the PEADM module and put it somewhere on the jumphost. e.g. ~/modules/peadm.
+3.  Download or git clone the module dependencies, and put them somewhere on the jumphost. e.g. ~/modules/stdlib, ~/modules/node_manager, etc.
+4.  Create an inventory file with connection information. Example included below.
+5.  Create a parameters file. Example included below.
+6.  Run the peadm::install plan with the inputs created. Example:
 
         bolt plan run peadm::install \
           --inventory inventory.yaml \
           --modulepath ~/modules \
           --params @params.json
-
 
 Example inventory.yaml Bolt inventory file:
 
@@ -85,9 +84,13 @@ groups:
         uri: 10.234.6.45
       - name: pe-xl-compiler-1.lab1.puppet.vm
         uri: 10.234.14.131
+      - name: pe-xl-legacy-compiler-0.lab1.puppet.vm
+        uri: 10.234.6.46
+      - name: pe-xl-legacy-compiler-1.lab1.puppet.vm
+        uri: 10.234.6.47
 ```
 
-Example params.json Bolt parameters file (shown: Extra Large with DR):
+example params.json bolt parameters file (shown: extra large with dr):
 
 ```json
 {
@@ -99,9 +102,12 @@ Example params.json Bolt parameters file (shown: Extra Large with DR):
     "pe-xl-compiler-0.lab1.puppet.vm",
     "pe-xl-compiler-1.lab1.puppet.vm"
   ],
-
+  "legacy_compilers": [
+    "pe-xl-legacy-compiler-0.lab1.puppet.vm",
+    "pe-xl-legacy-compiler-1.lab1.puppet.vm"
+  ],
   "console_password": "puppetlabs",
-  "dns_alt_names": [ "puppet", "puppet.lab1.puppet.vm" ],
+  "dns_alt_names": ["puppet", "puppet.lab1.puppet.vm"],
   "compiler_pool_address": "puppet.lab1.puppet.vm",
   "version": "2021.7.0"
 }
@@ -113,12 +119,12 @@ Example params.json Bolt parameters file (shown: Standard):
 {
   "primary_host": "pe-xl-core-0.lab1.puppet.vm",
   "console_password": "puppetlabs",
-  "dns_alt_names": [ "puppet", "puppet.lab1.puppet.vm" ],
+  "dns_alt_names": ["puppet", "puppet.lab1.puppet.vm"],
   "version": "2021.7.8"
 }
 ```
 
-Review the [peadm::install plan](../plans/install.pp) to learn about more advanced installation options. For example, it is possible to: supply an ssh private key and git clone URL for a control-repo as part of installation; supply the LDAP configuration data for PE; specify where the installer tarball is uploaded; and similar complete automation tie-ins.
+Review the [peadm::install plan](../plans/install.pp) to learn about more advanced installation options. For example, it is possible to: supply an SSH private key and git clone URL for a control-repo as part of installation; supply the LDAP configuration data for PE; specify where the installer tarball is uploaded; and similar complete automation tie-ins.
 
 ## Offline usage
 
@@ -126,28 +132,27 @@ The peadm::install plan downloads installation content from an online repository
 
 The default staging directory is `/tmp`. If a different staging dir is being used, it can be specified using the `stagingdir` parameter to the peadm::install plan.
 
-The content needed is the PE installation tarball for the target version. The installation content should be in the staging dir, and should have its original name. E.g. `/tmp/puppet-enterprise-2021.4.0-el-7-x86_64.tar.gz`.
+The content needed is the PE installation tarball for the target version. The installation content should be in the staging dir and should have its original name. E.g. `/tmp/puppet-enterprise-2021.4.0-el-7-x86_64.tar.gz`.
 
 Installation content can be downloaded from [https://puppet.com/try-puppet/puppet-enterprise/download/](https://puppet.com/try-puppet/puppet-enterprise/download/).
 
-If you wish to prevent the bolt host from transferring the installer tarball to the targets you can place the installer tar files on the target hosts in the _upload directory_. This can save time over slow networks, but is best to just perform the bolt task on the target node (puppetserver). The default _upload directory_ is `/tmp`. If a different upload dir is being used, it can be specified using the `uploaddir` parameter to the peadm::install plan. With default parameters the tar file will need to exist in the directories for offline configuration:
+If you wish to prevent the bolt host from transferring the installer tarball to the targets you can place the installer tar files on the target hosts in the _upload directory_. This can save time over slow networks, but is best to just perform the bolt task on the target node (puppetserver). The default _upload directory_ is `/tmp`. If a different upload dir is being used, it can be specified using the `uploaddir` parameter to the peadm::install plan. With default parameters, the tar file will need to exist in the directories for offline configuration:
 
-* /tmp on the Bolt host
-* /tmp on the primary
-* /tmp on the primary PuppetDB PostgreSQL (if used)
-* /tmp on the replica PuppetDB PostgreSQL (if used)
+- /tmp on the Bolt host
+- /tmp on the primary
+- /tmp on the primary PuppetDB PostgreSQL (if used)
+- /tmp on the replica PuppetDB PostgreSQL (if used)
 
 ## Online usage
 
-The peadm::install plan can be configured to download installation content directly to hosts. To configure online installation, set the `download_mode` parameter of the `peadm::install` plan to `direct`. The direct mode is often more efficient when PE hosts have a route to the internet.
+The peadm::install plan can be configured to download installation content directly to hosts. To configure the online installation, set the `download_mode` parameter of the `peadm::install` plan to `direct`. The direct mode is often more efficient when PE hosts have a route to the internet.
 
 ## Hostnames and Certificate Names
 
 The various host parameters given to the peadm::install or peadm::action::install plans will be set as Puppet certificate names. You must use the names here that you want the servers to be identified as by Puppet.
 
 While it is not required that target names match hostnames, it _is_ required that target names be resolvable.
-
-In the event that Bolt will reach servers by IP address or external DNS name rather than internal DNS name or desired certname, a Bolt inventory file should be used to specify URIs for each name. For example:
+If Bolt will reach servers by IP address or external DNS name rather than internal DNS name or desired certname, a Bolt inventory file should be used to specify URIs for each name. For example:
 
 ```yaml
 ---
@@ -158,7 +163,7 @@ targets:
     uri: 10.234.14.131
 ```
 
-A parameters JSON file can then reference the target names, which will become the Puppet certificate names, and Bolt will still be able to reach the systems by using the IP addresses or other DNS name specified as the URIs in the inventory.yaml file.
+A parameters JSON file can then reference the target names, which will become the Puppet certificate names, and Bolt will still be able to reach the systems by using the IP addresses or other DNS names specified as the URIs in the inventory.yaml file.
 
 ```json
 {
@@ -166,7 +171,7 @@ A parameters JSON file can then reference the target names, which will become th
   "replica_host": "pe-xl-core-1.lab1.puppet.vm",
 
   "console_password": "puppetlabs",
-  "dns_alt_names": [ "puppet", "puppet.lab1.puppet.vm" ],
+  "dns_alt_names": ["puppet", "puppet.lab1.puppet.vm"],
   "compiler_pool_address": "puppet.lab1.puppet.vm",
   "version": "2021.7.0"
 }
@@ -174,12 +179,11 @@ A parameters JSON file can then reference the target names, which will become th
 
 ## Implementation Reference
 
-Provisioning can be broken down into two actions: [install](../plans/action/install.pp), and [configure](../plans/subplans/configure.pp). Installation currently requires ssh access to the un-installed nodes, but configure can be performed using the Orchestrator transport if installation has already been completed.
+Provisioning can be broken down into two actions: [install](../plans/action/install.pp), and [configure](../plans/subplans/configure.pp). The installation currently requires SSH access to the uninstalled nodes, but configuration can be performed using the Orchestrator transport if the installation has already been completed.
 
-Besides getting Puppet Enterprise installed, the key configuration supporting Large and Extra Large architectures is laid out in four classification groups. Links are provided below to a Markdown document that describes the groups, and also to the Puppet manifest that actually configures them:
+Besides getting Puppet Enterprise installed, the key configuration supporting Large and Extra-large architectures is laid out in four classification groups. Links are provided below to a Markdown document that describes the groups, and also to the Puppet manifest that configures them:
 
-* [classification.md](classification.md)
-* [peadm::setup::node\_manager class](../manifests/setup/node_manager.pp)
+- [classification.md](classification.md)
+- [peadm::setup::node_manager class](../manifests/setup/node_manager.pp)
 
-The reference implementation uses trusted facts to put nodes in the right groups. Because the important puppet\_enterprise::\* class parameters and data are specified in the console, it should also be safe to have a pe.conf present on both the primary, and the primary replica nodes.
-
+The reference implementation uses trusted facts to put nodes in the right groups. Because the important puppet_enterprise::\* class parameters and data are specified in the console, it should also be safe to have a pe.conf present on both the primary and the primary replica nodes.

--- a/documentation/install.md
+++ b/documentation/install.md
@@ -35,7 +35,7 @@ Supplying a combination of host parameters that do not match one of the supporte
 
 ## Requirements
 
-Puppets must not be installed on any of the target PE cluster hosts prior to beginning installation.
+Puppet must not be installed on any of the target PE cluster hosts before beginning installation.
 
 ## Usage
 

--- a/functions/assert_supported_architecture.pp
+++ b/functions/assert_supported_architecture.pp
@@ -7,8 +7,28 @@ function peadm::assert_supported_architecture (
   Variant[TargetSpec, Undef] $compiler_hosts = undef,
   Variant[TargetSpec, Undef] $legacy_compilers = undef,
 )  >> Hash {
-  # At least one of the compilers variables should be set
-  $has_compilers = $compiler_hosts + $legacy_compilers
+  # Normalize $legacy_compilers to an array
+  $legacy_compilers_array = $legacy_compilers ? {
+    undef   => [],
+    String  => [$legacy_compilers],
+    Array   => $legacy_compilers,
+    default => fail("Unexpected type for \$legacy_compilers: ${legacy_compilers}"),
+  }
+
+  # Normalize $compiler_hosts to an array
+  $compiler_hosts_array = $compiler_hosts ? {
+    undef   => [],
+    String  => [$compiler_hosts],
+    Array   => $compiler_hosts,
+    default => fail("Unexpected type for \$compiler_hosts: ${compiler_hosts}"),
+  }
+  $all_compilers = $legacy_compilers_array + $compiler_hosts_array
+
+  # Set $has_compilers to undef if $all_compilers is empty, otherwise set it to true
+  $has_compilers = empty($all_compilers) ? {
+    true    => undef,
+    default => true,
+  }
 
   $result = case [
     !!($primary_host),
@@ -17,13 +37,13 @@ function peadm::assert_supported_architecture (
     !!($replica_postgresql_host),
   ] {
     [true, false, false, false]: { # Standard or Large, no DR
-      ({ 'disaster-recovery' => false, 'architecture' => $has_compilers? {
+      ({ 'disaster-recovery' => false, 'architecture' => $has_compilers ? {
             undef   => 'standard',
             default => 'large',
       } })
     }
     [true, true, false, false]: { # Standard or Large, DR
-      ({ 'disaster-recovery' => true, 'architecture' => $has_compilers? {
+      ({ 'disaster-recovery' => true, 'architecture' => $has_compilers ? {
             undef   => 'standard',
             default => 'large',
       } })
@@ -48,7 +68,7 @@ function peadm::assert_supported_architecture (
         <% if $replica_postgresql_host { -%>
           - pdb-database-replica
         <% } -%>
-        <% if $has_compilers{ -%>
+        <% if $has_compilers { -%>
           - compilers
         <% } -%>
 

--- a/functions/assert_supported_architecture.pp
+++ b/functions/assert_supported_architecture.pp
@@ -5,7 +5,11 @@ function peadm::assert_supported_architecture (
   Variant[TargetSpec, Undef] $primary_postgresql_host = undef,
   Variant[TargetSpec, Undef] $replica_postgresql_host = undef,
   Variant[TargetSpec, Undef] $compiler_hosts = undef,
+  Variant[TargetSpec, Undef] $legacy_compilers = undef,
 )  >> Hash {
+  # At least one of the compilers variables should be set
+  $has_compilers = $compiler_hosts + $legacy_compilers
+
   $result = case [
     !!($primary_host),
     !!($replica_host),
@@ -13,13 +17,13 @@ function peadm::assert_supported_architecture (
     !!($replica_postgresql_host),
   ] {
     [true, false, false, false]: { # Standard or Large, no DR
-      ({ 'disaster-recovery' => false, 'architecture' => $compiler_hosts ? {
+      ({ 'disaster-recovery' => false, 'architecture' => $has_compilers? {
             undef   => 'standard',
             default => 'large',
       } })
     }
     [true, true, false, false]: { # Standard or Large, DR
-      ({ 'disaster-recovery' => true, 'architecture' => $compiler_hosts ? {
+      ({ 'disaster-recovery' => true, 'architecture' => $has_compilers? {
             undef   => 'standard',
             default => 'large',
       } })
@@ -44,7 +48,7 @@ function peadm::assert_supported_architecture (
         <% if $replica_postgresql_host { -%>
           - pdb-database-replica
         <% } -%>
-        <% if $compiler_hosts { -%>
+        <% if $has_compilers{ -%>
           - compilers
         <% } -%>
 

--- a/plans/convert_compiler_to_legacy.pp
+++ b/plans/convert_compiler_to_legacy.pp
@@ -5,7 +5,7 @@ plan peadm::convert_compiler_to_legacy (
   Boolean $remove_pdb = false,
 ) {
   $primary_target            = peadm::get_targets($primary_host, 1)
-  $legacy_targets             = peadm::get_targets($legacy_hosts)
+  $legacy_compiler_targets             = peadm::get_targets($legacy_hosts)
 
   $cluster = run_task('peadm::get_peadm_config', $primary_host).first.value
   $error = getvar('cluster.error')
@@ -22,8 +22,8 @@ plan peadm::convert_compiler_to_legacy (
   ])
 
   if $remove_pdb {
-    run_command('puppet resource service puppet ensure=stopped', $legacy_targets)
-    run_command('puppet resource service pe-puppetdb ensure=stopped enable=false', $legacy_targets)
+    run_command('puppet resource service puppet ensure=stopped', $legacy_compiler_targets)
+    run_command('puppet resource service pe-puppetdb ensure=stopped enable=false', $legacy_compiler_targets)
   }
 
   apply($primary_target) {
@@ -36,23 +36,23 @@ plan peadm::convert_compiler_to_legacy (
     }
   }
 
-  run_plan('peadm::update_compiler_extensions',  compiler_hosts => $legacy_targets, primary_host => $primary_target, legacy => true)
+  run_plan('peadm::update_compiler_extensions',  compiler_hosts => $legacy_compiler_targets, primary_host => $primary_target, legacy => true)
 
-  run_task('peadm::puppet_runonce', $legacy_targets)
+  run_task('peadm::puppet_runonce', $legacy_compiler_targets)
   run_task('peadm::puppet_runonce', $primary_target)
   run_task('peadm::puppet_runonce', $all_targets)
 
   if $remove_pdb {
-    run_command('puppet resource package pe-puppetdb ensure=purged', $legacy_targets)
-    run_command('puppet resource user pe-puppetdb ensure=absent', $legacy_targets)
+    run_command('puppet resource package pe-puppetdb ensure=purged', $legacy_compiler_targets)
+    run_command('puppet resource user pe-puppetdb ensure=absent', $legacy_compiler_targets)
 
-    run_command('rm -rf /etc/puppetlabs/puppetdb', $legacy_targets)
-    run_command('rm -rf /var/log/puppetlabs/puppetdb', $legacy_targets)
-    run_command('rm -rf /opt/puppetlabs/server/data/puppetdb', $legacy_targets)
+    run_command('rm -rf /etc/puppetlabs/puppetdb', $legacy_compiler_targets)
+    run_command('rm -rf /var/log/puppetlabs/puppetdb', $legacy_compiler_targets)
+    run_command('rm -rf /opt/puppetlabs/server/data/puppetdb', $legacy_compiler_targets)
   }
 
-  run_command('systemctl start pe-puppetserver.service', $legacy_targets)
-  run_command('puppet resource service puppet ensure=running', $legacy_targets)
+  run_command('systemctl start pe-puppetserver.service', $legacy_compiler_targets)
+  run_command('puppet resource service puppet ensure=running', $legacy_compiler_targets)
 
-  return("Converted host ${legacy_targets} to legacy compiler.")
+  return("Converted host ${legacy_compiler_targets} to legacy compiler.")
 }

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -38,6 +38,7 @@ plan peadm::install (
 
   # Large
   Optional[TargetSpec]              $compiler_hosts = undef,
+  Optional[TargetSpec]              $legacy_compilers = undef,
 
   # Extra Large
   Optional[Peadm::SingleTargetSpec] $primary_postgresql_host = undef,
@@ -85,6 +86,7 @@ plan peadm::install (
 
     # Large
     compiler_hosts                 => $compiler_hosts,
+    legacy_compilers               => $legacy_compilers,
 
     # Extra Large
     primary_postgresql_host        => $primary_postgresql_host,
@@ -123,6 +125,7 @@ plan peadm::install (
 
     # Large
     compiler_hosts                   => $compiler_hosts,
+    legacy_compilers                 => $legacy_compilers,
 
     # Extra Large
     primary_postgresql_host          => $primary_postgresql_host,

--- a/plans/subplans/configure.pp
+++ b/plans/subplans/configure.pp
@@ -27,6 +27,7 @@ plan peadm::subplans::configure (
 
   # Large
   Optional[TargetSpec]              $compiler_hosts = undef,
+  Optional[TargetSpec]              $legacy_compilers = undef,
 
   # Extra Large
   Optional[Peadm::SingleTargetSpec] $primary_postgresql_host = undef,
@@ -51,6 +52,7 @@ plan peadm::subplans::configure (
   $replica_target                   = peadm::get_targets($replica_host, 1)
   $replica_postgresql_target        = peadm::get_targets($replica_postgresql_host, 1)
   $compiler_targets                 = peadm::get_targets($compiler_hosts)
+  $legacy_targets                   = peadm::get_targets($legacy_compilers)
   $primary_postgresql_target        = peadm::get_targets($primary_postgresql_host, 1)
 
   # Ensure input valid for a supported architecture
@@ -60,6 +62,7 @@ plan peadm::subplans::configure (
     $primary_postgresql_host,
     $replica_postgresql_host,
     $compiler_hosts,
+    $legacy_compilers,
   )
 
   # Source list of files on Primary and synchronize to new Replica
@@ -74,6 +77,7 @@ plan peadm::subplans::configure (
   run_plan('peadm::util::copy_file', peadm::flatten_compact([
         $replica_target,
         $compiler_targets,
+        $legacy_targets,
     ]),
     source_host   => $primary_target,
     path          => $common_content_source
@@ -139,6 +143,7 @@ plan peadm::subplans::configure (
         $primary_target,
         $primary_postgresql_target,
         $compiler_targets,
+        $legacy_targets,
         $replica_target,
         $replica_postgresql_target,
   ]))
@@ -161,6 +166,7 @@ plan peadm::subplans::configure (
         $primary_postgresql_target,
         $replica_postgresql_target,
         $compiler_targets,
+        $legacy_targets,
   ]))
 
   return("Configuration of Puppet Enterprise ${arch['architecture']} succeeded.")

--- a/plans/subplans/configure.pp
+++ b/plans/subplans/configure.pp
@@ -52,7 +52,7 @@ plan peadm::subplans::configure (
   $replica_target                   = peadm::get_targets($replica_host, 1)
   $replica_postgresql_target        = peadm::get_targets($replica_postgresql_host, 1)
   $compiler_targets                 = peadm::get_targets($compiler_hosts)
-  $legacy_targets                   = peadm::get_targets($legacy_compilers)
+  $legacy_compiler_targets                   = peadm::get_targets($legacy_compilers)
   $primary_postgresql_target        = peadm::get_targets($primary_postgresql_host, 1)
 
   # Ensure input valid for a supported architecture
@@ -77,7 +77,7 @@ plan peadm::subplans::configure (
   run_plan('peadm::util::copy_file', peadm::flatten_compact([
         $replica_target,
         $compiler_targets,
-        $legacy_targets,
+        $legacy_compiler_targets,
     ]),
     source_host   => $primary_target,
     path          => $common_content_source
@@ -143,7 +143,7 @@ plan peadm::subplans::configure (
         $primary_target,
         $primary_postgresql_target,
         $compiler_targets,
-        $legacy_targets,
+        $legacy_compiler_targets,
         $replica_target,
         $replica_postgresql_target,
   ]))
@@ -166,7 +166,7 @@ plan peadm::subplans::configure (
         $primary_postgresql_target,
         $replica_postgresql_target,
         $compiler_targets,
-        $legacy_targets,
+        $legacy_compiler_targets,
   ]))
 
   return("Configuration of Puppet Enterprise ${arch['architecture']} succeeded.")

--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -41,6 +41,7 @@ plan peadm::subplans::install (
 
   # Large
   Optional[TargetSpec]              $compiler_hosts           = undef,
+  Optional[TargetSpec]              $legacy_compilers         = undef,
 
   # Extra Large
   Optional[Peadm::SingleTargetSpec] $primary_postgresql_host  = undef,
@@ -79,6 +80,7 @@ plan peadm::subplans::install (
   $primary_postgresql_target = peadm::get_targets($primary_postgresql_host, 1)
   $replica_postgresql_target = peadm::get_targets($replica_postgresql_host, 1)
   $compiler_targets          = peadm::get_targets($compiler_hosts)
+  $legacy_targets            = peadm::get_targets($legacy_compilers)
 
   # Ensure input valid for a supported architecture
   $arch = peadm::assert_supported_architecture(
@@ -87,6 +89,7 @@ plan peadm::subplans::install (
     $primary_postgresql_host,
     $replica_postgresql_host,
     $compiler_hosts,
+    $legacy_compilers,
   )
 
   $all_targets = peadm::flatten_compact([
@@ -95,6 +98,7 @@ plan peadm::subplans::install (
       $replica_target,
       $replica_postgresql_target,
       $compiler_targets,
+      $legacy_targets,
   ])
 
   $primary_targets = peadm::flatten_compact([
@@ -115,6 +119,7 @@ plan peadm::subplans::install (
 
   $agent_installer_targets = peadm::flatten_compact([
       $compiler_targets,
+      $legacy_targets,
       $replica_target,
   ])
 
@@ -122,10 +127,14 @@ plan peadm::subplans::install (
   if $arch['disaster-recovery'] {
     $compiler_a_targets = $compiler_targets.filter |$index,$target| { $index % 2 == 0 }
     $compiler_b_targets = $compiler_targets.filter |$index,$target| { $index % 2 != 0 }
+    $legacy_a_targets   = $legacy_targets.filter |$index,$target| { $index % 2 == 0 }
+    $legacy_b_targets   = $legacy_targets.filter |$index,$target| { $index % 2 != 0 }
   }
   else {
     $compiler_a_targets = $compiler_targets
     $compiler_b_targets = []
+    $legacy_a_targets   = $legacy_targets
+    $legacy_b_targets   = []
   }
 
   $dns_alt_names_csv = $dns_alt_names.reduce |$csv,$x| { "${csv},${x}" }
@@ -143,7 +152,7 @@ plan peadm::subplans::install (
     true
   } elsif $replica_host {
     true
-  } elsif $compiler_hosts {
+  } elsif $compiler_hosts or $legacy_compilers {
     true
   } else {
     $code_manager_auto_configure
@@ -179,7 +188,7 @@ plan peadm::subplans::install (
   # puppet and are present in PuppetDB, it is not necessary anymore.
   $puppetdb_database_temp_config = {
     'puppet_enterprise::profile::database::puppetdb_hosts' => (
-      $compiler_targets + $primary_target + $replica_target
+      $compiler_targets + $legacy_targets + $primary_target + $replica_target
     ).map |$t| { $t.peadm::certname() },
   }
 
@@ -288,6 +297,24 @@ plan peadm::subplans::install (
           peadm::oid('pp_auth_role')             => 'pe_compiler',
           peadm::oid('peadm_availability_group') => 'B',
           peadm::oid('peadm_legacy_compiler')    => 'false',
+        }
+      )
+    },
+    background('compiler-a-csr.yaml') || {
+      run_plan('peadm::util::insert_csr_extension_requests', $legacy_a_targets,
+        extension_requests => {
+          peadm::oid('pp_auth_role')             => 'pe_compiler',
+          peadm::oid('peadm_availability_group') => 'A',
+          peadm::oid('peadm_legacy_compiler')    => 'true',
+        }
+      )
+    },
+    background('compiler-b-csr.yaml') || {
+      run_plan('peadm::util::insert_csr_extension_requests', $legacy_b_targets,
+        extension_requests => {
+          peadm::oid('pp_auth_role')             => 'pe_compiler',
+          peadm::oid('peadm_availability_group') => 'B',
+          peadm::oid('peadm_legacy_compiler')    => 'true',
         }
       )
     },

--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -80,7 +80,7 @@ plan peadm::subplans::install (
   $primary_postgresql_target = peadm::get_targets($primary_postgresql_host, 1)
   $replica_postgresql_target = peadm::get_targets($replica_postgresql_host, 1)
   $compiler_targets          = peadm::get_targets($compiler_hosts)
-  $legacy_targets            = peadm::get_targets($legacy_compilers)
+  $legacy_compiler_targets            = peadm::get_targets($legacy_compilers)
 
   # Ensure input valid for a supported architecture
   $arch = peadm::assert_supported_architecture(
@@ -98,7 +98,7 @@ plan peadm::subplans::install (
       $replica_target,
       $replica_postgresql_target,
       $compiler_targets,
-      $legacy_targets,
+      $legacy_compiler_targets,
   ])
 
   $primary_targets = peadm::flatten_compact([
@@ -119,7 +119,7 @@ plan peadm::subplans::install (
 
   $agent_installer_targets = peadm::flatten_compact([
       $compiler_targets,
-      $legacy_targets,
+      $legacy_compiler_targets,
       $replica_target,
   ])
 
@@ -127,13 +127,13 @@ plan peadm::subplans::install (
   if $arch['disaster-recovery'] {
     $compiler_a_targets = $compiler_targets.filter |$index,$target| { $index % 2 == 0 }
     $compiler_b_targets = $compiler_targets.filter |$index,$target| { $index % 2 != 0 }
-    $legacy_a_targets   = $legacy_targets.filter |$index,$target| { $index % 2 == 0 }
-    $legacy_b_targets   = $legacy_targets.filter |$index,$target| { $index % 2 != 0 }
+    $legacy_a_targets   = $legacy_compiler_targets.filter |$index,$target| { $index % 2 == 0 }
+    $legacy_b_targets   = $legacy_compiler_targets.filter |$index,$target| { $index % 2 != 0 }
   }
   else {
     $compiler_a_targets = $compiler_targets
     $compiler_b_targets = []
-    $legacy_a_targets   = $legacy_targets
+    $legacy_a_targets   = $legacy_compiler_targets
     $legacy_b_targets   = []
   }
 
@@ -188,7 +188,7 @@ plan peadm::subplans::install (
   # puppet and are present in PuppetDB, it is not necessary anymore.
   $puppetdb_database_temp_config = {
     'puppet_enterprise::profile::database::puppetdb_hosts' => (
-      $compiler_targets + $legacy_targets + $primary_target + $replica_target
+      $compiler_targets + $legacy_compiler_targets + $primary_target + $replica_target
     ).map |$t| { $t.peadm::certname() },
   }
 

--- a/spec/functions/assert_supported_architecture_spec.rb
+++ b/spec/functions/assert_supported_architecture_spec.rb
@@ -1,49 +1,50 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require 'spec_helper'
 # TODO: test the error case, however due to an issue with boltspec
 # and functions we cannot do this right now.
 # https://github.com/puppetlabs/bolt/issues/1688
 
-describe "peadm::assert_supported_architecture" do
+describe 'peadm::assert_supported_architecture' do
   let(:pre_condition) do
-    "type TargetSpec = Variant[String[1], Target, Array[TargetSpec]]"
+    'type TargetSpec = Variant[String[1], Target, Array[TargetSpec]]'
   end
   let(:primary_host) do
-    "puppet-std.puppet.vm"
+    'puppet-std.puppet.vm'
   end
   let(:replica_host) do
-    "pup-replica.puppet.vm"
+    'pup-replica.puppet.vm'
   end
   let(:primary_postgresql_host) do
-    "pup-db.puppet.vm"
+    'pup-db.puppet.vm'
   end
   let(:replica_postgresql_host) do
-    "pup-db-replica.puppet.vm"
+    'pup-db-replica.puppet.vm'
   end
   let(:compiler_hosts) do
-    "pup-c1.puppet.vm"
+    'pup-c1.puppet.vm'
   end
   let(:legacy_compilers) do
-    "pup-c2.puppet.vm"
+    'pup-c2.puppet.vm'
   end
   let(:compiler_hosts_array) do
-    ["pup-c1.puppet.vm"]
+    ['pup-c1.puppet.vm']
   end
   let(:legacy_compilers_array) do
-    ["pup-c2.puppet.vm"]
+    ['pup-c2.puppet.vm']
   end
+
   it {
     is_expected.to run.with_params(primary_host)
-                      .and_return("supported" => true,
-                                  "disaster-recovery" => false,
-                                  "architecture" => "standard")
+                      .and_return('supported' => true,
+                                  'disaster-recovery' => false,
+                                  'architecture' => 'standard')
   }
   it {
     is_expected.to run.with_params(primary_host, replica_host)
-                      .and_return("supported" => true,
-                                  "disaster-recovery" => true,
-                                  "architecture" => "standard")
+                      .and_return('supported' => true,
+                                  'disaster-recovery' => true,
+                                  'architecture' => 'standard')
   }
 
   it do
@@ -52,9 +53,9 @@ describe "peadm::assert_supported_architecture" do
                                    nil,
                                    nil,
                                    compiler_hosts)
-                      .and_return("supported" => true,
-                                  "disaster-recovery" => true,
-                                  "architecture" => "large")
+                      .and_return('supported' => true,
+                                  'disaster-recovery' => true,
+                                  'architecture' => 'large')
   end
 
   it do
@@ -63,9 +64,9 @@ describe "peadm::assert_supported_architecture" do
                                    nil,
                                    nil,
                                    compiler_hosts)
-                      .and_return("supported" => true,
-                                  "disaster-recovery" => false,
-                                  "architecture" => "large")
+                      .and_return('supported' => true,
+                                  'disaster-recovery' => false,
+                                  'architecture' => 'large')
   end
   it do
     is_expected.to run.with_params(primary_host,
@@ -74,9 +75,9 @@ describe "peadm::assert_supported_architecture" do
                                    nil,
                                    compiler_hosts,
                                    legacy_compilers)
-                      .and_return("supported" => true,
-                                  "disaster-recovery" => false,
-                                  "architecture" => "large")
+                      .and_return('supported' => true,
+                                  'disaster-recovery' => false,
+                                  'architecture' => 'large')
   end
   it do
     is_expected.to run.with_params(primary_host,
@@ -85,9 +86,9 @@ describe "peadm::assert_supported_architecture" do
                                    nil,
                                    nil,
                                    legacy_compilers)
-                      .and_return("supported" => true,
-                                  "disaster-recovery" => false,
-                                  "architecture" => "large")
+                      .and_return('supported' => true,
+                                  'disaster-recovery' => false,
+                                  'architecture' => 'large')
   end
 
   it do
@@ -96,9 +97,9 @@ describe "peadm::assert_supported_architecture" do
                                    primary_postgresql_host,
                                    replica_postgresql_host,
                                    compiler_hosts)
-                      .and_return("supported" => true,
-                                  "disaster-recovery" => true,
-                                  "architecture" => "extra-large")
+                      .and_return('supported' => true,
+                                  'disaster-recovery' => true,
+                                  'architecture' => 'extra-large')
   end
 
   it do
@@ -107,9 +108,9 @@ describe "peadm::assert_supported_architecture" do
                                    primary_postgresql_host,
                                    nil,
                                    compiler_hosts)
-                      .and_return("supported" => true,
-                                  "disaster-recovery" => false,
-                                  "architecture" => "extra-large")
+                      .and_return('supported' => true,
+                                  'disaster-recovery' => false,
+                                  'architecture' => 'extra-large')
   end
   it do
     is_expected.to run.with_params(primary_host,
@@ -118,9 +119,9 @@ describe "peadm::assert_supported_architecture" do
                                    nil,
                                    compiler_hosts,
                                    legacy_compilers)
-                      .and_return("supported" => true,
-                                  "disaster-recovery" => false,
-                                  "architecture" => "extra-large")
+                      .and_return('supported' => true,
+                                  'disaster-recovery' => false,
+                                  'architecture' => 'extra-large')
   end
   it do
     is_expected.to run.with_params(primary_host,
@@ -129,8 +130,8 @@ describe "peadm::assert_supported_architecture" do
                                    nil,
                                    compiler_hosts_array,
                                    legacy_compilers_array)
-                      .and_return("supported" => true,
-                                  "disaster-recovery" => false,
-                                  "architecture" => "extra-large")
+                      .and_return('supported' => true,
+                                  'disaster-recovery' => false,
+                                  'architecture' => 'extra-large')
   end
 end

--- a/spec/functions/assert_supported_architecture_spec.rb
+++ b/spec/functions/assert_supported_architecture_spec.rb
@@ -1,41 +1,49 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 # TODO: test the error case, however due to an issue with boltspec
 # and functions we cannot do this right now.
 # https://github.com/puppetlabs/bolt/issues/1688
 
-describe 'peadm::assert_supported_architecture' do
+describe "peadm::assert_supported_architecture" do
   let(:pre_condition) do
-    'type TargetSpec = Variant[String[1], Target, Array[TargetSpec]]'
+    "type TargetSpec = Variant[String[1], Target, Array[TargetSpec]]"
   end
   let(:primary_host) do
-    'puppet-std.puppet.vm'
+    "puppet-std.puppet.vm"
   end
   let(:replica_host) do
-    'pup-replica.puppet.vm'
+    "pup-replica.puppet.vm"
   end
   let(:primary_postgresql_host) do
-    'pup-db.puppet.vm'
+    "pup-db.puppet.vm"
   end
   let(:replica_postgresql_host) do
-    'pup-db-replica.puppet.vm'
+    "pup-db-replica.puppet.vm"
   end
   let(:compiler_hosts) do
-    'pup-c1.puppet.vm'
+    "pup-c1.puppet.vm"
   end
-
+  let(:legacy_compilers) do
+    "pup-c2.puppet.vm"
+  end
+  let(:compiler_hosts_array) do
+    ["pup-c1.puppet.vm"]
+  end
+  let(:legacy_compilers_array) do
+    ["pup-c2.puppet.vm"]
+  end
   it {
     is_expected.to run.with_params(primary_host)
-                      .and_return('supported' => true,
-                                  'disaster-recovery' => false,
-                                  'architecture' => 'standard')
+                      .and_return("supported" => true,
+                                  "disaster-recovery" => false,
+                                  "architecture" => "standard")
   }
   it {
     is_expected.to run.with_params(primary_host, replica_host)
-                      .and_return('supported' => true,
-                                  'disaster-recovery' => true,
-                                  'architecture' => 'standard')
+                      .and_return("supported" => true,
+                                  "disaster-recovery" => true,
+                                  "architecture" => "standard")
   }
 
   it do
@@ -44,9 +52,9 @@ describe 'peadm::assert_supported_architecture' do
                                    nil,
                                    nil,
                                    compiler_hosts)
-                      .and_return('supported' => true,
-                                  'disaster-recovery' => true,
-                                  'architecture' => 'large')
+                      .and_return("supported" => true,
+                                  "disaster-recovery" => true,
+                                  "architecture" => "large")
   end
 
   it do
@@ -55,9 +63,31 @@ describe 'peadm::assert_supported_architecture' do
                                    nil,
                                    nil,
                                    compiler_hosts)
-                      .and_return('supported' => true,
-                                  'disaster-recovery' => false,
-                                  'architecture' => 'large')
+                      .and_return("supported" => true,
+                                  "disaster-recovery" => false,
+                                  "architecture" => "large")
+  end
+  it do
+    is_expected.to run.with_params(primary_host,
+                                   nil,
+                                   nil,
+                                   nil,
+                                   compiler_hosts,
+                                   legacy_compilers)
+                      .and_return("supported" => true,
+                                  "disaster-recovery" => false,
+                                  "architecture" => "large")
+  end
+  it do
+    is_expected.to run.with_params(primary_host,
+                                   nil,
+                                   nil,
+                                   nil,
+                                   nil,
+                                   legacy_compilers)
+                      .and_return("supported" => true,
+                                  "disaster-recovery" => false,
+                                  "architecture" => "large")
   end
 
   it do
@@ -66,9 +96,9 @@ describe 'peadm::assert_supported_architecture' do
                                    primary_postgresql_host,
                                    replica_postgresql_host,
                                    compiler_hosts)
-                      .and_return('supported' => true,
-                                  'disaster-recovery' => true,
-                                  'architecture' => 'extra-large')
+                      .and_return("supported" => true,
+                                  "disaster-recovery" => true,
+                                  "architecture" => "extra-large")
   end
 
   it do
@@ -77,8 +107,30 @@ describe 'peadm::assert_supported_architecture' do
                                    primary_postgresql_host,
                                    nil,
                                    compiler_hosts)
-                      .and_return('supported' => true,
-                                  'disaster-recovery' => false,
-                                  'architecture' => 'extra-large')
+                      .and_return("supported" => true,
+                                  "disaster-recovery" => false,
+                                  "architecture" => "extra-large")
+  end
+  it do
+    is_expected.to run.with_params(primary_host,
+                                   nil,
+                                   primary_postgresql_host,
+                                   nil,
+                                   compiler_hosts,
+                                   legacy_compilers)
+                      .and_return("supported" => true,
+                                  "disaster-recovery" => false,
+                                  "architecture" => "extra-large")
+  end
+  it do
+    is_expected.to run.with_params(primary_host,
+                                   nil,
+                                   primary_postgresql_host,
+                                   nil,
+                                   compiler_hosts_array,
+                                   legacy_compilers_array)
+                      .and_return("supported" => true,
+                                  "disaster-recovery" => false,
+                                  "architecture" => "extra-large")
   end
 end

--- a/spec/plans/subplans/install_spec.rb
+++ b/spec/plans/subplans/install_spec.rb
@@ -1,6 +1,6 @@
-require 'spec_helper'
+require "spec_helper"
 
-describe 'peadm::subplans::install' do
+describe "peadm::subplans::install" do
   # Include the BoltSpec library functions
   include BoltSpec::Plans
 
@@ -9,10 +9,18 @@ describe 'peadm::subplans::install' do
     allow_any_plan
     allow_any_command
 
-    allow_task('peadm::precheck').return_for_targets(
-      'primary' => {
-        'hostname' => 'primary',
-        'platform' => 'el-7.11-x86_64'
+    allow_task("peadm::precheck").return_for_targets(
+      "primary" => {
+        "hostname" => "primary",
+        "platform" => "el-7.11-x86_64",
+      },
+      "compiler1" => {
+        "hostname" => "compiler1",
+        "platform" => "el-7.11-x86_64",
+      },
+      "compiler2" => {
+        "hostname" => "compiler2",
+        "platform" => "el-7.11-x86_64",
       },
     )
 
@@ -24,58 +32,68 @@ describe 'peadm::subplans::install' do
     allow(Puppet::FileSystem).to receive(:exist?).and_call_original
     allow_any_instance_of(BoltSpec::Plans::MockExecutor).to receive(:module_file_id).and_call_original
 
-    mockfile = instance_double('Tempfile', path: '/mock', write: nil, flush: nil, close: nil, unlink: nil)
-    mockpath = instance_double('Pathname', absolute?: true)
-    allow(Tempfile).to receive(:new).with('peadm').and_return(mockfile)
-    allow(Pathname).to receive(:new).with('/mock').and_return(mockpath)
-    allow(Puppet::FileSystem).to receive(:exist?).with('/mock').and_return(true)
-    allow_any_instance_of(BoltSpec::Plans::MockExecutor).to receive(:module_file_id).with('/mock').and_return('/mock')
+    mockfile = instance_double("Tempfile", path: "/mock", write: nil, flush: nil, close: nil, unlink: nil)
+    mockpath = instance_double("Pathname", absolute?: true)
+    allow(Tempfile).to receive(:new).with("peadm").and_return(mockfile)
+    allow(Pathname).to receive(:new).with("/mock").and_return(mockpath)
+    allow(Puppet::FileSystem).to receive(:exist?).with("/mock").and_return(true)
+    allow_any_instance_of(BoltSpec::Plans::MockExecutor).to receive(:module_file_id).with("/mock").and_return("/mock")
 
-    allow_upload('/mock')
+    allow_upload("/mock")
     # rubocop:enable AnyInstance
     ## </🤮>
     ##########
   end
 
-  it 'minimum variables to run' do
+  it "minimum variables to run" do
     params = {
-      'primary_host'     => 'primary',
-      'console_password' => 'puppetLabs123!',
-      'version'          => '2019.8.12',
+      "primary_host" => "primary",
+      "console_password" => "puppetLabs123!",
+      "version" => "2019.8.12",
     }
 
-    expect(run_plan('peadm::subplans::install', params)).to be_ok
+    expect(run_plan("peadm::subplans::install", params)).to be_ok
   end
 
-  it 'installs 2023.4 without r10k_known_hosts' do
+  it "installs 2023.4 without r10k_known_hosts" do
     params = {
-      'primary_host'             => 'primary',
-      'console_password'         => 'puppetLabs123!',
-      'version'                  => '2023.4.0',
-      'r10k_remote'              => 'git@github.com:puppetlabs/nothing',
-      'r10k_private_key_content' => '-----BEGINfoo',
+      "primary_host" => "primary",
+      "console_password" => "puppetLabs123!",
+      "version" => "2023.4.0",
+      "r10k_remote" => "git@github.com:puppetlabs/nothing",
+      "r10k_private_key_content" => "-----BEGINfoo",
     }
 
-    expect(run_plan('peadm::subplans::install', params)).to be_ok
+    expect(run_plan("peadm::subplans::install", params)).to be_ok
   end
 
-  it 'installs 2023.4+ with r10k_private_key and r10k_known_hosts' do
+  it "installs 2023.4+ with r10k_private_key and r10k_known_hosts" do
     params = {
-      'primary_host'             => 'primary',
-      'console_password'         => 'puppetLabs123!',
-      'version'                  => '2023.4.0',
-      'r10k_remote'              => 'git@github.com:puppetlabs/nothing',
-      'r10k_private_key_content' => '-----BEGINfoo',
-      'r10k_known_hosts'         => [
+      "primary_host" => "primary",
+      "console_password" => "puppetLabs123!",
+      "version" => "2023.4.0",
+      "r10k_remote" => "git@github.com:puppetlabs/nothing",
+      "r10k_private_key_content" => "-----BEGINfoo",
+      "r10k_known_hosts" => [
         {
-          'name' => 'test',
-          'type' => 'key-type',
-          'key'  => 'abcdef',
+          "name" => "test",
+          "type" => "key-type",
+          "key" => "abcdef",
         },
       ],
-      'permit_unsafe_versions' => true,
+      "permit_unsafe_versions" => true,
     }
 
-    expect(run_plan('peadm::subplans::install', params)).to be_ok
+    expect(run_plan("peadm::subplans::install", params)).to be_ok
+  end
+
+  it "installs 2021.7.9 with legacy compilers" do
+    params = {
+      "primary_host" => "primary",
+      "console_password" => "puppetLabs123!",
+      "version" => "2021.7.9",
+      "legacy_compilers" => ["compiler1", "compiler2"],
+    }
+    expect(run_plan("peadm::subplans::install", params)).to be_ok
   end
 end

--- a/spec/plans/subplans/install_spec.rb
+++ b/spec/plans/subplans/install_spec.rb
@@ -1,6 +1,6 @@
-require "spec_helper"
+require 'spec_helper'
 
-describe "peadm::subplans::install" do
+describe 'peadm::subplans::install' do
   # Include the BoltSpec library functions
   include BoltSpec::Plans
 
@@ -9,18 +9,18 @@ describe "peadm::subplans::install" do
     allow_any_plan
     allow_any_command
 
-    allow_task("peadm::precheck").return_for_targets(
-      "primary" => {
-        "hostname" => "primary",
-        "platform" => "el-7.11-x86_64",
+    allow_task('peadm::precheck').return_for_targets(
+      'primary' => {
+        'hostname' => 'primary',
+        'platform' => 'el-7.11-x86_64',
       },
-      "compiler1" => {
-        "hostname" => "compiler1",
-        "platform" => "el-7.11-x86_64",
+      'compiler1' => {
+        'hostname' => 'compiler1',
+        'platform' => 'el-7.11-x86_64',
       },
-      "compiler2" => {
-        "hostname" => "compiler2",
-        "platform" => "el-7.11-x86_64",
+      'compiler2' => {
+        'hostname' => 'compiler2',
+        'platform' => 'el-7.11-x86_64',
       },
     )
 
@@ -32,68 +32,68 @@ describe "peadm::subplans::install" do
     allow(Puppet::FileSystem).to receive(:exist?).and_call_original
     allow_any_instance_of(BoltSpec::Plans::MockExecutor).to receive(:module_file_id).and_call_original
 
-    mockfile = instance_double("Tempfile", path: "/mock", write: nil, flush: nil, close: nil, unlink: nil)
-    mockpath = instance_double("Pathname", absolute?: true)
-    allow(Tempfile).to receive(:new).with("peadm").and_return(mockfile)
-    allow(Pathname).to receive(:new).with("/mock").and_return(mockpath)
-    allow(Puppet::FileSystem).to receive(:exist?).with("/mock").and_return(true)
-    allow_any_instance_of(BoltSpec::Plans::MockExecutor).to receive(:module_file_id).with("/mock").and_return("/mock")
+    mockfile = instance_double('Tempfile', path: '/mock', write: nil, flush: nil, close: nil, unlink: nil)
+    mockpath = instance_double('Pathname', absolute?: true)
+    allow(Tempfile).to receive(:new).with('peadm').and_return(mockfile)
+    allow(Pathname).to receive(:new).with('/mock').and_return(mockpath)
+    allow(Puppet::FileSystem).to receive(:exist?).with('/mock').and_return(true)
+    allow_any_instance_of(BoltSpec::Plans::MockExecutor).to receive(:module_file_id).with('/mock').and_return('/mock')
 
-    allow_upload("/mock")
+    allow_upload('/mock')
     # rubocop:enable AnyInstance
     ## </🤮>
     ##########
   end
 
-  it "minimum variables to run" do
+  it 'minimum variables to run' do
     params = {
-      "primary_host" => "primary",
-      "console_password" => "puppetLabs123!",
-      "version" => "2019.8.12",
+      'primary_host' => 'primary',
+      'console_password' => 'puppetLabs123!',
+      'version' => '2019.8.12',
     }
 
-    expect(run_plan("peadm::subplans::install", params)).to be_ok
+    expect(run_plan('peadm::subplans::install', params)).to be_ok
   end
 
-  it "installs 2023.4 without r10k_known_hosts" do
+  it 'installs 2023.4 without r10k_known_hosts' do
     params = {
-      "primary_host" => "primary",
-      "console_password" => "puppetLabs123!",
-      "version" => "2023.4.0",
-      "r10k_remote" => "git@github.com:puppetlabs/nothing",
-      "r10k_private_key_content" => "-----BEGINfoo",
+      'primary_host' => 'primary',
+      'console_password' => 'puppetLabs123!',
+      'version' => '2023.4.0',
+      'r10k_remote' => 'git@github.com:puppetlabs/nothing',
+      'r10k_private_key_content' => '-----BEGINfoo',
     }
 
-    expect(run_plan("peadm::subplans::install", params)).to be_ok
+    expect(run_plan('peadm::subplans::install', params)).to be_ok
   end
 
-  it "installs 2023.4+ with r10k_private_key and r10k_known_hosts" do
+  it 'installs 2023.4+ with r10k_private_key and r10k_known_hosts' do
     params = {
-      "primary_host" => "primary",
-      "console_password" => "puppetLabs123!",
-      "version" => "2023.4.0",
-      "r10k_remote" => "git@github.com:puppetlabs/nothing",
-      "r10k_private_key_content" => "-----BEGINfoo",
-      "r10k_known_hosts" => [
+      'primary_host' => 'primary',
+      'console_password' => 'puppetLabs123!',
+      'version' => '2023.4.0',
+      'r10k_remote' => 'git@github.com:puppetlabs/nothing',
+      'r10k_private_key_content' => '-----BEGINfoo',
+      'r10k_known_hosts' => [
         {
-          "name" => "test",
-          "type" => "key-type",
-          "key" => "abcdef",
+          'name' => 'test',
+          'type' => 'key-type',
+          'key' => 'abcdef',
         },
       ],
-      "permit_unsafe_versions" => true,
+      'permit_unsafe_versions' => true,
     }
 
-    expect(run_plan("peadm::subplans::install", params)).to be_ok
+    expect(run_plan('peadm::subplans::install', params)).to be_ok
   end
 
-  it "installs 2021.7.9 with legacy compilers" do
+  it 'installs 2021.7.9 with legacy compilers' do
     params = {
-      "primary_host" => "primary",
-      "console_password" => "puppetLabs123!",
-      "version" => "2021.7.9",
-      "legacy_compilers" => ["compiler1", "compiler2"],
+      'primary_host' => 'primary',
+      'console_password' => 'puppetLabs123!',
+      'version' => '2021.7.9',
+      'legacy_compilers' => ['compiler1', 'compiler2'],
     }
-    expect(run_plan("peadm::subplans::install", params)).to be_ok
+    expect(run_plan('peadm::subplans::install', params)).to be_ok
   end
 end


### PR DESCRIPTION
## Summary
- Added `legacy_compilers` parameter to `peadm::install`, `peadm::subplans::install`, and `peadm::subplans::configure` plans.
- Updated `peadm::assert_supported_architecture` function to handle `legacy_compilers`.
- Modified various plans to include `legacy_compilers` in the installation and configuration processes.
- Updated documentation to reflect the changes and added examples for `legacy_compilers`.

This change allows the PEADM module to support legacy compilers in addition to the standard compilers.- Added `legacy_compilers` parameter to `peadm::install`, `peadm::subplans::install`, and `peadm::subplans::configure` plans.
- Updated `peadm::assert_supported_architecture` function to handle `legacy_compilers`.
- Modified various plans to include `legacy_compilers` in the installation and configuration processes.
- Updated documentation to reflect the changes and added examples for `legacy_compilers`.

This change allows the PEADM module to support legacy compilers in addition to the standard compilers.

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [x] Yes
- [ ] Not needed

#### Have you updated the documentation?
- [x] Yes, I've updated the appropriate docs
- [ ] Not needed
