### PR TITLE
(maint) Constrain orchestrator_client to < 0.7.1

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -10,6 +10,11 @@ Gemfile:
         version: '1.16.4' # Pinned to latest bug fix version
       - gem: 'octokit'
         version: '4.21.0' # Locked due to https://github.com/octokit/octokit.rb/issues/1391
+      # The Faraday requirements in orchestrator_client 0.7.1 causes Bundler to
+      # resolve the dependency in unexpected ways and causes issues in CI
+      - gem: 'orchestrator_client'
+        version: '< 0.7.1'
+        condition: 'ENV["GEM_BOLT"]'
 Rakefile:
   changelog_since_tag: '2.5.0'
   default_disabled_lint_checks: ['strict_indent','manifest_whitespace_missing_newline_end_of_file']

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,41 +1,44 @@
 ---
 Gemfile:
   required:
-    ':development':
-      - gem: 'bolt'
+    :development:
+      - gem: bolt
         version: '>= 3.10.0'
   optional:
-    ':development':
-      - gem: 'github_changelog_generator'
-        version: '1.16.4' # Pinned to latest bug fix version
-      - gem: 'octokit'
-        version: '4.21.0' # Locked due to https://github.com/octokit/octokit.rb/issues/1391
+    :development:
+      - gem: github_changelog_generator
+        version: 1.16.4  # Pinned to latest bug fix version
+      - gem: octokit
+        version: 4.21.0  # Locked due to https://github.com/octokit/octokit.rb/issues/1391
       # The Faraday requirements in orchestrator_client 0.7.1 causes Bundler to
       # resolve the dependency in unexpected ways and causes issues in CI
-      - gem: 'orchestrator_client'
-        version: '< 0.7.1'
-        condition: 'ENV["GEM_BOLT"]'
+      - gem: orchestrator_client
+        version: < 0.7.1
+        condition: ENV["GEM_BOLT"]
 Rakefile:
-  changelog_since_tag: '2.5.0'
-  default_disabled_lint_checks: ['strict_indent','manifest_whitespace_missing_newline_end_of_file']
+  changelog_since_tag: 2.5.0
+  default_disabled_lint_checks:
+    - strict_indent
+    - manifest_whitespace_missing_newline_end_of_file
   extras:
-    - 'PuppetSyntax.exclude_paths = ["plans/**/*.pp", "spec/acceptance/**/plans/**/*.pp", "vendor/**/*"]'
+    - PuppetSyntax.exclude_paths = ["plans/**/*.pp", "spec/acceptance/**/plans/**/*.pp",
+      "vendor/**/*"]
 spec/spec_helper.rb:
-    mock_with: ':rspec'
+  mock_with: :rspec
 .gitignore:
   paths:
-    - '.rerun.json'
+    - .rerun.json
     - '*.tar.gz'
-    - '.modules/'
-    - '.plan_cache.json'
-    - '.resource_types/'
-    - 'bolt-debug.log'
-    - 'spec/docker/**/*.tar.gz'
-    - 'spec/docker/**/*.asc'
-    - 'spec/docker/**/files/puppet-enterprise*'
-    - 'spec/docker/.task_cache.json'
+    - .modules/
+    - .plan_cache.json
+    - .resource_types/
+    - bolt-debug.log
+    - spec/docker/**/*.tar.gz
+    - spec/docker/**/*.asc
+    - spec/docker/**/files/puppet-enterprise*
+    - spec/docker/.task_cache.json
 .github/workflows/auto_release.yml:
-  unmanaged: false 
+  unmanaged: false
 .github/workflows/release.yml:
   unmanaged: false
 .github/workflows/spec.yml:
@@ -46,7 +49,7 @@ spec/spec_helper.rb:
   unmanaged: false
 .travis.yml:
   delete: true
-".gitlab-ci.yml":
+.gitlab-ci.yml:
   delete: true
 appveyor.yml:
   delete: true

--- a/.sync.yml
+++ b/.sync.yml
@@ -14,7 +14,6 @@ Gemfile:
       # resolve the dependency in unexpected ways and causes issues in CI
       - gem: orchestrator_client
         version: < 0.7.1
-        condition: ENV["GEM_BOLT"]
 Rakefile:
   changelog_since_tag: 2.5.0
   default_disabled_lint_checks:

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ group :development do
   gem "bolt", '>= 3.27.2',                       require: false
   gem "github_changelog_generator", '1.16.4',    require: false
   gem "octokit", '4.21.0',                       require: false
-  gem "orchestrator_client", '< 0.7.1', require: false if ENV["GEM_BOLT"]
+  gem "orchestrator_client", '< 0.7.1',          require: false
 end
 group :system_tests do
   gem "puppet_litmus", '~> 1.0', require: false, platforms: [:ruby, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :development do
   gem "bolt", '>= 3.27.2',                       require: false
   gem "github_changelog_generator", '1.16.4',    require: false
   gem "octokit", '4.21.0',                       require: false
+  gem "orchestrator_client", '< 0.7.1', require: false if ENV["GEM_BOLT"]
 end
 group :system_tests do
   gem "puppet_litmus", '~> 1.0', require: false, platforms: [:ruby, :x64_mingw]

--- a/metadata.json
+++ b/metadata.json
@@ -34,7 +34,7 @@
     },
     {
       "name": "puppetlabs/ruby_task_helper",
-      "version_requirement": ">= 0.6.1 < 1.0.0"
+      "version_requirement": ">= 1.0.0 < 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
## Summary
Based on https://github.com/puppetlabs/puppetlabs-puppet_agent/pull/743 to fix an issue with the version 0.7.1 of orchestrator_client

"The 0.7.1 release of orchestrator_client broadened its dependency on Faraday (see https://github.com/puppetlabs/orchestrator_client-ruby/commit/6f8661e). This change has caused Bundler to resolve Faraday in unexpected ways when there are other Gems with dependencies on Faraday.

This commit constrains orchestrator_client to < 0.7.1 until this issue is resolved."

## Additional Context
Add any additional context about the problem here.

## Related Issues (if any)
https://github.com/rubygems/rubygems/issues/8286

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [x] Not needed
