### PR TITLE
(PE-39891) Add support for PE 2025

### DIFF
--- a/.github/workflows/test-add-compiler-matrix.yml
+++ b/.github/workflows/test-add-compiler-matrix.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [standard, large, extra-large]
-        version: [2021.7.9, 2023.8.0, 2025.1.0]
+        version: [2021.7.9, 2023.8.0, 2025.0.0]
         image: [almalinux-cloud/almalinux-8]
     steps:
       - name: Checkout Source

--- a/.github/workflows/test-add-compiler-matrix.yml
+++ b/.github/workflows/test-add-compiler-matrix.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [standard, large, extra-large]
-        version: [2021.7.9, 2023.8.0]
+        version: [2021.7.9, 2023.8.0, 2025.1.0]
         image: [almalinux-cloud/almalinux-8]
     steps:
       - name: Checkout Source

--- a/.github/workflows/test-add-compiler.yaml
+++ b/.github/workflows/test-add-compiler.yaml
@@ -14,7 +14,7 @@ on:
       version:
         description: PE version to install
         required: true
-        default: 2021.7.9
+        default: 2023.8.0
       ssh-debugging:
         description: Boolean; whether or not to pause for ssh debugging
         required: true

--- a/.github/workflows/test-add-compiler.yaml
+++ b/.github/workflows/test-add-compiler.yaml
@@ -84,7 +84,7 @@ jobs:
             --modulepath spec/fixtures/modules \
             architecture=${{ matrix.architecture }} \
             version=${{ matrix.version }} \
-            console_password=${{ secrets.CONSOLE_PASSWORD }
+            console_password=${{ secrets.CONSOLE_PASSWORD }}
       - name: Run add_compilers plan
         timeout-minutes: 50
         run: |

--- a/.github/workflows/test-add-replica-matrix.yaml
+++ b/.github/workflows/test-add-replica-matrix.yaml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [standard, standard-with-dr, large, extra-large]
-        version: [2023.8.0, 2025.1.0]
+        version: [2023.8.0, 2025.0.0]
         image: [almalinux-cloud/almalinux-8]
     steps:
       - name: Checkout Source

--- a/.github/workflows/test-add-replica-matrix.yaml
+++ b/.github/workflows/test-add-replica-matrix.yaml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [standard, standard-with-dr, large, extra-large]
-        version: [2023.8.0]
+        version: [2023.8.0, 2025.1.0]
         image: [almalinux-cloud/almalinux-8]
     steps:
       - name: Checkout Source

--- a/.github/workflows/test-add-replica.yaml
+++ b/.github/workflows/test-add-replica.yaml
@@ -14,7 +14,7 @@ on:
       version:
         description: PE version to install
         required: true
-        default: 2021.7.9
+        default: 2023.8.0
       ssh-debugging:
         description: Boolean; whether or not to pause for ssh debugging
         required: true

--- a/.github/workflows/test-backup-restore.yaml
+++ b/.github/workflows/test-backup-restore.yaml
@@ -24,14 +24,14 @@ on:
       version:
         description: PE version to install
         required: true
-        default: 2023.5.0
+        default: 2025.1.0
       ssh-debugging:
         description: Boolean; whether or not to pause for ssh debugging
         required: true
         default: 'false'
 jobs:
   backup-restore-test:
-    name: "Backup, break and restore cluster: PE ${{ github.event.inputs.version || '2023.5.0' }}\
+    name: "Backup, break and restore cluster: PE ${{ github.event.inputs.version || '2025.1.0' }}\
       \ ${{ github.event.inputs.architecture || 'extra-large' }} on ${{ github.event.inputs.image || 'almalinux-cloud/almalinux-8' }}"
     runs-on: ubuntu-20.04
     env:

--- a/.github/workflows/test-backup-restore.yaml
+++ b/.github/workflows/test-backup-restore.yaml
@@ -24,14 +24,14 @@ on:
       version:
         description: PE version to install
         required: true
-        default: 2025.1.0
+        default: 2025.0.0
       ssh-debugging:
         description: Boolean; whether or not to pause for ssh debugging
         required: true
         default: 'false'
 jobs:
   backup-restore-test:
-    name: "Backup, break and restore cluster: PE ${{ github.event.inputs.version || '2025.1.0' }}\
+    name: "Backup, break and restore cluster: PE ${{ github.event.inputs.version || '2025.0.0' }}\
       \ ${{ github.event.inputs.architecture || 'extra-large' }} on ${{ github.event.inputs.image || 'almalinux-cloud/almalinux-8' }}"
     runs-on: ubuntu-20.04
     env:

--- a/.github/workflows/test-failover.yaml
+++ b/.github/workflows/test-failover.yaml
@@ -14,7 +14,7 @@ on:
       version_to_upgrade:
         description: PE version to upgrade to
         required: false
-        default: 2021.7.9
+        default: 2023.8.0
       ssh-debugging:
         description: Boolean; whether or not to pause for ssh debugging
         required: true

--- a/.github/workflows/test-fips-install-matrix.yaml
+++ b/.github/workflows/test-fips-install-matrix.yaml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [standard-with-dr, large, extra-large-with-dr]
-        version: [2019.8.12, 2021.7.9, 2023.8.0]
+        version: [2019.8.12, 2021.7.9, 2023.8.0, 2025.1.0]
         image: [rhel-8]
         fips: [enable]
     steps:

--- a/.github/workflows/test-fips-install-matrix.yaml
+++ b/.github/workflows/test-fips-install-matrix.yaml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [standard-with-dr, large, extra-large-with-dr]
-        version: [2019.8.12, 2021.7.9, 2023.8.0, 2025.1.0]
+        version: [2019.8.12, 2021.7.9, 2023.8.0, 2025.0.0]
         image: [rhel-8]
         fips: [enable]
     steps:

--- a/.github/workflows/test-install-matrix.yaml
+++ b/.github/workflows/test-install-matrix.yaml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [standard-with-dr, large, extra-large-with-dr]
-        version: [2019.8.12, 2021.7.9, 2023.8.0]
+        version: [2019.8.12, 2021.7.9, 2023.8.0, 2025.1.0]
         image: [almalinux-cloud/almalinux-8]
     steps:
       - name: Checkout Source

--- a/.github/workflows/test-install-matrix.yaml
+++ b/.github/workflows/test-install-matrix.yaml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [standard-with-dr, large, extra-large-with-dr]
-        version: [2019.8.12, 2021.7.9, 2023.8.0, 2025.1.0]
+        version: [2019.8.12, 2021.7.9, 2023.8.0, 2025.0.0]
         image: [almalinux-cloud/almalinux-8]
     steps:
       - name: Checkout Source

--- a/.github/workflows/test-install-rhel-9.yaml
+++ b/.github/workflows/test-install-rhel-9.yaml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [standard-with-dr, large, extra-large-with-dr]
-        version: [2021.7.9, 2023.8.0]
+        version: [2021.7.9, 2023.8.0, 2025.1.0]
         image: [rhel-9]
     steps:
       - name: Checkout Source

--- a/.github/workflows/test-install-rhel-9.yaml
+++ b/.github/workflows/test-install-rhel-9.yaml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [standard-with-dr, large, extra-large-with-dr]
-        version: [2021.7.9, 2023.8.0, 2025.1.0]
+        version: [2021.7.9, 2023.8.0, 2025.0.0]
         image: [rhel-9]
     steps:
       - name: Checkout Source

--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -14,7 +14,7 @@ on:
       version:
         description: PE version to install
         required: true
-        default: 2021.7.9
+        default: 2023.8.0
       ssh-debugging:
         description: Boolean; whether or not to pause for ssh debugging
         required: true

--- a/.github/workflows/test-legacy-compilers.yaml
+++ b/.github/workflows/test-legacy-compilers.yaml
@@ -99,7 +99,7 @@ jobs:
             --modulepath spec/fixtures/modules \
             architecture=large-with-dr \
             console_password=${{ secrets.CONSOLE_PASSWORD }} \
-            version=2023.7.0
+            version=2025.1.0
       - name: Wait as long as the file ${HOME}/pause file is present
         if: ${{ always() && github.event.inputs.ssh-debugging == 'true' }}
         run: |

--- a/.github/workflows/test-legacy-compilers.yaml
+++ b/.github/workflows/test-legacy-compilers.yaml
@@ -99,7 +99,7 @@ jobs:
             --modulepath spec/fixtures/modules \
             architecture=large-with-dr \
             console_password=${{ secrets.CONSOLE_PASSWORD }} \
-            version=2025.1.0
+            version=2025.0.0
       - name: Wait as long as the file ${HOME}/pause file is present
         if: ${{ always() && github.event.inputs.ssh-debugging == 'true' }}
         run: |

--- a/.github/workflows/test-legacy-upgrade.yaml
+++ b/.github/workflows/test-legacy-upgrade.yaml
@@ -98,7 +98,7 @@ jobs:
           legacy_compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | sed -n 2p)
           replica=$(yq '.groups[].targets[] | select(.vars.role == "replica") | .name' spec/fixtures/litmus_inventory.yaml)
           hash_random=$(LC_ALL=C tr -dc 'A-Za-z0-9!#$%&'\''()*+,-./:;<=>?@[\]^_`{|}~' </dev/urandom | head -c 30; echo)
-          echo -n '{ "download_mode": "direct", "primary_host": "'$primary'", "replica_host": "'$replica'", "legacy_compilers": ["'$legacy_compiler'"], "compiler_hosts": ["'$compiler'"], "version": "2025.1.0", "console_password": "'$hash_random'" }' > params.json
+          echo -n '{ "download_mode": "direct", "primary_host": "'$primary'", "replica_host": "'$replica'", "legacy_compilers": ["'$legacy_compiler'"], "compiler_hosts": ["'$compiler'"], "version": "2025.0.0", "console_password": "'$hash_random'" }' > params.json
       - name: Install PE with legacy compilers
         timeout-minutes: 120
         run: |

--- a/.github/workflows/test-legacy-upgrade.yaml
+++ b/.github/workflows/test-legacy-upgrade.yaml
@@ -98,7 +98,7 @@ jobs:
           legacy_compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | sed -n 2p)
           replica=$(yq '.groups[].targets[] | select(.vars.role == "replica") | .name' spec/fixtures/litmus_inventory.yaml)
           hash_random=$(LC_ALL=C tr -dc 'A-Za-z0-9!#$%&'\''()*+,-./:;<=>?@[\]^_`{|}~' </dev/urandom | head -c 30; echo)
-          echo -n '{ "download_mode": "direct", "primary_host": "'$primary'", "replica_host": "'$replica'", "legacy_compilers": ["'$legacy_compiler'"], "compiler_hosts": ["'$compiler'"], "version": "2025.0.0", "console_password": "'$hash_random'" }' > params.json
+          echo -n '{ "download_mode": "direct", "primary_host": "'$primary'", "replica_host": "'$replica'", "legacy_compilers": ["'$legacy_compiler'"], "compiler_hosts": ["'$compiler'"], "version": "2023.8.0", "console_password": "'$hash_random'" }' > params.json
       - name: Install PE with legacy compilers
         timeout-minutes: 120
         run: |
@@ -152,7 +152,7 @@ jobs:
           compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | head -n 1)
           legacy_compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | sed -n 2p)
           replica=$(yq '.groups[].targets[] | select(.vars.role == "replica") | .name' spec/fixtures/litmus_inventory.yaml)
-          echo -n '{ "primary_host": "'$primary'", "replica_host": "'$replica'", "compiler_hosts": ["'$compiler'", "'$legacy_compiler'"], "version": "2023.8.0"}' > upgrade_params.json
+          echo -n '{ "primary_host": "'$primary'", "replica_host": "'$replica'", "compiler_hosts": ["'$compiler'", "'$legacy_compiler'"], "version": "2025.0.0"}' > upgrade_params.json
       - name: Upgrade PE with legacy compilers
         run: |
           echo ::group::upgrade_params.json

--- a/.github/workflows/test-legacy-upgrade.yaml
+++ b/.github/workflows/test-legacy-upgrade.yaml
@@ -98,7 +98,7 @@ jobs:
           legacy_compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | sed -n 2p)
           replica=$(yq '.groups[].targets[] | select(.vars.role == "replica") | .name' spec/fixtures/litmus_inventory.yaml)
           hash_random=$(LC_ALL=C tr -dc 'A-Za-z0-9!#$%&'\''()*+,-./:;<=>?@[\]^_`{|}~' </dev/urandom | head -c 30; echo)
-          echo -n '{ "download_mode": "direct", "primary_host": "'$primary'", "replica_host": "'$replica'", "legacy_compilers": ["'$legacy_compiler'"], "compiler_hosts": ["'$compiler'"], "version": "2023.7.0", "console_password": "'$hash_random'" }' > params.json
+          echo -n '{ "download_mode": "direct", "primary_host": "'$primary'", "replica_host": "'$replica'", "legacy_compilers": ["'$legacy_compiler'"], "compiler_hosts": ["'$compiler'"], "version": "2025.1.0", "console_password": "'$hash_random'" }' > params.json
       - name: Install PE with legacy compilers
         timeout-minutes: 120
         run: |

--- a/.github/workflows/test-upgrade-latest-dev.yaml
+++ b/.github/workflows/test-upgrade-latest-dev.yaml
@@ -23,7 +23,7 @@ on:
         type: string
         required: true
         description: The initial version of PE to install before upgrade
-        default: 2021.7.9
+        default: 2023.8.0
       ssh-debugging:
         description: Boolean; whether or not to pause for ssh debugging
         required: true

--- a/.github/workflows/test-upgrade-latest-xlarge-dev-nightly.yaml
+++ b/.github/workflows/test-upgrade-latest-xlarge-dev-nightly.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [extra-large-with-dr]
-        version: [2021.7.9]
+        version: [2023.8.0]
         image: [almalinux-cloud/almalinux-8]
     steps:
       - name: Checkout Source

--- a/.github/workflows/test-upgrade-matrix.yaml
+++ b/.github/workflows/test-upgrade-matrix.yaml
@@ -37,14 +37,24 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [standard, extra-large-with-dr]
-        version: [2019.8.12, 2021.7.9]
-        version_to_upgrade: [2021.7.9, 2023.8.0]
+        version: [2019.8.12, 2021.7.9, 2023.8.0]
+        version_to_upgrade: [2021.7.9, 2023.8.0, 2025.1.0]
         image: [almalinux-cloud/almalinux-8]
         download_mode: [direct]
         exclude:
           - version: 2019.8.12
             version_to_upgrade: 2023.8.0
+          - version: 2019.8.12
+            version_to_upgrade: 2025.1.0
           - version: 2021.7.9
+            version_to_upgrade: 2021.7.9
+          - version: 2021.7.9
+            version_to_upgrade: 2025.1.0
+          - version: 2023.8.0
+            version_to_upgrade: 2023.8.0
+          - version: 2023.8.0
+            version_to_upgrade: 2025.1.0
+          - version: 2023.8.0
             version_to_upgrade: 2021.7.9
     steps:
       - name: Start SSH session

--- a/.github/workflows/test-upgrade-matrix.yaml
+++ b/.github/workflows/test-upgrade-matrix.yaml
@@ -38,22 +38,22 @@ jobs:
       matrix:
         architecture: [standard, extra-large-with-dr]
         version: [2019.8.12, 2021.7.9, 2023.8.0]
-        version_to_upgrade: [2021.7.9, 2023.8.0, 2025.1.0]
+        version_to_upgrade: [2021.7.9, 2023.8.0, 2025.0.0]
         image: [almalinux-cloud/almalinux-8]
         download_mode: [direct]
         exclude:
           - version: 2019.8.12
             version_to_upgrade: 2023.8.0
           - version: 2019.8.12
-            version_to_upgrade: 2025.1.0
+            version_to_upgrade: 2025.0.0
           - version: 2021.7.9
             version_to_upgrade: 2021.7.9
           - version: 2021.7.9
-            version_to_upgrade: 2025.1.0
+            version_to_upgrade: 2025.0.0
           - version: 2023.8.0
             version_to_upgrade: 2023.8.0
           - version: 2023.8.0
-            version_to_upgrade: 2025.1.0
+            version_to_upgrade: 2025.0.0
           - version: 2023.8.0
             version_to_upgrade: 2021.7.9
     steps:

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2185,7 +2185,7 @@ Data type: `Peadm::Pe_version`
 
 
 
-Default value: `'2021.7.9'`
+Default value: `'2023.8.0'`
 
 ##### <a name="-peadm--install--dns_alt_names"></a>`dns_alt_names`
 

--- a/documentation/install.md
+++ b/documentation/install.md
@@ -120,7 +120,7 @@ Example params.json Bolt parameters file (shown: Standard):
   "primary_host": "pe-xl-core-0.lab1.puppet.vm",
   "console_password": "puppetlabs",
   "dns_alt_names": ["puppet", "puppet.lab1.puppet.vm"],
-  "version": "2021.7.9"
+  "version": "2023.8.0"
 }
 ```
 

--- a/functions/assert_supported_pe_version.pp
+++ b/functions/assert_supported_pe_version.pp
@@ -6,7 +6,7 @@ function peadm::assert_supported_pe_version (
   Boolean $permit_unsafe_versions = false,
 ) >> Struct[{ 'supported' => Boolean }] {
   $oldest = '2019.7'
-  $newest = '2025.1'
+  $newest = '2025.0'
   $supported = ($version =~ SemVerRange(">= ${oldest} <= ${newest}"))
 
   if $permit_unsafe_versions {

--- a/functions/assert_supported_pe_version.pp
+++ b/functions/assert_supported_pe_version.pp
@@ -6,7 +6,7 @@ function peadm::assert_supported_pe_version (
   Boolean $permit_unsafe_versions = false,
 ) >> Struct[{ 'supported' => Boolean }] {
   $oldest = '2019.7'
-  $newest = '2023.8'
+  $newest = '2025.1'
   $supported = ($version =~ SemVerRange(">= ${oldest} <= ${newest}"))
 
   if $permit_unsafe_versions {

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -46,7 +46,7 @@ plan peadm::install (
 
   # Common Configuration
   String                            $console_password,
-  Peadm::Pe_version                 $version                          = '2021.7.9',
+  Peadm::Pe_version                 $version                          = '2023.8.0',
   Optional[Stdlib::HTTPSUrl]        $pe_installer_source              = undef,
   Optional[Array[String]]           $dns_alt_names                    = undef,
   Optional[String]                  $compiler_pool_address            = undef,

--- a/spec/functions/assert_supported_pe_version_spec.rb
+++ b/spec/functions/assert_supported_pe_version_spec.rb
@@ -19,7 +19,7 @@ describe 'peadm::assert_supported_pe_version' do
     end
 
     it 'accepts the newest supported version' do
-      is_expected.to run.with_params('2025.1.0').and_return({ 'supported' => true })
+      is_expected.to run.with_params('2025.0.0').and_return({ 'supported' => true })
     end
 
     it 'accepts a version in the middle' do

--- a/spec/functions/assert_supported_pe_version_spec.rb
+++ b/spec/functions/assert_supported_pe_version_spec.rb
@@ -19,7 +19,7 @@ describe 'peadm::assert_supported_pe_version' do
     end
 
     it 'accepts the newest supported version' do
-      is_expected.to run.with_params('2021.7.9').and_return({ 'supported' => true })
+      is_expected.to run.with_params('2025.1.0').and_return({ 'supported' => true })
     end
 
     it 'accepts a version in the middle' do

--- a/spec/plans/subplans/install_spec.rb
+++ b/spec/plans/subplans/install_spec.rb
@@ -87,11 +87,11 @@ describe 'peadm::subplans::install' do
     expect(run_plan('peadm::subplans::install', params)).to be_ok
   end
 
-  it 'installs 2021.7.9 with legacy compilers' do
+  it 'installs 2023.8.0 with legacy compilers' do
     params = {
       'primary_host' => 'primary',
       'console_password' => 'puppetLabs123!',
-      'version' => '2021.7.9',
+      'version' => '2023.8.0',
       'legacy_compilers' => ['compiler1', 'compiler2'],
     }
     expect(run_plan('peadm::subplans::install', params)).to be_ok


### PR DESCRIPTION
## Summary
Added PE 2025.0 as a supported PE version and to the test matrices. Also changed the default version to PE 2023

## Additional Context
Do not merge until PE 2025 is officially released

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [x] Yes
- [ ] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [ ] Not needed
