### PR TITLE
Check for curl failure

### DIFF
--- a/tasks/agent_install.sh
+++ b/tasks/agent_install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set -o pipefail
 
 if [ -x "/opt/puppetlabs/bin/puppet" ]; then
   echo "WARNING: Puppet agent is already installed. Re-install, re-configuration, or upgrade not supported and might fail."
@@ -8,4 +9,4 @@ fi
 
 flags=$(echo "$PT_install_flags" | sed -e 's/^\["*//' -e 's/"*\]$//' -e 's/", *"/ /g')
 
-curl -k "https://${PT_server}:8140/packages/current/install.bash" | bash -s -- $flags
+curl --fail -k "https://${PT_server}:8140/packages/current/install.bash" | bash -s -- $flags


### PR DESCRIPTION
When running the peadm::agent_install shell task, fail the task if the curl command fails.

## Summary
Ensure a curl failure when attempting to install the agent results in a failure of the task. Otherwise,
the task will report success regardless, leading to confusing and misleading failures in following
steps during the install.
