### PR TITLE
Remove insecure pe_installer_source parameter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2042,7 +2042,6 @@ The following parameters are available in the `peadm::install` plan:
 * [`compiler_pool_address`](#-peadm--install--compiler_pool_address)
 * [`internal_compiler_a_pool_address`](#-peadm--install--internal_compiler_a_pool_address)
 * [`internal_compiler_b_pool_address`](#-peadm--install--internal_compiler_b_pool_address)
-* [`pe_installer_source`](#-peadm--install--pe_installer_source)
 * [`ldap_config`](#-peadm--install--ldap_config)
 * [`final_agent_state`](#-peadm--install--final_agent_state)
 * [`stagingdir`](#-peadm--install--stagingdir)
@@ -2095,17 +2094,6 @@ Data type: `Optional[String]`
 A load balancer address directing traffic to any of the "B" pool
 compilers. This is used for DR configuration in large and extra large
 architectures.
-
-Default value: `undef`
-
-##### <a name="-peadm--install--pe_installer_source"></a>`pe_installer_source`
-
-Data type: `Optional[Stdlib::HTTPSUrl]`
-
-The URL to download the Puppet Enterprise installer media from. If not
-specified, PEAdm will attempt to download PE installation media from its
-standard public source. When specified, PEAdm will download directly from the
-URL given.
 
 Default value: `undef`
 
@@ -2567,7 +2555,6 @@ The following parameters are available in the `peadm::upgrade` plan:
 * [`compiler_pool_address`](#-peadm--upgrade--compiler_pool_address)
 * [`internal_compiler_a_pool_address`](#-peadm--upgrade--internal_compiler_a_pool_address)
 * [`internal_compiler_b_pool_address`](#-peadm--upgrade--internal_compiler_b_pool_address)
-* [`pe_installer_source`](#-peadm--upgrade--pe_installer_source)
 * [`final_agent_state`](#-peadm--upgrade--final_agent_state)
 * [`r10k_known_hosts`](#-peadm--upgrade--r10k_known_hosts)
 * [`stagingdir`](#-peadm--upgrade--stagingdir)
@@ -2609,17 +2596,6 @@ Data type: `Optional[String]`
 A load balancer address directing traffic to any of the "B" pool
 compilers. This is used for DR configuration in large and extra large
 architectures.
-
-Default value: `undef`
-
-##### <a name="-peadm--upgrade--pe_installer_source"></a>`pe_installer_source`
-
-Data type: `Optional[Stdlib::HTTPSUrl]`
-
-The URL to download the Puppet Enterprise installer media from. If not
-specified, PEAdm will attempt to download PE installation media from its
-standard public source. When specified, PEAdm will download directly from the
-URL given.
 
 Default value: `undef`
 

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -11,11 +11,6 @@
 #   A load balancer address directing traffic to any of the "B" pool
 #   compilers. This is used for DR configuration in large and extra large
 #   architectures.
-# @param pe_installer_source
-#   The URL to download the Puppet Enterprise installer media from. If not
-#   specified, PEAdm will attempt to download PE installation media from its
-#   standard public source. When specified, PEAdm will download directly from the
-#   URL given.
 # @param ldap_config
 #   If specified, configures PE RBAC DS with the supplied configuration hash.
 #   The parameter should be set to a valid set of connection settings as
@@ -47,7 +42,6 @@ plan peadm::install (
   # Common Configuration
   String                            $console_password,
   Peadm::Pe_version                 $version                          = '2023.8.1',
-  Optional[Stdlib::HTTPSUrl]        $pe_installer_source              = undef,
   Optional[Array[String]]           $dns_alt_names                    = undef,
   Optional[String]                  $compiler_pool_address            = undef,
   Optional[String]                  $internal_compiler_a_pool_address = undef,
@@ -94,7 +88,6 @@ plan peadm::install (
 
     # Common Configuration
     version                        => $version,
-    pe_installer_source            => $pe_installer_source,
     console_password               => $console_password,
     dns_alt_names                  => $dns_alt_names,
     pe_conf_data                   => $pe_conf_data,

--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -28,12 +28,6 @@
 #   Config data to plane into pe.conf when generated on all hosts, this can be
 #   used for tuning data etc.
 #
-# @param pe_installer_source
-#   The URL to download the Puppet Enterprise installer media from. If not
-#   specified, PEAdm will attempt to download PE installation media from its
-#   standard public source. When specified, PEAdm will download directly from the
-#   URL given.
-#
 plan peadm::subplans::install (
   # Standard
   Peadm::SingleTargetSpec           $primary_host,
@@ -50,7 +44,6 @@ plan peadm::subplans::install (
   # Common Configuration
   String               $console_password,
   Peadm::Pe_version    $version,
-  Optional[Stdlib::HTTPSUrl] $pe_installer_source = undef,
   Array[String]        $dns_alt_names       = [],
   Hash                 $pe_conf_data        = {},
 
@@ -237,13 +230,8 @@ plan peadm::subplans::install (
     )
   }
 
-  if $pe_installer_source {
-    $pe_tarball_name = $pe_installer_source.split('/')[-1]
-    $pe_tarball_source = $pe_installer_source
-  } else {
-    $pe_tarball_name   = "puppet-enterprise-${version}-${platform}.tar.gz"
-    $pe_tarball_source = "https://s3.amazonaws.com/pe-builds/released/${version}/${pe_tarball_name}"
-  }
+  $pe_tarball_name   = "puppet-enterprise-${version}-${platform}.tar.gz"
+  $pe_tarball_source = "https://s3.amazonaws.com/pe-builds/released/${version}/${pe_tarball_name}"
 
   $upload_tarball_path = "${uploaddir}/${pe_tarball_name}"
 

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -11,11 +11,6 @@
 #   A load balancer address directing traffic to any of the "B" pool
 #   compilers. This is used for DR configuration in large and extra large
 #   architectures.
-# @param pe_installer_source
-#   The URL to download the Puppet Enterprise installer media from. If not
-#   specified, PEAdm will attempt to download PE installation media from its
-#   standard public source. When specified, PEAdm will download directly from the
-#   URL given.
 # @param final_agent_state
 #   Configures the state the puppet agent should be in on infrastructure nodes
 #   after PE is upgraded successfully.
@@ -46,7 +41,6 @@ plan peadm::upgrade (
 
   # Common Configuration
   Optional[Peadm::Pe_version]  $version                          = undef,
-  Optional[Stdlib::HTTPSUrl]   $pe_installer_source              = undef,
   Optional[String]             $compiler_pool_address            = undef,
   Optional[String]             $internal_compiler_a_pool_address = undef,
   Optional[String]             $internal_compiler_b_pool_address = undef,
@@ -119,21 +113,14 @@ plan peadm::upgrade (
 
   $platform = run_task('peadm::precheck', $primary_target).first['platform']
 
-  if $pe_installer_source {
-    $pe_tarball_name   = $pe_installer_source.split('/')[-1]
-    $pe_tarball_source = $pe_installer_source
-    $_version          = $pe_tarball_name.split('-')[2]
-  } else {
-    $_version          = $version
-    $pe_tarball_name   = "puppet-enterprise-${_version}-${platform}.tar.gz"
-    $pe_tarball_source = "https://s3.amazonaws.com/pe-builds/released/${_version}/${pe_tarball_name}"
-  }
+  $pe_tarball_name   = "puppet-enterprise-${version}-${platform}.tar.gz"
+  $pe_tarball_source = "https://s3.amazonaws.com/pe-builds/released/${version}/${pe_tarball_name}"
 
   $upload_tarball_path = "${uploaddir}/${pe_tarball_name}"
 
   peadm::assert_supported_bolt_version()
 
-  peadm::assert_supported_pe_version($_version, $permit_unsafe_versions)
+  peadm::assert_supported_pe_version($version, $permit_unsafe_versions)
 
   # Gather certificate extension information from all systems
   $cert_extensions_temp = run_task('peadm::cert_data', $all_targets).reduce({}) |$memo,$result| {
@@ -402,7 +389,7 @@ plan peadm::upgrade (
     # doesn't deal well with the PuppetDB database being on a separate node.
     # So, move it aside before running the upgrade.
     $pdbapps = '/opt/puppetlabs/server/apps/puppetdb/cli/apps'
-    $workaround_delete_reports = $arch['disaster-recovery'] and $_version =~ SemVerRange('>= 2019.8')
+    $workaround_delete_reports = $arch['disaster-recovery'] and $version =~ SemVerRange('>= 2019.8')
     if $workaround_delete_reports {
 # lint:ignore:strict_indent
       run_command(@("COMMAND"/$), $replica_target)
@@ -454,7 +441,7 @@ plan peadm::upgrade (
     )
   }
 
-  peadm::check_version_and_known_hosts($current_pe_version, $_version, $r10k_known_hosts)
+  peadm::check_version_and_known_hosts($current_pe_version, $version, $r10k_known_hosts)
 
   return("Upgrade of Puppet Enterprise ${arch['architecture']} completed.")
 }

--- a/tasks/download.json
+++ b/tasks/download.json
@@ -23,5 +23,6 @@
   "implementations": [
     {"name": "download.sh", "requirements": ["shell"],  "input_method": "environment"},
     {"name": "download.ps1", "requirements": ["powershell"], "input_method": "powershell"}
-    ]
+  ],
+  "private": true
 }


### PR DESCRIPTION
## Summary

As discussed in an earlier meeting, https://github.com/puppetlabs/puppetlabs-peadm/pull/465 was closed because the security team demands that peadm doesn't support downloading from provided URLs and the `pe_installer_source` parameter has to go away.

## Additional Context
Add any additional context about the problem here.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Have you updated the documentation?
- [x] Yes, I've updated the appropriate docs
- [ ] Not needed
