### PR TITLE
(MAINT) SSL Verification extended

### DIFF
--- a/tasks/get_peadm_config.rb
+++ b/tasks/get_peadm_config.rb
@@ -105,7 +105,8 @@ class GetPEAdmConfig
     https.use_ssl = true
     https.cert = @cert ||= OpenSSL::X509::Certificate.new(File.read(Puppet.settings[:hostcert]))
     https.key = @key ||= OpenSSL::PKey::RSA.new(File.read(Puppet.settings[:hostprivkey]))
-    https.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    https.verify_mode = OpenSSL::SSL::VERIFY_PEER
+    https.ca_file = Puppet.settings[:localcacert]
     https
   end
 

--- a/tasks/get_peadm_config.rb
+++ b/tasks/get_peadm_config.rb
@@ -101,7 +101,7 @@ class GetPEAdmConfig
   end
 
   def https(port)
-    https = Net::HTTP.new('localhost', port)
+    https = Net::HTTP.new(Puppet.settings[:certname], port)
     https.use_ssl = true
     https.cert = @cert ||= OpenSSL::X509::Certificate.new(File.read(Puppet.settings[:hostcert]))
     https.key = @key ||= OpenSSL::PKey::RSA.new(File.read(Puppet.settings[:hostprivkey]))

--- a/tasks/rbac_token.rb
+++ b/tasks/rbac_token.rb
@@ -22,13 +22,13 @@ body = {
   'label'    => 'provision-time token',
 }.to_json
 
-https. = Net::HTTP.new(Puppet.settings[:certname], 4433)
-https..use_ssl = true
-https..cert = OpenSSL::X509::Certificate.new(File.read(Puppet.settings[:hostcert]))
-https..key = OpenSSL::PKey::RSA.new(File.read(Puppet.settings[:hostprivkey]))
-https..verify_mode = OpenSSL::SSL::VERIFY_PEER
-https..ca_file = Puppet.settings[:localcacert]
-request = Net::https.:Post.new('/rbac-api/v1/auth/token')
+https = Net::HTTP.new(Puppet.settings[:certname], 4433)
+https.use_ssl = true
+https.cert = OpenSSL::X509::Certificate.new(File.read(Puppet.settings[:hostcert]))
+https.key = OpenSSL::PKey::RSA.new(File.read(Puppet.settings[:hostprivkey]))
+https.verify_mode = OpenSSL::SSL::VERIFY_PEER
+https.ca_file = Puppet.settings[:localcacert]
+request = Net::https:Post.new('/rbac-api/v1/auth/token')
 request['Content-Type'] = 'application/json'
 request.body = body
 

--- a/tasks/rbac_token.rb
+++ b/tasks/rbac_token.rb
@@ -28,7 +28,7 @@ https.cert = OpenSSL::X509::Certificate.new(File.read(Puppet.settings[:hostcert]
 https.key = OpenSSL::PKey::RSA.new(File.read(Puppet.settings[:hostprivkey]))
 https.verify_mode = OpenSSL::SSL::VERIFY_PEER
 https.ca_file = Puppet.settings[:localcacert]
-request = Net::https:Post.new('/rbac-api/v1/auth/token')
+request = Net::HTTP::Post.new('/rbac-api/v1/auth/token')
 request['Content-Type'] = 'application/json'
 request.body = body
 

--- a/tasks/rbac_token.rb
+++ b/tasks/rbac_token.rb
@@ -4,16 +4,17 @@
 #
 # rubocop:disable Style/GlobalVars
 require 'net/https'
-require 'uri'
 require 'json'
 require 'fileutils'
+require 'puppet'
 
 # Parameters expected:
 #   Hash
 #     String password
 $params = JSON.parse(STDIN.read)
 
-uri = URI.parse('https://localhost:4433/rbac-api/v1/auth/token')
+Puppet.initialize_settings
+
 body = {
   'login'    => 'admin',
   'password' => $params['password'],
@@ -21,15 +22,18 @@ body = {
   'label'    => 'provision-time token',
 }.to_json
 
-http = Net::HTTP.new(uri.host, uri.port)
-http.use_ssl = true
-http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-request = Net::HTTP::Post.new(uri.request_uri)
+https. = Net::HTTP.new(Puppet.settings[:certname], 4433)
+https..use_ssl = true
+https..cert = OpenSSL::X509::Certificate.new(File.read(Puppet.settings[:hostcert]))
+https..key = OpenSSL::PKey::RSA.new(File.read(Puppet.settings[:hostprivkey]))
+https..verify_mode = OpenSSL::SSL::VERIFY_PEER
+https..ca_file = Puppet.settings[:localcacert]
+request = Net::https.:Post.new('/rbac-api/v1/auth/token')
 request['Content-Type'] = 'application/json'
 request.body = body
 
-response = http.request(request)
-raise "Error requesting token, #{response.body}" unless response.is_a? Net::HTTPSuccess
+response = https.request(request)
+raise "Error requesting token, #{response.body}" unless response.is_a? Net::https.success
 token = JSON.parse(response.body)['token']
 
 FileUtils.mkdir_p('/root/.puppetlabs')

--- a/tasks/rbac_token.rb
+++ b/tasks/rbac_token.rb
@@ -33,7 +33,7 @@ request['Content-Type'] = 'application/json'
 request.body = body
 
 response = https.request(request)
-raise "Error requesting token, #{response.body}" unless response.is_a? Net::https.success
+raise "Error requesting token, #{response.body}" unless response.is_a? Net::HTTPSuccess
 token = JSON.parse(response.body)['token']
 
 FileUtils.mkdir_p('/root/.puppetlabs')


### PR DESCRIPTION
## Summary
- Changed SSL verification mode to VERIFY_PEER for enhanced security.
- Added Puppet settings initialization to load necessary certificates.
- Updated HTTP request to use Puppet's certname and certificate files.
- Ensured CA file is set for SSL verification.


## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [x] Not needed
