### PR TITLE
(PE-39118) Adding code manager check to add_replica

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1075,6 +1075,14 @@ Run on a PE primary node to check if Code Manager is enabled.
 
 **Supports noop?** false
 
+#### Parameters
+
+##### `host`
+
+Data type: `String[1]`
+
+Hostname of the PE primary node
+
 ### <a name="code_sync_status"></a>`code_sync_status`
 
 A task to confirm code is in sync accross the cluster for clusters with code manager configured

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -56,6 +56,7 @@
 * [`cert_data`](#cert_data): Return certificate data related to the Puppet agent
 * [`cert_valid_status`](#cert_valid_status): Check primary for valid state of a certificate
 * [`code_manager`](#code_manager): Perform various code manager actions
+* [`code_manager_enabled`](#code_manager_enabled): Run on a PE primary node to check if Code Manager is enabled.
 * [`code_sync_status`](#code_sync_status): A task to confirm code is in sync accross the cluster for clusters with code manager configured
 * [`divert_code_manager`](#divert_code_manager): Divert the code manager live-dir setting
 * [`download`](#download): Download a file using curl
@@ -1067,6 +1068,12 @@ Perform various code manager actions
 Data type: `String`
 
 What code manager action to perform. For example: 'deploy production'; 'flush-environment-cache'; 'file-sync commit'
+
+### <a name="code_manager_enabled"></a>`code_manager_enabled`
+
+Run on a PE primary node to check if Code Manager is enabled.
+
+**Supports noop?** false
 
 ### <a name="code_sync_status"></a>`code_sync_status`
 

--- a/plans/add_replica.pp
+++ b/plans/add_replica.pp
@@ -22,7 +22,10 @@ plan peadm::add_replica(
   $replica_target             = peadm::get_targets($replica_host, 1)
   $replica_postgresql_target  = peadm::get_targets($replica_postgresql_host, 1)
 
-  $code_manager_enabled = run_task('peadm::code_manager_enabled', $primary_target).first.value['code_manager_enabled']
+  $code_manager_enabled = run_task(
+    'peadm::code_manager_enabled', $primary_target, host => $primary_target.peadm::certname()
+  ).first.value['code_manager_enabled']
+
   if $code_manager_enabled == false {
     fail('Code Manager must be enabled to add a replica. Please refer to the docs for more information on enabling Code Manager.')
   }

--- a/plans/add_replica.pp
+++ b/plans/add_replica.pp
@@ -22,6 +22,11 @@ plan peadm::add_replica(
   $replica_target             = peadm::get_targets($replica_host, 1)
   $replica_postgresql_target  = peadm::get_targets($replica_postgresql_host, 1)
 
+  $code_manager_enabled = run_task('peadm::code_manager_enabled', $primary_target).first.value['code_manager_enabled']
+  if $code_manager_enabled == false {
+    fail('Code Manager must be enabled to add a replica. Please refer to the docs for more information on enabling Code Manager.')
+  }
+
   run_command('systemctl stop puppet.service', peadm::flatten_compact([
         $primary_target,
         $replica_postgresql_target,

--- a/tasks/code_manager_enabled.json
+++ b/tasks/code_manager_enabled.json
@@ -1,5 +1,10 @@
 {
   "description": "Run on a PE primary node to check if Code Manager is enabled.",
-  "parameters": { },
+  "parameters": {
+    "host": {
+      "type": "String[1]",
+      "description": "Hostname of the PE primary node"
+    }
+   },
   "input_method": "stdin"
 }

--- a/tasks/code_manager_enabled.json
+++ b/tasks/code_manager_enabled.json
@@ -1,0 +1,5 @@
+{
+  "description": "Run on a PE primary node to check if Code Manager is enabled.",
+  "parameters": { },
+  "input_method": "stdin"
+}

--- a/tasks/code_manager_enabled.rb
+++ b/tasks/code_manager_enabled.rb
@@ -1,0 +1,75 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'uri'
+require 'net/http'
+require 'puppet'
+
+# GetPEAdmConfig task class
+class GetPEAdmConfig
+  def initialize(params); end
+
+  def execute!
+    code_manager_enabled = groups.dig('PE Master', 'classes', 'puppet_enterprise::profile::master', 'code_manager_auto_configure')
+    
+    puts({"code_manager_enabled" => code_manager_enabled}.to_json)
+  end
+
+  # Returns a GetPEAdmConfig::NodeGroups object created from the /groups object
+  # returned by the classifier
+  def groups
+    @groups ||= begin
+      net = https(4433)
+      res = net.get('/classifier-api/v1/groups')
+      NodeGroup.new(JSON.parse(res.body))
+    end
+  end
+
+  def https(port)
+    https = Net::HTTP.new('localhost', port)
+    https.use_ssl = true
+    https.cert = @cert ||= OpenSSL::X509::Certificate.new(File.read(Puppet.settings[:hostcert]))
+    https.key = @key ||= OpenSSL::PKey::RSA.new(File.read(Puppet.settings[:hostprivkey]))
+    https.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    https
+  end
+
+  def pdb_query(query)
+    pdb = https(8081)
+    pdb_request = Net::HTTP::Get.new('/pdb/query/v4')
+    pdb_request.set_form_data({ 'query' => query })
+    JSON.parse(pdb.request(pdb_request).body)
+  end
+
+  # Utility class to aid in retrieving useful information from the node group
+  # data
+  class NodeGroup
+    attr_reader :data
+
+    def initialize(data)
+      @data = data
+    end
+
+    # Aids in digging into node groups by name, rather than UUID
+    def dig(name, *args)
+      group = @data.find { |obj| obj['name'] == name }
+      if group.nil?
+        nil
+      elsif args.empty?
+        group
+      else
+        group.dig(*args)
+      end
+    end
+  end
+end
+
+# Run the task unless an environment flag has been set, signaling not to. The
+# environment flag is used to disable auto-execution and enable Ruby unit
+# testing of this task.
+unless ENV['RSPEC_UNIT_TEST_MODE']
+  Puppet.initialize_settings
+  task = GetPEAdmConfig.new(JSON.parse(STDIN.read))
+  task.execute!
+end

--- a/tasks/code_manager_enabled.rb
+++ b/tasks/code_manager_enabled.rb
@@ -12,8 +12,10 @@ class GetPEAdmConfig
 
   def execute!
     code_manager_enabled = groups.dig('PE Master', 'classes', 'puppet_enterprise::profile::master', 'code_manager_auto_configure')
-    
-    puts({"code_manager_enabled" => code_manager_enabled}.to_json)
+
+    code_manager_enabled_value = code_manager_enabled == true
+
+    puts({ 'code_manager_enabled' => code_manager_enabled_value }.to_json)
   end
 
   # Returns a GetPEAdmConfig::NodeGroups object created from the /groups object


### PR DESCRIPTION
## Summary
When user tries to add replica without code manager setup they were getting an error without any descriptive message.

This is adding a check to add_replica to alert user to enable code manager before proceeding. 

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.

#### Changes include test coverage?
- [x] Yes
- [ ] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [x] Not needed
