### PR TITLE
(PE-40372/3) Add optional upgrade and replica support to migration plan

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2322,6 +2322,8 @@ The following parameters are available in the `peadm::migrate` plan:
 
 * [`old_primary_host`](#-peadm--migrate--old_primary_host)
 * [`new_primary_host`](#-peadm--migrate--new_primary_host)
+* [`upgrade_version`](#-peadm--migrate--upgrade_version)
+* [`replica_host`](#-peadm--migrate--replica_host)
 
 ##### <a name="-peadm--migrate--old_primary_host"></a>`old_primary_host`
 
@@ -2334,6 +2336,22 @@ The existing PE primary server that will be migrated from
 Data type: `Peadm::SingleTargetSpec`
 
 The new server that will become the PE primary server
+
+##### <a name="-peadm--migrate--upgrade_version"></a>`upgrade_version`
+
+Data type: `Optional[String]`
+
+Optional version to upgrade to after migration is complete
+
+Default value: `undef`
+
+##### <a name="-peadm--migrate--replica_host"></a>`replica_host`
+
+Data type: `Optional[Peadm::SingleTargetSpec]`
+
+
+
+Default value: `undef`
 
 ### <a name="peadm--modify_certificate"></a>`peadm::modify_certificate`
 

--- a/plans/migrate.pp
+++ b/plans/migrate.pp
@@ -11,6 +11,7 @@ plan peadm::migrate (
   Peadm::SingleTargetSpec $old_primary_host,
   Peadm::SingleTargetSpec $new_primary_host,
   Optional[String] $upgrade_version = undef,
+  Optional[Peadm::SingleTargetSpec] $replica_host = undef,
 ) {
   peadm::assert_supported_bolt_version()
 
@@ -18,17 +19,19 @@ plan peadm::migrate (
       backup_type => 'migration',
   })
 
-  download_file($backup_file['path'], 'backup', $old_primary_host)
+  $download_results = download_file($backup_file['path'], 'backup', $old_primary_host)
+  $download_path = $download_results[0]['path']
 
   $backup_filename = basename($backup_file['path'])
   $remote_backup_path = "/tmp/${backup_filename}"
-  $current_dir = system::env('PWD')
 
-  upload_file("${current_dir}/downloads/backup/${old_primary_host}/${backup_filename}", $remote_backup_path, $new_primary_host)
+  upload_file($download_path, $remote_backup_path, $new_primary_host)
 
   $old_primary_target = get_targets($old_primary_host)[0]
   $old_primary_password = peadm::get_pe_conf($old_primary_target)['console_admin_password']
   $old_pe_conf = run_task('peadm::get_peadm_config', $old_primary_target).first.value
+
+  out::message("old_pe_conf:${old_pe_conf}.")
 
   run_plan('peadm::install', {
       primary_host                => $new_primary_host,
@@ -44,11 +47,54 @@ plan peadm::migrate (
       input_file => $remote_backup_path,
   })
 
-  if $upgrade_version {
+  $node_types = {
+    'primary_host'             => $old_pe_conf['params']['primary_host'],
+    'replica_host'             => $old_pe_conf['params']['replica_host'],
+    'primary_postgresql_host'  => $old_pe_conf['params']['primary_postgresql_host'],
+    'replica_postgresql_host'  => $old_pe_conf['params']['replica_postgresql_host'],
+    'compilers'                => $old_pe_conf['params']['compilers'],
+    'legacy_compilers'         => $old_pe_conf['params']['legacy_compilers'],
+  }
+
+  $nodes_to_purge = $node_types.reduce([]) |$memo, $entry| {
+    $value = $entry[1]
+
+    if empty($value) {
+      $memo
+    }
+    elsif $value =~ Array {
+      $memo + $value.filter |$node| { !empty($node) }
+    }
+    else {
+      $memo + [$value]
+    }
+  }
+
+  out::message("Nodes to purge: ${nodes_to_purge}")
+
+  if !empty($nodes_to_purge) {
+    out::message('Purging nodes from old configuration individually')
+    $nodes_to_purge.each |$node| {
+      out::message("Purging node: ${node}")
+      run_command("/opt/puppetlabs/bin/puppet node purge ${node}", $new_primary_host)
+    }
+  } else {
+    out::message('No nodes to purge from old configuration')
+  }
+
+  if $replica_host {
+    run_plan('peadm::add_replica', {
+        primary_host => $new_primary_host,
+        replica_host => $replica_host,
+    })
+  }
+
+  if $upgrade_version and $upgrade_version != '' and !empty($upgrade_version) {
     run_plan('peadm::upgrade', {
         primary_host                => $new_primary_host,
         version                     => $upgrade_version,
-        download_mode              => 'direct',
+        download_mode               => 'direct',
+        replica_host                => $replica_host,
     })
   }
 }

--- a/plans/migrate.pp
+++ b/plans/migrate.pp
@@ -4,10 +4,13 @@
 #   The existing PE primary server that will be migrated from
 # @param new_primary_host
 #   The new server that will become the PE primary server
+# @param upgrade_version
+#   Optional version to upgrade to after migration is complete
 #
 plan peadm::migrate (
   Peadm::SingleTargetSpec $old_primary_host,
   Peadm::SingleTargetSpec $new_primary_host,
+  Optional[String] $upgrade_version = undef,
 ) {
   peadm::assert_supported_bolt_version()
 
@@ -40,4 +43,12 @@ plan peadm::migrate (
       restore_type => 'migration',
       input_file => $remote_backup_path,
   })
+
+  if $upgrade_version {
+    run_plan('peadm::upgrade', {
+        primary_host                => $new_primary_host,
+        version                     => $upgrade_version,
+        download_mode              => 'direct',
+    })
+  }
 }


### PR DESCRIPTION
This commit extends the existing migration plan by adding an optional upgrade
step after the migration is complete. If an upgrade version is specified, the 
plan will automatically perform an upgrade to the new version using the 
peadm::upgrade plan.

This commit extends the migration plan to support and utilise an
optional new replica host parameter. Code has also been added to purge
old nodes from the newly restored infrastructure.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [x] Not needed
