### PR TITLE
(PE-39397) Adding LDAP endpoint for 2023.8

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1384,6 +1384,12 @@ Data type: `String`
 
 The PE Main server
 
+##### `pe_version`
+
+Data type: `String`
+
+The PE version
+
 ### <a name="pe_uninstall"></a>`pe_uninstall`
 
 Uninstall Puppet Enterprise

--- a/plans/subplans/configure.pp
+++ b/plans/subplans/configure.pp
@@ -124,10 +124,15 @@ plan peadm::subplans::configure (
   }
 
   if $ldap_config {
+    $pe_version = run_task('peadm::read_file', $primary_target,
+      path => '/opt/puppetlabs/server/pe_version',
+    )[0][content].chomp
+
     # Run the task to configure ldap
     $ldap_result = run_task('peadm::pe_ldap_config', $primary_target,
       pe_main         => $primary_target.peadm::certname(),
       ldap_config     => $ldap_config,
+      pe_version      => $pe_version,
       '_catch_errors' => true,
     )
 

--- a/tasks/pe_ldap_config.json
+++ b/tasks/pe_ldap_config.json
@@ -8,6 +8,10 @@
     "pe_main": {
       "type": "String",
       "description": "The PE Main server"
+    },
+    "pe_version": {
+      "type": "String",
+      "description": "The PE version"
     }
   },
   "input_method": "stdin",


### PR DESCRIPTION
## Summary
As rbac-api/v1/ds has been deprecated, and remove in 2023.8, we need to utilise the new endpoint. Adding case for installs of versions 23.8 and above to use rbac-api/v1/command/ldap/create.

## Additional Context
Add any additional context about the problem here.

## Related Issues (if any)
https://github.com/puppetlabs/puppetlabs-peadm/issues/498

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [ ] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [ ] Not needed
