### PR TITLE
(MAINT) Add compiler missing legacy false

### DIFF
--- a/plans/subplans/component_install.pp
+++ b/plans/subplans/component_install.pp
@@ -21,10 +21,13 @@ plan peadm::subplans::component_install(
     $certificate_extensions = {
       peadm::oid('pp_auth_role')             => 'pe_compiler',
       peadm::oid('peadm_availability_group') => $avail_group_letter,
+      peadm::oid('peadm_legacy_compiler')    => false,
     }
   } elsif $role == 'pe_compiler_legacy' {
     $certificate_extensions = {
-      peadm::oid('peadm_role')               => $role,
+      peadm::oid('pp_auth_role')             => 'pe_compiler',
+      peadm::oid('peadm_availability_group') => $avail_group_letter,
+      peadm::oid('peadm_legacy_compiler')    => true,
     }
   } else {
     $certificate_extensions = {


### PR DESCRIPTION
## Summary
Component install missing additional cert to show compilers aren't legacy

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [x] Not needed
