### PR TITLE
(PE-39352) Add version to get peadm config

### DIFF
--- a/tasks/get_peadm_config.rb
+++ b/tasks/get_peadm_config.rb
@@ -41,6 +41,7 @@ class GetPEAdmConfig
 
     # Build and return the task output
     {
+      'pe_version' => pe_version,
       'params' => {
         'primary_host' => primary,
         'replica_host' => replica,
@@ -71,6 +72,12 @@ class GetPEAdmConfig
         },
       },
     }
+  end
+
+  # @return [String] Local PE version string.
+  def pe_version
+    pe_build_file = '/opt/puppetlabs/server/pe_build'
+    File.read(pe_build_file).strip if File.exist?(pe_build_file)
   end
 
   # Returns a GetPEAdmConfig::NodeGroups object created from the /groups object

--- a/tasks/get_peadm_config.rb
+++ b/tasks/get_peadm_config.rb
@@ -11,9 +11,9 @@ class GetPEAdmConfig
   def initialize(params); end
 
   def execute!
-    # if there is no 'PE HA Replica' node group, it's not a peadm-configured cluster.
-    replica_group = groups.data.find { |obj| obj['name'] == 'PE HA Replica' }
-    if replica_group
+    # if there is no 'PE Primary A' node group, it's not a peadm-configured cluster.
+    peadm_primary_a_group = groups.data.find { |obj| obj['name'] == 'PE Primary A' }
+    if peadm_primary_a_group
       puts config.to_json
     else
       puts({ 'error' => 'This is not a peadm-compatible cluster. Use peadm::convert first.' }).to_json


### PR DESCRIPTION
## Summary
Adds a lookup of the pe_build file to provide the PE version in the hash
returned by the get_peadm_config task.

We will use this in add_database and backup/restore plans as a version
gate for handling the newer host_action_collector database that is only
present in PE 2023.7+, for example.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

Debated this; get_peadm_config task doesn't currently have a spec. I could certainly add one, if we'd like to expand the coverage there, but it's quite a bit more code than the pe_version addition :)

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [x] Not needed
