### PR TITLE
(PE-39612) update default PE version to 2021.7.9 and 2023.8.0

### DIFF
--- a/.github/workflows/test-add-compiler.yaml
+++ b/.github/workflows/test-add-compiler.yaml
@@ -15,7 +15,7 @@ on:
       version:
         description: 'PE version to install'
         required: true
-        default: '2021.7.8'
+        default: '2021.7.9'
       ssh-debugging:
         description: 'Boolean; whether or not to pause for ssh debugging'
         required: true

--- a/.github/workflows/test-add-replica.yaml
+++ b/.github/workflows/test-add-replica.yaml
@@ -15,7 +15,7 @@ on:
       version:
         description: 'PE version to install'
         required: true
-        default: '2021.7.8'
+        default: '2021.7.9'
       ssh-debugging:
         description: 'Boolean; whether or not to pause for ssh debugging'
         required: true

--- a/.github/workflows/test-failover.yaml
+++ b/.github/workflows/test-failover.yaml
@@ -15,7 +15,7 @@ on:
       version_to_upgrade:
         description: 'PE version to upgrade to'
         required: false
-        default: '2021.7.8'
+        default: '2021.7.9'
       ssh-debugging:
         description: 'Boolean; whether or not to pause for ssh debugging'
         required: true

--- a/.github/workflows/test-fips-install-matrix.yaml
+++ b/.github/workflows/test-fips-install-matrix.yaml
@@ -43,8 +43,8 @@ jobs:
           - extra-large-with-dr
         version:
           - 2019.8.12
-          - 2021.7.8
-          - 2023.7.0
+          - 2021.7.9
+          - 2023.8.0
         image:
           - rhel-8
         fips:

--- a/.github/workflows/test-install-matrix.yaml
+++ b/.github/workflows/test-install-matrix.yaml
@@ -43,8 +43,8 @@ jobs:
           - extra-large-with-dr
         version:
           - 2019.8.12
-          - 2021.7.8
-          - 2023.7.0
+          - 2021.7.9
+          - 2023.8.0
         image:
           - almalinux-cloud/almalinux-8
     steps:

--- a/.github/workflows/test-install-rhel-9.yaml
+++ b/.github/workflows/test-install-rhel-9.yaml
@@ -42,8 +42,8 @@ jobs:
           - large
           - extra-large-with-dr
         version:
-          - 2021.7.8
-          - 2023.7.0
+          - 2021.7.9
+          - 2023.8.0
         image:
           - rhel-9
     steps:

--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -15,7 +15,7 @@ on:
       version:
         description: 'PE version to install'
         required: true
-        default: '2021.7.8'
+        default: '2021.7.9'
       ssh-debugging:
         description: 'Boolean; whether or not to pause for ssh debugging'
         required: true

--- a/.github/workflows/test-upgrade-latest-dev.yaml
+++ b/.github/workflows/test-upgrade-latest-dev.yaml
@@ -24,7 +24,7 @@ on:
         type: string
         required: true
         description: "The initial version of PE to install before upgrade"
-        default: "2021.7.8"
+        default: "2021.7.9"
       ssh-debugging:
         description: "Boolean; whether or not to pause for ssh debugging"
         required: true

--- a/.github/workflows/test-upgrade-latest-xlarge-dev-nightly.yaml
+++ b/.github/workflows/test-upgrade-latest-xlarge-dev-nightly.yaml
@@ -19,7 +19,7 @@ jobs:
         architecture:
           - "extra-large-with-dr"
         version:
-          - "2021.7.8"
+          - "2021.7.9"
         image:
           - "almalinux-cloud/almalinux-8"
 

--- a/.github/workflows/test-upgrade-matrix.yaml
+++ b/.github/workflows/test-upgrade-matrix.yaml
@@ -43,19 +43,19 @@ jobs:
           - 'extra-large-with-dr'
         version:
           - '2019.8.12'
-          - '2021.7.8'
+          - '2021.7.9'
         version_to_upgrade:
-          - '2021.7.8'
-          - '2023.7.0'
+          - '2021.7.9'
+          - '2023.8.0'
         image:
           - 'almalinux-cloud/almalinux-8'
         download_mode:
           - 'direct'
         exclude:
           - version: '2019.8.12'
-            version_to_upgrade: '2023.7.0'
-          - version: '2021.7.8'
-            version_to_upgrade: '2021.7.8' 
+            version_to_upgrade: '2023.8.0'
+          - version: '2021.7.9'
+            version_to_upgrade: '2021.7.9' 
 
     steps:
       - name: 'Start SSH session'

--- a/.github/workflows/test-upgrade.yaml
+++ b/.github/workflows/test-upgrade.yaml
@@ -27,7 +27,7 @@ on:
       upgrade_version:
         description: 'PE version to upgrade to'
         required: true
-        default: '2021.7.8'
+        default: '2021.7.9'
       ssh-debugging:
         description: 'Boolean; whether or not to pause for ssh debugging'
         required: true

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1954,7 +1954,7 @@ Data type: `Peadm::Pe_version`
 
 
 
-Default value: `'2021.7.8'`
+Default value: `'2021.7.9'`
 
 ##### <a name="-peadm--install--dns_alt_names"></a>`dns_alt_names`
 

--- a/documentation/install.md
+++ b/documentation/install.md
@@ -114,7 +114,7 @@ Example params.json Bolt parameters file (shown: Standard):
   "primary_host": "pe-xl-core-0.lab1.puppet.vm",
   "console_password": "puppetlabs",
   "dns_alt_names": [ "puppet", "puppet.lab1.puppet.vm" ],
-  "version": "2021.7.8"
+  "version": "2021.7.9"
 }
 ```
 

--- a/documentation/upgrade.md
+++ b/documentation/upgrade.md
@@ -8,11 +8,11 @@ The `peadm::upgrade` plan requires as input the version of PE to upgrade to, and
 
 Please note that when upgrading from before 2023.4 to 2023.4 or above and you are using code manager, it is nessesary to provide known hosts for r10k. r10k_known_hosts is an optional parameter and is only required one time when upgrading to 2023.4 or beyond. But if you currently use the SSH protocol to allow r10k to access your remote Git repository, your Code manager or r10k code management tool cannot function until you define the r10k_known_hosts parameter. Subsequent upgrades will already have this and it won't be required again. Please refer to the Puppet Enterprise 2023.4 Upgrade cautions for more details.
 
-The following is an example parameters file for upgrading an Extra Large architecture deployment of PE 2023.2.0 to PE 2023.7.0.
+The following is an example parameters file for upgrading an Extra Large architecture deployment of PE 2023.2.0 to PE 2023.8.0.
 
 ```json
 {
-  "version": "2023.7.0",
+  "version": "2023.8.0",
   "primary_host": "pe-master-09a40c-0.us-west1-a.c.reidmv-peadm.internal",
   "primary_postgresql_host": "pe-psql-09a40c-0.us-west1-a.c.reidmv-peadm.internal",
   "replica_host": "pe-master-09a40c-1.us-west1-b.c.reidmv-peadm.internal",
@@ -24,8 +24,8 @@ The following is an example parameters file for upgrading an Extra Large archite
     "pe-compiler-09a40c-3.us-west1-a.c.reidmv-peadm.internal"
   ],
   "r10k_known_hosts": [
-     {"name": "remotehostname", "type": "ssh-rsa", "key": "hash"},
-     {"name": "remotehostname2", "type": "ssh-rsa", "key": "hash"}
+    { "name": "remotehostname", "type": "ssh-rsa", "key": "hash" },
+    { "name": "remotehostname2", "type": "ssh-rsa", "key": "hash" }
   ]
 }
 ```
@@ -50,7 +50,7 @@ If you wish to prevent the bolt host from transferring the installer tarball to 
 
 Note if `pe_repo` classes have been declared (for agents with different OS/platform than your primary server - see [Install \*nix agents with PE package management](https://www.puppet.com/docs/pe/2021.7/installing_nix_agents.html#install_nix_agents_pe_package_management)), you must also stage the agent repo tarballs for the new PE version before running the `peadm::upgrade` plan, otherwise the plan will fail when it runs puppet to complete the upgrade, as it will not be able to download the agent repos from the internet.
 
-See [Upgrade agents without internet access](https://www.puppet.com/docs/pe/2021.7/upgrading_agents.html#upgrade_agents_without_internet_access) for the location of the agent staging directory on the primary server. From the **Puppet Release Information & Downloads** page linked in the agent upgrade documentation, select the required PE version and navigate to the **Agent Repos** section to download the corresponding agent repo tarball. Ensure the files are prefetched/downloaded from the correct section - the agent repo staging directory expects the agent ___repo___ tarballs (`.tar.gz`), NOT the agent package downloads available from the same page.
+See [Upgrade agents without internet access](https://www.puppet.com/docs/pe/2021.7/upgrading_agents.html#upgrade_agents_without_internet_access) for the location of the agent staging directory on the primary server. From the **Puppet Release Information & Downloads** page linked in the agent upgrade documentation, select the required PE version and navigate to the **Agent Repos** section to download the corresponding agent repo tarball. Ensure the files are prefetched/downloaded from the correct section - the agent repo staging directory expects the agent **_repo_** tarballs (`.tar.gz`), NOT the agent package downloads available from the same page.
 
 ## Online usage
 
@@ -107,7 +107,7 @@ Note: it is assumed that the Puppet primary is in cluster A when the upgrade sta
 
 **Phase 1: stop puppet service**
 
-* Stop the `puppet` service on all PE infrastructure nodes to prevent normal automatic runs from interfering with the upgrade process
+- Stop the `puppet` service on all PE infrastructure nodes to prevent normal automatic runs from interfering with the upgrade process
 
 **Phase 2: upgrade DR cluster A**
 
@@ -133,14 +133,14 @@ The following steps apply _only_ if upgrading from 2019.5 or older
 
 1. Run `puppet infra run convert_legacy_compiler` for all compilers
 2. Modify the peadm node groups "PE Compiler Group A" and "PE Compiler Group B" as follows:
-   * Re-parent the groups. They should be children of "PE Compiler"
-   * Remove configuration data (Hiera data). Leave the classes and class parameters
-   * Add the rule `trusted.extensions.pp_auth_role = pe_compiler`
-   * Remove the rule `trusted.extensions."1.3.6.1.4.1.34380.1.1.9812" = puppet/compiler`
+   - Re-parent the groups. They should be children of "PE Compiler"
+   - Remove configuration data (Hiera data). Leave the classes and class parameters
+   - Add the rule `trusted.extensions.pp_auth_role = pe_compiler`
+   - Remove the rule `trusted.extensions."1.3.6.1.4.1.34380.1.1.9812" = puppet/compiler`
 
 **Phase 4: resume puppet service**
 
-* Ensure the `puppet` service on all PE infrastructure nodes is running again
+- Ensure the `puppet` service on all PE infrastructure nodes is running again
 
 ## Upgrade from 2018.1
 

--- a/functions/assert_supported_pe_version.pp
+++ b/functions/assert_supported_pe_version.pp
@@ -6,7 +6,7 @@ function peadm::assert_supported_pe_version (
   Boolean $permit_unsafe_versions = false,
 ) >> Struct[{ 'supported' => Boolean }] {
   $oldest = '2019.7'
-  $newest = '2023.7'
+  $newest = '2023.8'
   $supported = ($version =~ SemVerRange(">= ${oldest} <= ${newest}"))
 
   if $permit_unsafe_versions {

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -45,7 +45,7 @@ plan peadm::install (
 
   # Common Configuration
   String                            $console_password,
-  Peadm::Pe_version                 $version                          = '2021.7.8',
+  Peadm::Pe_version                 $version                          = '2021.7.9',
   Optional[Stdlib::HTTPSUrl]        $pe_installer_source              = undef,
   Optional[Array[String]]           $dns_alt_names                    = undef,
   Optional[String]                  $compiler_pool_address            = undef,

--- a/spec/functions/assert_supported_pe_version_spec.rb
+++ b/spec/functions/assert_supported_pe_version_spec.rb
@@ -19,7 +19,7 @@ describe 'peadm::assert_supported_pe_version' do
     end
 
     it 'accepts the newest supported version' do
-      is_expected.to run.with_params('2021.7.8').and_return({ 'supported' => true })
+      is_expected.to run.with_params('2021.7.9').and_return({ 'supported' => true })
     end
 
     it 'accepts a version in the middle' do

--- a/spec/plans/convert_spec.rb
+++ b/spec/plans/convert_spec.rb
@@ -19,7 +19,7 @@ describe 'peadm::convert' do
     allow_apply
 
     expect_task('peadm::cert_data').return_for_targets('primary' => trustedjson)
-    expect_task('peadm::read_file').always_return({ 'content' => '2021.7.8' })
+    expect_task('peadm::read_file').always_return({ 'content' => '2021.7.9' })
 
     # For some reason, expect_plan() was not working??
     allow_plan('peadm::modify_certificate').always_return({})

--- a/spec/plans/install_spec.rb
+++ b/spec/plans/install_spec.rb
@@ -7,7 +7,7 @@ describe 'peadm::install' do
     it 'runs successfully with the minimum required parameters' do
       expect_plan('peadm::subplans::install')
       expect_plan('peadm::subplans::configure')
-      expect(run_plan('peadm::install', 'primary_host' => 'primary', 'console_password' => 'puppetLabs123!', 'version' => '2021.7.8')).to be_ok
+      expect(run_plan('peadm::install', 'primary_host' => 'primary', 'console_password' => 'puppetLabs123!', 'version' => '2021.7.9')).to be_ok
     end
   end
 end

--- a/spec/plans/upgrade_spec.rb
+++ b/spec/plans/upgrade_spec.rb
@@ -31,7 +31,7 @@ describe 'peadm::upgrade' do
 
     expect(run_plan('peadm::upgrade',
                     'primary_host' => 'primary',
-                    'version' => '2021.7.8')).to be_ok
+                    'version' => '2021.7.9')).to be_ok
   end
 
   it 'runs with a primary, compilers, but no replica' do
@@ -47,7 +47,7 @@ describe 'peadm::upgrade' do
     expect(run_plan('peadm::upgrade',
                     'primary_host' => 'primary',
                     'compiler_hosts' => 'compiler',
-                    'version' => '2021.7.8')).to be_ok
+                    'version' => '2021.7.9')).to be_ok
   end
 
   it 'fails if the primary uses the pcp transport' do


### PR DESCRIPTION
## Summary
- Updated default PE version in various GitHub workflow YAML files.
- Updated example parameters in documentation files.
- Adjusted supported PE version range in assert_supported_pe_version function.
- Modified unit tests to reflect the new default PE version.


## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [ ] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [ ] Not needed
