### PR TITLE
Save Windows Powershell agent installer to Task temp dir

### DIFF
--- a/tasks/agent_install.ps1
+++ b/tasks/agent_install.ps1
@@ -8,8 +8,9 @@ if (Test-Path "C:\Program Files\Puppet Labs\Puppet\puppet\bin\puppet"){
   Exit 1
 }
 $flags=$install_flags -replace '^\["*','' -replace 's/"*\]$','' -replace '/", *"',' '
+$mypath = $MyInvocation.MyCommand.Path | Split-Path -Parent
 try {
-  [Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; $webClient = New-Object System.Net.WebClient; $webClient.DownloadFile("https://${server}:8140/packages/current/install.ps1", 'install.ps1'); powershell.exe -c "install.ps1 $flags"
+  [Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}; $webClient = New-Object System.Net.WebClient; $webClient.DownloadFile("https://${server}:8140/packages/current/install.ps1", "${mypath}\install.ps1"); powershell.exe -c "${mypath}\install.ps1 $flags"
   }
   catch {
   Write-Host "Installer failed with Exception: $_.Exception.Message"


### PR DESCRIPTION
Without an explicit destination path specified, the download of install.ps1 is being written to the Windows system directory.

This adjusts the Task to obtain the path it is located in and save the install.ps1 download there.

## Summary

I was unable to figure out why, but I observed that the `agent_install.ps1` Task would consistently end up downloading the `install.ps1` install script into `C:\Windows\System32` instead of the temporary directory the Task was run from.  This ensures the install script will be downloaded to the Task directory.
