### PR TITLE
(PE-38771) Convert plan accepts legacy compilers key in params.json

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1719,6 +1719,7 @@ The following parameters are available in the `peadm::convert` plan:
 * [`primary_host`](#-peadm--convert--primary_host)
 * [`replica_host`](#-peadm--convert--replica_host)
 * [`compiler_hosts`](#-peadm--convert--compiler_hosts)
+* [`legacy_compilers`](#-peadm--convert--legacy_compilers)
 * [`primary_postgresql_host`](#-peadm--convert--primary_postgresql_host)
 * [`replica_postgresql_host`](#-peadm--convert--replica_postgresql_host)
 * [`compiler_pool_address`](#-peadm--convert--compiler_pool_address)
@@ -1742,6 +1743,14 @@ Data type: `Optional[Peadm::SingleTargetSpec]`
 Default value: `undef`
 
 ##### <a name="-peadm--convert--compiler_hosts"></a>`compiler_hosts`
+
+Data type: `Optional[TargetSpec]`
+
+
+
+Default value: `undef`
+
+##### <a name="-peadm--convert--legacy_compilers"></a>`legacy_compilers`
 
 Data type: `Optional[TargetSpec]`
 

--- a/documentation/convert.md
+++ b/documentation/convert.md
@@ -1,6 +1,6 @@
-# Convert infrastructure for use with the peadm module
+# Convert infrastructure for use with the PEADM module
 
-The peadm::convert plan can be used to adopt manually deployed infrastructure for use with peadm, or to adopt infrastructure deployed with an older version of peadm.
+The peadm::convert plan can be used to adopt manually deployed infrastructure for use with PEADM or to adopt infrastructure deployed with an older version of peadm.
 
 ## Convert an Existing Deployment
 
@@ -14,7 +14,10 @@ Prepare to run the plan against all servers in the PE infrastructure, using a pa
     "pe-xl-compiler-0.lab1.puppet.vm",
     "pe-xl-compiler-1.lab1.puppet.vm"
   ],
-
+  "legacy_compilers": [
+    "pe-xl-legacy-compiler-0.lab1.puppet.vm",
+    "pe-xl-legacy-compiler-1.lab1.puppet.vm"
+  ],
   "compiler_pool_address": "puppet.lab1.puppet.vm"
 }
 ```
@@ -29,13 +32,13 @@ bolt plan run peadm::convert --params @params.json
 
 This plan is broken down into steps. Normally, the plan runs through all the steps from start to finish. The name of each step is displayed during the plan run, as the step begins.
 
-The `begin_at_step` parameter can be used to facilitate re-running this plan after a failed attempt, skipping past any steps that already completed successfully on the first try and picking up again at the step specified. The step name to resume at can be read from the previous run logs. A full list of available values for this parameter can be viewed by running `bolt plan show peadm::convert`.
+The `begin_at_step` parameter can be used to facilitate re-running this plan after a failed attempt, skipping past any steps that were already completed successfully on the first try and picking up again at the step specified. The step name to resume can be read from the previous run logs. A full list of available values for this parameter can be viewed by running `bolt plan show peadm::convert`.
 
 ## Convert compilers to legacy
 
 ### Puppet Enterprise installed with puppetlabs-peadm version 3.21 or later
 
-To convert compilers to legacy compilers use the `peadm::convert_compiler_to_legacy` plan. This plan will create the needed Node group and Classifier rules to make the compilers legacy. Also will add certificate extensions to those nodes.
+To convert compilers to legacy compilers use the `peadm::convert_compiler_to_legacy` plan. This plan will create the needed Node group and Classifier rules to make compilers legacy. Also will add certificate extensions to those nodes.
 
 ```shell
 bolt plan run peadm::convert_compiler_to_legacy legacy_hosts=compiler1.example.com,compiler2.example.com primary_host=primary.example.com

--- a/plans/convert.pp
+++ b/plans/convert.pp
@@ -304,6 +304,9 @@ plan peadm::convert (
     # completion
     run_command('systemctl restart pe-puppetserver.service pe-puppetdb.service',
     $all_targets - $primary_target - $primary_postgresql_target - $replica_postgresql_target)
+
+    # Run puppet on all targets again to ensure everything is fully up-to-date
+    run_task('peadm::puppet_runonce', $all_targets)
   }
 
   return("Conversion to peadm Puppet Enterprise ${arch['architecture']} completed.")


### PR DESCRIPTION
## Summary

- Introduced `legacy_compilers` parameter to handle legacy compiler hosts.
- Added logic to filter and categorize legacy compiler targets.
- Updated certificate modification steps to include legacy compiler targets with appropriate extensions.
- Added a step to run puppet on all targets after restarting services.
- Ensures all targets are fully up-to-date after conversion.
- Added 'legacy_compilers' section in the example JSON parameters.
- Improved clarity in the description of the `begin_at_step` parameter.
- Fixed minor grammatical issues in the instructions for converting compilers to legacy.

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Have you updated the documentation?
- [x] Yes, I've updated the appropriate docs
- [ ] Not needed
