### PR TITLE
(PE-39307) Legacy compilers support smoke tests

### DIFF
--- a/.github/workflows/test-legacy-compilers.yaml
+++ b/.github/workflows/test-legacy-compilers.yaml
@@ -23,7 +23,6 @@ on:
       - .puppet-lint.rc
       - .fixtures.yml
     branches: [main]
-  push:
   workflow_dispatch:
     inputs:
       ssh-debugging:
@@ -143,8 +142,7 @@ jobs:
           echo ::endgroup::
           echo ::group::smoke_test
           legacy_compiler=$(yq '.items[0].value.params.legacy_compilers[0]' peadm_config.json)
-          if [ "$compiler" != "$legacy_compiler" ]
-          then
+          if [ "$compiler" != "$legacy_compiler" ]; then
             echo "Compiler conversion failed, expected $compiler, got $legacy_compiler"
             exit 1
           fi

--- a/.github/workflows/test-legacy-compilers.yaml
+++ b/.github/workflows/test-legacy-compilers.yaml
@@ -1,0 +1,161 @@
+---
+name: Convert compiler to legacy
+on:
+  pull_request:
+    paths:
+      - .github/workflows/**/*
+      - spec/**/*
+      - lib/**/*
+      - tasks/**/*
+      - functions/**/*
+      - types/**/*
+      - plans/**/*
+      - hiera/**/*
+      - manifests/**/*
+      - templates/**/*
+      - files/**/*
+      - metadata.json
+      - Rakefile
+      - Gemfile
+      - provision.yaml
+      - .rspec
+      - .rubocop.yml
+      - .puppet-lint.rc
+      - .fixtures.yml
+    branches: [main]
+  push:
+  workflow_dispatch:
+    inputs:
+      ssh-debugging:
+        description: Boolean; whether or not to pause for ssh debugging
+        required: true
+        default: 'false'
+jobs:
+  convert_compiler:
+    name: Convert compilers to legacy
+    runs-on: ubuntu-20.04
+    env:
+      BOLT_GEM: true
+      BOLT_DISABLE_ANALYTICS: true
+      LANG: en_US.UTF-8
+    steps:
+      - name: Start SSH session
+        if: ${{ github.event.inputs.ssh-debugging == 'true' }}
+        uses: luchihoratiu/debug-via-ssh@main
+        with:
+          NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
+          SSH_PASS: ${{ secrets.SSH_PASS }}
+      - name: Checkout Source
+        uses: actions/checkout@v2
+      - name: Activate Ruby 2.7
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+          bundler-cache: true
+      - name: Print bundle environment
+        if: ${{ github.repository_owner == 'puppetlabs' }}
+        run: |
+          echo ::group::info:bundler
+            bundle env
+          echo ::endgroup::
+      - name: Provision test cluster
+        timeout-minutes: 15
+        run: |
+          echo ::group::prepare
+            mkdir -p $HOME/.ssh
+            echo 'Host *'                      >  $HOME/.ssh/config
+            echo '    ServerAliveInterval 150' >> $HOME/.ssh/config
+            echo '    ServerAliveCountMax 2'   >> $HOME/.ssh/config
+            bundle exec rake spec_prep
+          echo ::endgroup::
+          echo ::group::provision
+            bundle exec bolt plan run peadm_spec::provision_test_cluster \
+              --modulepath spec/fixtures/modules \
+              provider=provision_service \
+              image=almalinux-cloud/almalinux-8 \
+              architecture=large-with-dr
+          echo ::endgroup::
+          echo ::group::certnames
+            bundle exec bolt plan run peadm_spec::add_inventory_hostnames \
+            --inventory spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            --no-host-key-check \
+            inventory_file=spec/fixtures/litmus_inventory.yaml
+          echo ::endgroup::
+          echo ::group::info:request
+            cat request.json || true; echo
+          echo ::endgroup::
+          echo ::group::info:inventory
+            sed -e 's/password: .*/password: "[redacted]"/' < spec/fixtures/litmus_inventory.yaml || true
+          echo ::endgroup::
+      - name: Set up yq
+        uses: frenck/action-setup-yq@v1
+        with:
+          version: v4.30.5
+      - name: Install PE on test cluster
+        timeout-minutes: 120
+        run: |
+          bundle exec bolt plan run peadm_spec::install_test_cluster \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            architecture=large-with-dr \
+            console_password=${{ secrets.CONSOLE_PASSWORD }} \
+            version=2023.7.0
+      - name: Wait as long as the file ${HOME}/pause file is present
+        if: ${{ always() && github.event.inputs.ssh-debugging == 'true' }}
+        run: |
+          while [ -f "${HOME}/pause" ] ; do
+            echo "${HOME}/pause present, sleeping for 60 seconds..."
+            sleep 60
+          done 
+          echo "${HOME}/pause absent, continuing workflow."
+      - name: Convert one compiler to legacy
+        timeout-minutes: 120
+        run: |
+          primary=$(yq '.groups[].targets[] | select(.vars.role == "primary") | .name' spec/fixtures/litmus_inventory.yaml)
+          compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | head -n 1)
+          echo ::group::convert_compiler_to_legacy
+          bundle exec bolt plan run peadm::convert_compiler_to_legacy \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            --no-host-key-check \
+            primary_host=$primary \
+            legacy_hosts=$compiler
+          echo ::endgroup::
+      - name: Check if compiler is converted
+        timeout-minutes: 120
+        run: |
+          echo ::group::inventory
+            sed -e 's/password: .*/password: "[redacted]"/' < spec/fixtures/litmus_inventory.yaml || true
+          echo ::endgroup::
+          echo ::group::get_peadm_config
+          primary=$(yq '.groups[].targets[] | select(.vars.role == "primary") | .name' spec/fixtures/litmus_inventory.yaml)
+          compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | head -n 1)
+          bundle exec bolt task run peadm::get_peadm_config \
+            --targets $primary \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            --no-host-key-check \
+            --format json > peadm_config.json
+          cat peadm_config.json
+          echo ::endgroup::
+          echo ::group::smoke_test
+          legacy_compiler=$(yq '.items[0].value.params.legacy_compilers[0]' peadm_config.json)
+          if [ "$compiler" != "$legacy_compiler" ]
+          then
+            echo "Compiler conversion failed, expected $compiler, got $legacy_compiler"
+            exit 1
+          fi
+          echo ::endgroup::
+      - name: Tear down test cluster
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |-
+          if [ -f spec/fixtures/litmus_inventory.yaml ]; then
+            echo ::group::tear_down
+              bundle exec rake 'litmus:tear_down'
+            echo ::endgroup::
+            echo ::group::info:request
+              cat request.json || true; echo
+            echo ::endgroup::
+          fi

--- a/.github/workflows/test-legacy-upgrade.yaml
+++ b/.github/workflows/test-legacy-upgrade.yaml
@@ -23,7 +23,6 @@ on:
       - .puppet-lint.rc
       - .fixtures.yml
     branches: [main]
-  push:
   workflow_dispatch:
     inputs:
       ssh-debugging:
@@ -141,7 +140,7 @@ jobs:
           echo ::group::smoke_test
           configured_legacy_compiler=$(yq '.items[0].value.params.legacy_compilers[0]' peadm_config.json)
           configured_compiler=$(yq '.items[0].value.params.compiler_hosts[0]' peadm_config.json)
-          if [ "$configured_legacy_compiler" != "$legacy_compiler" AND "$configured_compiler" != "$compiler" ]
+          if [ "$configured_legacy_compiler" != "$legacy_compiler" ] && [ "$configured_compiler" != "$compiler" ]; then
             echo "Compilers are not configured, expected $legacy_compiler and $compiler, got $configured_legacy_compiler and $configured_compiler"
             exit 1
           fi
@@ -186,7 +185,7 @@ jobs:
           echo ::group::smoke_test
           configured_legacy_compiler=$(yq '.items[0].value.params.legacy_compilers[0]' peadm_config.json)
           configured_compiler=$(yq '.items[0].value.params.compiler_hosts[0]' peadm_config.json)
-          if [ "$configured_legacy_compiler" != "$legacy_compiler" AND "$configured_compiler" != "$compiler" ]
+          if [ "$configured_legacy_compiler" != "$legacy_compiler" ] && [ "$configured_compiler" != "$compiler" ]; then
             echo "Compilers are not configured, expected $legacy_compiler and $compiler, got $configured_legacy_compiler and $configured_compiler"
             exit 1
           fi

--- a/.github/workflows/test-legacy-upgrade.yaml
+++ b/.github/workflows/test-legacy-upgrade.yaml
@@ -1,5 +1,5 @@
 ---
-name: Convert compiler to legacy
+name: Upgrade PE with legacy compilers
 on:
   pull_request:
     paths:
@@ -92,15 +92,26 @@ jobs:
         uses: frenck/action-setup-yq@v1
         with:
           version: v4.30.5
-      - name: Install PE on test cluster
+      - name: Create the params.json file
+        run: |
+          primary=$(yq '.groups[].targets[] | select(.vars.role == "primary") | .name' spec/fixtures/litmus_inventory.yaml)
+          compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | head -n 1)
+          legacy_compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | head -n 2)
+          replica=$(yq '.groups[].targets[] | select(.vars.role == "replica") | .name' spec/fixtures/litmus_inventory.yaml)
+          echo -n '{ "primary_host": "'$primary'", "replica_host": "'$replica'", "legacy_compilers": ["'$legacy_compiler'"], "compiler_hosts": ["'$compiler'"], "version": "2023.7.0", "console_password": "'${{ secrets.CONSOLE_PASSWORD }}'" }' > params.json
+      - name: Install PE with legacy compilers
         timeout-minutes: 120
         run: |
-          bundle exec bolt plan run peadm_spec::install_test_cluster \
+          echo ::group::params.json
+          sed -e 's/console_password: .*/console_password: "[redacted]"/' < params.json || true
+          echo ::endgroup::
+          echo ::group::install
+          bundle exec bolt plan run peadm::install \
             --inventoryfile spec/fixtures/litmus_inventory.yaml \
             --modulepath spec/fixtures/modules \
-            architecture=large-with-dr \
-            console_password=${{ secrets.CONSOLE_PASSWORD }} \
-            version=2023.7.0
+            --no-host-key-check \
+            --params @params.json
+          echo ::endgroup::
       - name: Wait as long as the file ${HOME}/pause file is present
         if: ${{ always() && github.event.inputs.ssh-debugging == 'true' }}
         run: |
@@ -109,22 +120,7 @@ jobs:
             sleep 60
           done 
           echo "${HOME}/pause absent, continuing workflow."
-      - name: Convert one compiler to legacy
-        timeout-minutes: 120
-        run: |
-          primary=$(yq '.groups[].targets[] | select(.vars.role == "primary") | .name' spec/fixtures/litmus_inventory.yaml)
-          compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | head -n 1)
-          echo "primary: $primary"
-          echo "compiler: $compiler"
-          echo ::group::convert_compiler_to_legacy
-          bundle exec bolt plan run peadm::convert_compiler_to_legacy \
-            --inventoryfile spec/fixtures/litmus_inventory.yaml \
-            --modulepath spec/fixtures/modules \
-            --no-host-key-check \
-            primary_host=$primary \
-            legacy_hosts=$compiler
-          echo ::endgroup::
-      - name: Check if compiler is converted
+      - name: Check if compilers are configured
         timeout-minutes: 120
         run: |
           echo ::group::inventory
@@ -133,6 +129,7 @@ jobs:
           echo ::group::get_peadm_config
           primary=$(yq '.groups[].targets[] | select(.vars.role == "primary") | .name' spec/fixtures/litmus_inventory.yaml)
           compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | head -n 1)
+          legacy_compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | head -n 2)
           bundle exec bolt task run peadm::get_peadm_config \
             --targets $primary \
             --inventoryfile spec/fixtures/litmus_inventory.yaml \
@@ -142,10 +139,55 @@ jobs:
           cat peadm_config.json
           echo ::endgroup::
           echo ::group::smoke_test
-          legacy_compiler=$(yq '.items[0].value.params.legacy_compilers[0]' peadm_config.json)
-          if [ "$compiler" != "$legacy_compiler" ]
-          then
-            echo "Compiler conversion failed, expected $compiler, got $legacy_compiler"
+          configured_legacy_compiler=$(yq '.items[0].value.params.legacy_compilers[0]' peadm_config.json)
+          configured_compiler=$(yq '.items[0].value.params.compiler_hosts[0]' peadm_config.json)
+          if [ "$configured_legacy_compiler" != "$legacy_compiler" AND "$configured_compiler" != "$compiler" ]
+            echo "Compilers are not configured, expected $legacy_compiler and $compiler, got $configured_legacy_compiler and $configured_compiler"
+            exit 1
+          fi
+          echo ::endgroup::
+      - name: Create the upgrade params.json file
+        run: |
+          primary=$(yq '.groups[].targets[] | select(.vars.role == "primary") | .name' spec/fixtures/litmus_inventory.yaml)
+          compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | head -n 1)
+          legacy_compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | head -n 2)
+          replica=$(yq '.groups[].targets[] | select(.vars.role == "replica") | .name' spec/fixtures/litmus_inventory.yaml)
+          echo -n '{ "primary_host": "'$primary'", "replica_host": "'$replica'", "compiler_hosts": ["'$compiler'", "'$legacy_compiler'"], "version": "2023.8.0"}' > upgrade_params.json
+      - name: Upgrade PE with legacy compilers
+        run: |
+          echo ::group::upgrade_params.json
+          echo upgrade_params.json
+          echo ::endgroup::
+          echo ::group::upgrade
+          bundle exec bolt plan run peadm::upgrade \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            --no-host-key-check \
+            --params @upgrade_params.json
+          echo ::endgroup::
+      - name: Check if we still have legacy compilers configured
+        timeout-minutes: 120
+        run: |
+          echo ::group::inventory
+            sed -e 's/password: .*/password: "[redacted]"/' < spec/fixtures/litmus_inventory.yaml || true
+          echo ::endgroup::
+          echo ::group::get_peadm_config
+          primary=$(yq '.groups[].targets[] | select(.vars.role == "primary") | .name' spec/fixtures/litmus_inventory.yaml)
+          compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | head -n 1)
+          legacy_compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | head -n 2)
+          bundle exec bolt task run peadm::get_peadm_config \
+            --targets $primary \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            --no-host-key-check \
+            --format json > peadm_config.json
+          cat peadm_config.json
+          echo ::endgroup::
+          echo ::group::smoke_test
+          configured_legacy_compiler=$(yq '.items[0].value.params.legacy_compilers[0]' peadm_config.json)
+          configured_compiler=$(yq '.items[0].value.params.compiler_hosts[0]' peadm_config.json)
+          if [ "$configured_legacy_compiler" != "$legacy_compiler" AND "$configured_compiler" != "$compiler" ]
+            echo "Compilers are not configured, expected $legacy_compiler and $compiler, got $configured_legacy_compiler and $configured_compiler"
             exit 1
           fi
           echo ::endgroup::

--- a/.github/workflows/test-legacy-upgrade.yaml
+++ b/.github/workflows/test-legacy-upgrade.yaml
@@ -31,8 +31,8 @@ on:
         required: true
         default: 'false'
 jobs:
-  convert_compiler:
-    name: Convert compilers to legacy
+  upgrade_with_legacy_compilers:
+    name: Upgrade PE with legacy compilers
     runs-on: ubuntu-20.04
     env:
       BOLT_GEM: true
@@ -96,14 +96,14 @@ jobs:
         run: |
           primary=$(yq '.groups[].targets[] | select(.vars.role == "primary") | .name' spec/fixtures/litmus_inventory.yaml)
           compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | head -n 1)
-          legacy_compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | head -n 2)
+          legacy_compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | sed -n 2p)
           replica=$(yq '.groups[].targets[] | select(.vars.role == "replica") | .name' spec/fixtures/litmus_inventory.yaml)
-          echo -n '{ "primary_host": "'$primary'", "replica_host": "'$replica'", "legacy_compilers": ["'$legacy_compiler'"], "compiler_hosts": ["'$compiler'"], "version": "2023.7.0", "console_password": "'${{ secrets.CONSOLE_PASSWORD }}'" }' > params.json
+          echo -n '{ "download_mode": "direct", "primary_host": "'$primary'", "replica_host": "'$replica'", "legacy_compilers": ["'$legacy_compiler'"], "compiler_hosts": ["'$compiler'"], "version": "2023.7.0", "console_password": "'${{ secrets.CONSOLE_PASSWORD }}'" }' > params.json
       - name: Install PE with legacy compilers
         timeout-minutes: 120
         run: |
           echo ::group::params.json
-          sed -e 's/console_password: .*/console_password: "[redacted]"/' < params.json || true
+          jq '.console_password = "[redacted]"' params.json || true
           echo ::endgroup::
           echo ::group::install
           bundle exec bolt plan run peadm::install \
@@ -129,7 +129,7 @@ jobs:
           echo ::group::get_peadm_config
           primary=$(yq '.groups[].targets[] | select(.vars.role == "primary") | .name' spec/fixtures/litmus_inventory.yaml)
           compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | head -n 1)
-          legacy_compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | head -n 2)
+          legacy_compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | sed -n 2p)
           bundle exec bolt task run peadm::get_peadm_config \
             --targets $primary \
             --inventoryfile spec/fixtures/litmus_inventory.yaml \
@@ -150,13 +150,13 @@ jobs:
         run: |
           primary=$(yq '.groups[].targets[] | select(.vars.role == "primary") | .name' spec/fixtures/litmus_inventory.yaml)
           compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | head -n 1)
-          legacy_compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | head -n 2)
+          legacy_compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | sed -n 2p)
           replica=$(yq '.groups[].targets[] | select(.vars.role == "replica") | .name' spec/fixtures/litmus_inventory.yaml)
           echo -n '{ "primary_host": "'$primary'", "replica_host": "'$replica'", "compiler_hosts": ["'$compiler'", "'$legacy_compiler'"], "version": "2023.8.0"}' > upgrade_params.json
       - name: Upgrade PE with legacy compilers
         run: |
           echo ::group::upgrade_params.json
-          echo upgrade_params.json
+          cat upgrade_params.json
           echo ::endgroup::
           echo ::group::upgrade
           bundle exec bolt plan run peadm::upgrade \
@@ -174,7 +174,7 @@ jobs:
           echo ::group::get_peadm_config
           primary=$(yq '.groups[].targets[] | select(.vars.role == "primary") | .name' spec/fixtures/litmus_inventory.yaml)
           compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | head -n 1)
-          legacy_compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | head -n 2)
+          legacy_compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | sed -n 2p)
           bundle exec bolt task run peadm::get_peadm_config \
             --targets $primary \
             --inventoryfile spec/fixtures/litmus_inventory.yaml \

--- a/spec/acceptance/peadm_spec/plans/add_inventory_hostnames.pp
+++ b/spec/acceptance/peadm_spec/plans/add_inventory_hostnames.pp
@@ -4,10 +4,15 @@ plan peadm_spec::add_inventory_hostnames(
   $t = get_targets('*')
   wait_until_available($t)
 
-  parallelize($t) |$target| {
-    $fqdn = run_command('hostname -f', $target)
-    $target.set_var('certname', $fqdn.first['stdout'].chomp)
-    $command = "yq eval '(.groups[].targets[] | select(.uri == \"${target.uri}\").name) = \"${target.vars['certname']}\"' -i ${inventory_file}"
-    run_command($command, 'localhost')
+  $t.map |$target| {
+    $fqdn = run_command('hostname -f', $target).first
+    if $fqdn['exit_code'] != 0 {
+      fail("Failed to get FQDN for target ${target.name}: ${fqdn['stderr']}")
+    }
+    $command = "yq eval '(.groups[].targets[] | select(.uri == \"${target.uri}\").name) = \"${fqdn['stdout'].chomp}\"' -i ${inventory_file}"
+    $result = run_command($command, 'localhost').first
+    if $result['exit_code'] != 0 {
+      fail("Failed to update inventory file for target ${uri}: ${result['stderr']}")
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Install Puppet Enterprise with legacy compilers 
- Convert one compiler to legacy and verify the conversion

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [x] Not needed
