### PR TITLE
Move download_type enum to own type alias

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -44,6 +44,7 @@
 ### Data types
 
 * [`Peadm::ConvertSteps`](#Peadm--ConvertSteps): type for the different steps where the peadm::convert plan can be started
+* [`Peadm::Download_mode`](#Peadm--Download_mode): download the installer to the bolt node and upload to targets, or let the targets download it directly
 * [`Peadm::Known_hosts`](#Peadm--Known_hosts)
 * [`Peadm::Ldap_config`](#Peadm--Ldap_config)
 * [`Peadm::Pe_version`](#Peadm--Pe_version)
@@ -927,6 +928,12 @@ Data type: `TargetSpec`
 type for the different steps where the peadm::convert plan can be started
 
 Alias of `Enum['modify-primary-certs', 'modify-infra-certs', 'convert-node-groups', 'finalize']`
+
+### <a name="Peadm--Download_mode"></a>`Peadm::Download_mode`
+
+download the installer to the bolt node and upload to targets, or let the targets download it directly
+
+Alias of `Enum['direct', 'bolthost']`
 
 ### <a name="Peadm--Known_hosts"></a>`Peadm::Known_hosts`
 
@@ -2262,7 +2269,7 @@ Default value: `undef`
 
 ##### <a name="-peadm--install--download_mode"></a>`download_mode`
 
-Data type: `Enum['direct', 'bolthost']`
+Data type: `Peadm::Download_mode`
 
 
 
@@ -2654,7 +2661,7 @@ Default value: `undef`
 
 ##### <a name="-peadm--upgrade--download_mode"></a>`download_mode`
 
-Data type: `Enum[direct,bolthost]`
+Data type: `Peadm::Download_mode`
 
 
 

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -71,7 +71,7 @@ plan peadm::install (
   Optional[String]           $stagingdir             = undef,
   Optional[String]           $uploaddir              = undef,
   Enum['running', 'stopped'] $final_agent_state      = 'running',
-  Enum['direct', 'bolthost'] $download_mode          = 'bolthost',
+  Peadm::Download_mode       $download_mode          = 'bolthost',
   Boolean                    $permit_unsafe_versions = false,
   String                     $token_lifetime         = '1y',
 ) {

--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -68,7 +68,7 @@ plan peadm::subplans::install (
   # Other
   String                $stagingdir             = '/tmp',
   String                $uploaddir              = '/tmp',
-  Enum[direct,bolthost] $download_mode          = 'bolthost',
+  Peadm::Download_mode  $download_mode          = 'bolthost',
   Boolean               $permit_unsafe_versions = false,
   String                $token_lifetime         = '1y',
 ) {

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -57,7 +57,7 @@ plan peadm::upgrade (
   String                     $stagingdir             = '/tmp',
   String                     $uploaddir              = '/tmp',
   Enum['running', 'stopped'] $final_agent_state      = 'running',
-  Enum[direct,bolthost]      $download_mode          = 'bolthost',
+  Peadm::Download_mode       $download_mode          = 'bolthost',
   Boolean                    $permit_unsafe_versions = false,
 
   Optional[Peadm::UpgradeSteps] $begin_at_step = undef,

--- a/types/download_mode.pp
+++ b/types/download_mode.pp
@@ -1,0 +1,2 @@
+# @summary download the installer to the bolt node and upload to targets, or let the targets download it directly
+type Peadm::Download_mode = Enum['direct','bolthost']


### PR DESCRIPTION
This allows users of PEADM to reuse the type and validate their input properly before calling peadm.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Have you updated the documentation?
- [x] Yes, I've updated the appropriate docs
- [ ] Not needed
