### PR TITLE
fix: echo environment variable containing special char

### DIFF
--- a/tasks/agent_install.sh
+++ b/tasks/agent_install.sh
@@ -6,6 +6,6 @@ if [ -x "/opt/puppetlabs/bin/puppet" ]; then
   echo "WARNING: Puppet agent is already installed. Re-install, re-configuration, or upgrade not supported and might fail."
 fi
 
-flags=$(echo $PT_install_flags | sed -e 's/^\["*//' -e 's/"*\]$//' -e 's/", *"/ /g')
+flags=$(echo "$PT_install_flags" | sed -e 's/^\["*//' -e 's/"*\]$//' -e 's/", *"/ /g')
 
 curl -k "https://${PT_server}:8140/packages/current/install.bash" | bash -s -- $flags


### PR DESCRIPTION
## Summary
The PT_install_flags variable is known to contain special characters, which may not be deterministically resolved by the shell unless escaped. It is recommended to quote such variables when using in conjunction with `echo`.

> The unquoted variable is essentially one long character class, [...], and it will match any single-letter filename in the current directory whose name occurs in within the brackets.

[source](https://unix.stackexchange.com/questions/785504/why-does-the-environment-variable-change-based-on-pwd#comment1505210_785504)

## Additional Context
- https://unix.stackexchange.com/a/347954/663749
- https://unix.stackexchange.com/questions/785504/why-does-the-environment-variable-change-based-on-pwd#comment1505199_785504

## Related Issues (if any)
- https://portal.perforce.com/s/detail/500PA00000FWMszYAH

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [x] Not needed
