### PR TITLE
(maint) Run pdk update with version 3.4.0 and fix sync.yml with the pdk

### DIFF
--- a/.github/workflows/yamlformatter.yml
+++ b/.github/workflows/yamlformatter.yml
@@ -22,8 +22,9 @@ jobs:
         id: changed_yaml_files
         run: |
           echo ${{ steps.get_file_changes.outputs.files }} | xargs -n 1 | grep -E "\.yml$|\.yaml$" > changed_files.txt
-          # Remove dependabot.yml if it exists in the list
-          sed -i '/.github\/dependabot.yml/d' changed_files.txt || true
+          # Remove dependabot.yml and sync.yml if they exist in the list
+            sed -i '/.github\/dependabot.yml/d' changed_files.txt || true
+            sed -i '/.sync.yml/d' changed_files.txt || true
           yaml_files=$(cat changed_files.txt | tr '\n' ' ')
           rm changed_files.txt
           echo "files=${yaml_files}" >> $GITHUB_OUTPUT

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 /spec/fixtures/modules/*
 /tmp/
 /vendor/
+/.vendor/
 /convert_report.txt
 /update_report.txt
 .DS_Store
@@ -26,12 +27,15 @@
 .envrc
 /inventory.yaml
 /spec/fixtures/litmus_inventory.yaml
+.resource_types
+.modules
+.task_cache.json
+.plan_cache.json
 .rerun.json
+bolt-debug.log
 *.tar.gz
 .modules/
-.plan_cache.json
 .resource_types/
-bolt-debug.log
 spec/docker/**/*.tar.gz
 spec/docker/**/*.asc
 spec/docker/**/files/puppet-enterprise*

--- a/.pdkignore
+++ b/.pdkignore
@@ -19,6 +19,7 @@
 /spec/fixtures/modules/*
 /tmp/
 /vendor/
+/.vendor/
 /convert_report.txt
 /update_report.txt
 .DS_Store
@@ -26,9 +27,16 @@
 .envrc
 /inventory.yaml
 /spec/fixtures/litmus_inventory.yaml
+.resource_types
+.modules
+.task_cache.json
+.plan_cache.json
+.rerun.json
+bolt-debug.log
 /.fixtures.yml
 /Gemfile
 /.gitattributes
+/.github/
 /.gitignore
 /.pdkignore
 /.puppet-lint.rc

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,1 +1,11 @@
+--fail-on-warnings
 --relative
+--no-80chars-check
+--no-140chars-check
+--no-class_inherits_from_params_class-check
+--no-autoloader_layout-check
+--no-documentation-check
+--no-single_quote_string_with_variables-check
+--no-strict_indent-check
+--no-manifest_whitespace_missing_newline_end_of_file-check
+--ignore-paths=.vendor/**/*.pp,.bundle/**/*.pp,pkg/**/*.pp,spec/**/*.pp,tests/**/*.pp,types/**/*.pp,vendor/**/*.pp

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,38 +1,33 @@
 ---
-require:
-- rubocop-performance
-- rubocop-rspec
+require: [rubocop-performance, rubocop-rspec]
 AllCops:
   NewCops: enable
   DisplayCopNames: true
   TargetRubyVersion: '2.6'
-  Include:
-  - "**/*.rb"
+  Include: ['**/*.rb']
   Exclude:
-  - bin/*
-  - ".vendor/**/*"
-  - "**/Gemfile"
-  - "**/Rakefile"
-  - pkg/**/*
-  - spec/fixtures/**/*
-  - vendor/**/*
-  - "**/Puppetfile"
-  - "**/Vagrantfile"
-  - "**/Guardfile"
+    - bin/*
+    - .vendor/**/*
+    - '**/Gemfile'
+    - '**/Rakefile'
+    - pkg/**/*
+    - spec/fixtures/**/*
+    - vendor/**/*
+    - '**/Puppetfile'
+    - '**/Vagrantfile'
+    - '**/Guardfile'
 Layout/LineLength:
   Description: People have wide screens, use them.
   Max: 200
 RSpec/BeforeAfterAll:
   Description: Beware of using after(:all) as it may cause state to leak between tests.
     A necessary evil in acceptance testing.
-  Exclude:
-  - spec/acceptance/**/*.rb
+  Exclude: [spec/acceptance/**/*.rb]
 RSpec/HookArgument:
   Description: Prefer explicit :each argument, matching existing module's style
   EnforcedStyle: each
 RSpec/DescribeSymbol:
-  Exclude:
-  - spec/unit/facter/**/*.rb
+  Exclude: [spec/unit/facter/**/*.rb]
 Style/BlockDelimiters:
   Description: Prefer braces for chaining. Mostly an aesthetical choice. Better to
     be consistent then.
@@ -75,9 +70,7 @@ Style/SymbolArray:
 RSpec/MessageSpies:
   EnforcedStyle: receive
 Style/Documentation:
-  Exclude:
-  - lib/puppet/parser/functions/**/*
-  - spec/**/*
+  Exclude: [lib/puppet/parser/functions/**/*, spec/**/*]
 Style/WordArray:
   EnforcedStyle: brackets
 Performance/AncestorsInclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,11 +3,9 @@ require:
 - rubocop-performance
 - rubocop-rspec
 AllCops:
-  Newcops: enable
-  ExtraDetails: true
-  DisplayStyleGuide: true
+  NewCops: enable
   DisplayCopNames: true
-  TargetRubyVersion: '2.7'
+  TargetRubyVersion: '2.6'
   Include:
   - "**/*.rb"
   Exclude:
@@ -530,6 +528,8 @@ Lint/DuplicateBranch:
   Enabled: false
 Lint/DuplicateMagicComment:
   Enabled: false
+Lint/DuplicateMatchPattern:
+  Enabled: false
 Lint/DuplicateRegexpCharacterClassElement:
   Enabled: false
 Lint/EmptyBlock:
@@ -646,6 +646,8 @@ Style/ComparableClamp:
   Enabled: false
 Style/ConcatArrayLiterals:
   Enabled: false
+Style/DataInheritance:
+  Enabled: false
 Style/DirEmpty:
   Enabled: false
 Style/DocumentDynamicEvalDefinition:
@@ -713,6 +715,8 @@ Style/RedundantEach:
 Style/RedundantHeredocDelimiterQuotes:
   Enabled: false
 Style/RedundantInitialize:
+  Enabled: false
+Style/RedundantLineContinuation:
   Enabled: false
 Style/RedundantSelfAssignmentBranch:
   Enabled: false

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,43 +1,40 @@
 ---
 Gemfile:
   required:
-    :development:
-      - gem: bolt
+    ':development':
+      - gem: 'bolt'
         version: '>= 3.10.0'
   optional:
-    :development:
-      - gem: github_changelog_generator
-        version: 1.16.4  # Pinned to latest bug fix version
-      - gem: octokit
-        version: 4.21.0  # Locked due to https://github.com/octokit/octokit.rb/issues/1391
+    ':development':
+      - gem: 'github_changelog_generator'
+        version: '1.16.4' # Pinned to latest bug fix version
+      - gem: 'octokit'
+        version: '4.21.0' # Locked due to https://github.com/octokit/octokit.rb/issues/1391
       # The Faraday requirements in orchestrator_client 0.7.1 causes Bundler to
       # resolve the dependency in unexpected ways and causes issues in CI
       - gem: orchestrator_client
         version: < 0.7.1
 Rakefile:
-  changelog_since_tag: 2.5.0
-  default_disabled_lint_checks:
-    - strict_indent
-    - manifest_whitespace_missing_newline_end_of_file
+  changelog_since_tag: '2.5.0'
+  default_disabled_lint_checks: ['strict_indent','manifest_whitespace_missing_newline_end_of_file']
   extras:
-    - PuppetSyntax.exclude_paths = ["plans/**/*.pp", "spec/acceptance/**/plans/**/*.pp",
-      "vendor/**/*"]
+    - 'PuppetSyntax.exclude_paths = ["plans/**/*.pp", "spec/acceptance/**/plans/**/*.pp", "vendor/**/*"]'
 spec/spec_helper.rb:
-  mock_with: :rspec
+    mock_with: ':rspec'
 .gitignore:
   paths:
-    - .rerun.json
+    - '.rerun.json'
     - '*.tar.gz'
-    - .modules/
-    - .plan_cache.json
-    - .resource_types/
-    - bolt-debug.log
-    - spec/docker/**/*.tar.gz
-    - spec/docker/**/*.asc
-    - spec/docker/**/files/puppet-enterprise*
-    - spec/docker/.task_cache.json
+    - '.modules/'
+    - '.plan_cache.json'
+    - '.resource_types/'
+    - 'bolt-debug.log'
+    - 'spec/docker/**/*.tar.gz'
+    - 'spec/docker/**/*.asc'
+    - 'spec/docker/**/files/puppet-enterprise*'
+    - 'spec/docker/.task_cache.json'
 .github/workflows/auto_release.yml:
-  unmanaged: false
+  unmanaged: false 
 .github/workflows/release.yml:
   unmanaged: false
 .github/workflows/spec.yml:
@@ -48,7 +45,7 @@ spec/spec_helper.rb:
   unmanaged: false
 .travis.yml:
   delete: true
-.gitlab-ci.yml:
+".gitlab-ci.yml":
   delete: true
 appveyor.yml:
   delete: true

--- a/Gemfile
+++ b/Gemfile
@@ -20,33 +20,35 @@ group :development do
   gem "json", '= 2.6.1',                         require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.3',                         require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "racc", '~> 1.4.0',                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "deep_merge", '~> 1.2.2',                  require: false
   gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
-  gem "facterdb", '~> 1.18',                     require: false
-  gem "metadata-json-lint", '~> 3.0',            require: false
-  gem "puppetlabs_spec_helper", '~> 6.0',        require: false
-  gem "rspec-puppet-facts", '~> 2.0',            require: false
-  gem "codecov", '~> 0.2',                       require: false
+  gem "facterdb", '~> 2.1',                      require: false
+  gem "metadata-json-lint", '~> 4.0',            require: false
+  gem "rspec-puppet-facts", '~> 4.0',            require: false
   gem "dependency_checker", '~> 1.0.0',          require: false
   gem "parallel_tests", '= 3.12.1',              require: false
   gem "pry", '~> 0.10',                          require: false
-  gem "simplecov-console", '~> 0.5',             require: false
+  gem "simplecov-console", '~> 0.9',             require: false
   gem "puppet-debugger", '~> 1.0',               require: false
-  gem "rubocop", '= 1.48.1',                     require: false
+  gem "rubocop", '~> 1.50.0',                    require: false
   gem "rubocop-performance", '= 1.16.0',         require: false
   gem "rubocop-rspec", '= 2.19.0',               require: false
   gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "bolt", '>= 3.27.2',                       require: false
+  gem "rexml", '>= 3.0.0', '< 3.2.7',            require: false
+  gem "bolt", '>= 3.10.0',                       require: false
   gem "github_changelog_generator", '1.16.4',    require: false
   gem "octokit", '4.21.0',                       require: false
   gem "orchestrator_client", '< 0.7.1',          require: false
 end
-group :system_tests do
-  gem "puppet_litmus", '~> 1.0', require: false, platforms: [:ruby, :x64_mingw]
-  gem "serverspec", '~> 2.41',   require: false
-end
-group :release_prep do
+group :development, :release_prep do
   gem "puppet-strings", '~> 4.0',         require: false
-  gem "puppetlabs_spec_helper", '~> 6.0', require: false
+  gem "puppetlabs_spec_helper", '~> 8.0', require: false
+  gem "puppet-blacksmith", '~> 7.0',      require: false
+end
+group :system_tests do
+  gem "puppet_litmus", '~> 1.0',   require: false, platforms: [:ruby, :x64_mingw]
+  gem "CFPropertyList", '< 3.0.7', require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "serverspec", '~> 2.41',     require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Rakefile
+++ b/Rakefile
@@ -4,89 +4,18 @@ require 'bundler'
 require 'puppet_litmus/rake_tasks' if Gem.loaded_specs.key? 'puppet_litmus'
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'
-require 'github_changelog_generator/task' if Gem.loaded_specs.key? 'github_changelog_generator'
 require 'puppet-strings/tasks' if Gem.loaded_specs.key? 'puppet-strings'
 
-def changelog_user
-  return unless Rake.application.top_level_tasks.include? "changelog"
-  returnVal = nil || JSON.load(File.read('metadata.json'))['author']
-  raise "unable to find the changelog_user in .sync.yml, or the author in metadata.json" if returnVal.nil?
-  puts "GitHubChangelogGenerator user:#{returnVal}"
-  returnVal
-end
-
-def changelog_project
-  return unless Rake.application.top_level_tasks.include? "changelog"
-
-  returnVal = nil
-  returnVal ||= begin
-    metadata_source = JSON.load(File.read('metadata.json'))['source']
-    metadata_source_match = metadata_source && metadata_source.match(%r{.*\/([^\/]*?)(?:\.git)?\Z})
-
-    metadata_source_match && metadata_source_match[1]
-  end
-
-  raise "unable to find the changelog_project in .sync.yml or calculate it from the source in metadata.json" if returnVal.nil?
-
-  puts "GitHubChangelogGenerator project:#{returnVal}"
-  returnVal
-end
-
-def changelog_future_release
-  return unless Rake.application.top_level_tasks.include? "changelog"
-  returnVal = "v%s" % JSON.load(File.read('metadata.json'))['version']
-  raise "unable to find the future_release (version) in metadata.json" if returnVal.nil?
-  puts "GitHubChangelogGenerator future_release:#{returnVal}"
-  returnVal
-end
-
 PuppetLint.configuration.send('disable_relative')
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.send('disable_140chars')
+PuppetLint.configuration.send('disable_class_inherits_from_params_class')
+PuppetLint.configuration.send('disable_autoloader_layout')
+PuppetLint.configuration.send('disable_documentation')
+PuppetLint.configuration.send('disable_single_quote_string_with_variables')
 PuppetLint.configuration.send('disable_strict_indent')
 PuppetLint.configuration.send('disable_manifest_whitespace_missing_newline_end_of_file')
-
-
-if Gem.loaded_specs.key? 'github_changelog_generator'
-  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?
-    config.user = "#{changelog_user}"
-    config.project = "#{changelog_project}"
-    config.since_tag = "2.5.0"
-    config.future_release = "#{changelog_future_release}"
-    config.exclude_labels = ['maintenance']
-    config.header = "# Change log\n\nAll notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org)."
-    config.add_pr_wo_labels = true
-    config.issues = false
-    config.merge_prefix = "### UNCATEGORIZED PRS; LABEL THEM ON GITHUB"
-    config.configure_sections = {
-      "Changed" => {
-        "prefix" => "### Changed",
-        "labels" => ["backwards-incompatible"],
-      },
-      "Added" => {
-        "prefix" => "### Added",
-        "labels" => ["enhancement", "feature"],
-      },
-      "Fixed" => {
-        "prefix" => "### Fixed",
-        "labels" => ["bug", "documentation", "bugfix"],
-      },
-    }
-  end
-else
-  desc 'Generate a Changelog from GitHub'
-  task :changelog do
-    raise <<EOM
-The changelog tasks depends on recent features of the github_changelog_generator gem.
-Please manually add it to your .sync.yml for now, and run `pdk update`:
----
-Gemfile:
-  optional:
-    ':development':
-      - gem: 'github_changelog_generator'
-        version: '~> 1.15'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"
-EOM
-  end
-end
+PuppetLint.configuration.fail_on_warnings = true
+PuppetLint.configuration.ignore_paths = [".vendor/**/*.pp", ".bundle/**/*.pp", "pkg/**/*.pp", "spec/**/*.pp", "tests/**/*.pp", "types/**/*.pp", "vendor/**/*.pp"]
 
 PuppetSyntax.exclude_paths = ["plans/**/*.pp", "spec/acceptance/**/plans/**/*.pp", "vendor/**/*"]

--- a/metadata.json
+++ b/metadata.json
@@ -86,7 +86,7 @@
       "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
-  "pdk-version": "3.0.0",
+  "pdk-version": "3.4.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",
-  "template-ref": "tags/3.0.0-0-g056e50d"
+  "template-ref": "tags/3.4.0-0-gd3cc13f"
 }

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -2,7 +2,8 @@
 #
 # Facts specified here will override the values provided by rspec-puppet-facts.
 ---
-ipaddress: "172.16.254.254"
-ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
+networking:
+  ip: "172.16.254.254"
+  ip6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
+  mac: "AA:AA:AA:AA:AA:AA"
 is_pe: false
-macaddress: "AA:AA:AA:AA:AA:AA"

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -1,9 +1,6 @@
-# Use default_module_facts.yml for module specific facts.
-#
-# Facts specified here will override the values provided by rspec-puppet-facts.
 ---
 networking:
-  ip: "172.16.254.254"
-  ip6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
-  mac: "AA:AA:AA:AA:AA:AA"
+  ip: 172.16.254.254
+  ip6: FE80:0000:0000:0000:AAAA:AAAA:AAAA
+  mac: AA:AA:AA:AA:AA:AA
 is_pe: false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,8 @@ default_fact_files.each do |f|
   next unless File.exist?(f) && File.readable?(f) && File.size?(f)
 
   begin
-    default_facts.merge!(YAML.safe_load(File.read(f), permitted_classes: [], permitted_symbols: [], aliases: true))
+    require 'deep_merge'
+    default_facts.deep_merge!(YAML.safe_load(File.read(f), permitted_classes: [], permitted_symbols: [], aliases: true))
   rescue StandardError => e
     RSpec.configuration.reporter.message "WARNING: Unable to load #{f}: #{e}"
   end
@@ -33,7 +34,7 @@ end
 
 # read default_facts and merge them over what is provided by facterdb
 default_facts.each do |fact, value|
-  add_custom_fact fact, value
+  add_custom_fact fact, value, merge_facts: true
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
## Summary
The yamlformatter action broke the sync.yml for the pdk.

## Additional Context
The yamlformatter action automatically changes all yaml files we commit to be a standard format, including no 'quotes' around key names. (see the attached diff for an example). While both of these files are valid YAML officially, ruby's yaml parser apparently treats keys starting with ':' as symbols, which aren't an allowed class by YAML.safe_load by default, leading to a Psych error from the PDK.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [ ] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [ ] Not needed
