### PR TITLE
(PE-39351) Update add_database plan to work with patching/HAC

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -35,6 +35,7 @@
 * [`peadm::migration_opts_default`](#peadm--migration_opts_default)
 * [`peadm::node_manager_yaml_location`](#peadm--node_manager_yaml_location)
 * [`peadm::oid`](#peadm--oid)
+* [`peadm::pe_db_names`](#peadm--pe_db_names)
 * [`peadm::plan_step`](#peadm--plan_step)
 * [`peadm::recovery_opts_all`](#peadm--recovery_opts_all)
 * [`peadm::recovery_opts_default`](#peadm--recovery_opts_default)
@@ -818,6 +819,24 @@ The peadm::oid function.
 Returns: `Any`
 
 ##### `short_name`
+
+Data type: `String`
+
+
+
+### <a name="peadm--pe_db_names"></a>`peadm::pe_db_names`
+
+Type: Puppet Language
+
+The peadm::pe_db_names function.
+
+#### `peadm::pe_db_names(String $pe_ver)`
+
+The peadm::pe_db_names function.
+
+Returns: `Array`
+
+##### `pe_ver`
 
 Data type: `String`
 

--- a/functions/pe_db_names.pp
+++ b/functions/pe_db_names.pp
@@ -8,9 +8,13 @@ function peadm::pe_db_names (
     'pe-orchestrator',
     'pe-rbac',
   ]
+
+  $pe_2025_or_later = SemVerRange('>= 2025.0.0')
+  $pe_2023_8_or_later = SemVerRange('>= 2023.8.0')
+
   case $pe_ver {
     # The patching service was added in 2025.0.0
-    SemVerRange('>= 2025.0.0'): {
+    $pe_2025_or_later: {
       $original_db_names + [
         'pe-hac',
         'pe-patching',
@@ -18,8 +22,8 @@ function peadm::pe_db_names (
     }
 
     # The host-action-collector (hac) was added in 2023.8
-    SemVerRange('>= 2023.8.0'): {
-      $original_db_names + [ 'pe-hac' ]
+    $pe_2023_8_or_later: {
+      $original_db_names + ['pe-hac']
     }
 
     default: {

--- a/functions/pe_db_names.pp
+++ b/functions/pe_db_names.pp
@@ -1,0 +1,29 @@
+function peadm::pe_db_names (
+  String $pe_ver,
+) >> Array {
+  $original_db_names = [
+    'pe-activity',
+    'pe-classifier',
+    'pe-inventory',
+    'pe-orchestrator',
+    'pe-rbac',
+  ]
+  case $pe_ver {
+    # The patching service was added in 2025.0.0
+    SemVerRange('>= 2025.0.0'): {
+      $original_db_names + [
+        'pe-hac',
+        'pe-patching',
+      ]
+    }
+
+    # The host-action-collector (hac) was added in 2023.8
+    SemVerRange('>= 2023.8.0'): {
+      $original_db_names + [ 'pe-hac' ]
+    }
+
+    default: {
+      $original_db_names
+    }
+  }
+}


### PR DESCRIPTION
This commit updates the add_database plan to include the pe-patching and pe-hac databases when it cleans up the original postgres on the primary.

The add_database plan uses pg_basebackup to copy the entire contents of the postgres DB from the original primary DB to the new DB node's postgres. That process doesn't individually update a list of databases, so there's no context of "which DBs to move", because it just moves everything. However, during the cleanup process on the original DB That exists on the primary, the plan _does_ need to list the individual internal postgres dbs that need to be deleted.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [x] Not needed
