### PR TITLE
(PE-40535) Github Actions deprecated Ubuntu 20.04 support

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -7,7 +7,7 @@ env:
 jobs:
   auto_release:
     name: Automatic release prep
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Source
         if: ${{ github.repository_owner == 'puppetlabs' }}

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   setup_matrix:
     name: Setup Test Matrix
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       spec_matrix: ${{ steps.get-matrix.outputs.spec_matrix }}
     steps:
@@ -63,7 +63,7 @@ jobs:
     name: 'Spec Tests (Puppet: ${{matrix.puppet_version}}, Ruby Ver: ${{matrix.ruby_version}})'
     needs: [setup_matrix]
     if: ${{ needs.setup_matrix.outputs.spec_matrix != '{}' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.setup_matrix.outputs.spec_matrix)}}

--- a/.github/workflows/test-add-compiler-matrix.yml
+++ b/.github/workflows/test-add-compiler-matrix.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   test-add-compiler:
     name: PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true

--- a/.github/workflows/test-add-compiler.yaml
+++ b/.github/workflows/test-add-compiler.yaml
@@ -22,7 +22,7 @@ on:
 jobs:
   test-add-compiler:
     name: PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true

--- a/.github/workflows/test-add-replica-matrix.yaml
+++ b/.github/workflows/test-add-replica-matrix.yaml
@@ -27,7 +27,7 @@ on:
 jobs:
   test-add-replica:
     name: PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true

--- a/.github/workflows/test-add-replica.yaml
+++ b/.github/workflows/test-add-replica.yaml
@@ -22,7 +22,7 @@ on:
 jobs:
   test-add-replica:
     name: PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true

--- a/.github/workflows/test-backup-restore-migration.yaml
+++ b/.github/workflows/test-backup-restore-migration.yaml
@@ -23,7 +23,7 @@ jobs:
   backup:
     name: 'Backup: Cluster A: PE ${{ inputs.version }} ${{ inputs.architecture }}
       on ${{ inputs.image }}'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true
@@ -138,7 +138,7 @@ jobs:
   restore:
     name: 'Restore: Cluster B: PE ${{ inputs.version }} ${{ inputs.architecture }}
       on ${{ inputs.image }}'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true

--- a/.github/workflows/test-backup-restore.yaml
+++ b/.github/workflows/test-backup-restore.yaml
@@ -33,7 +33,7 @@ jobs:
   backup-restore-test:
     name: "Backup, break and restore cluster: PE ${{ github.event.inputs.version || '2025.0.0' }}\
       \ ${{ github.event.inputs.architecture || 'extra-large' }} on ${{ github.event.inputs.image || 'almalinux-cloud/almalinux-8' }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true

--- a/.github/workflows/test-failover.yaml
+++ b/.github/workflows/test-failover.yaml
@@ -26,7 +26,7 @@ on:
 jobs:
   test-failover:
     name: PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true

--- a/.github/workflows/test-fips-install-matrix.yaml
+++ b/.github/workflows/test-fips-install-matrix.yaml
@@ -28,7 +28,7 @@ jobs:
   test-install:
     name: PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }}
       with fips ${{ matrix.fips }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true

--- a/.github/workflows/test-install-latest-dev.yaml
+++ b/.github/workflows/test-install-latest-dev.yaml
@@ -26,7 +26,7 @@ on:
 jobs:
   test-install:
     name: PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true

--- a/.github/workflows/test-install-latest-xlarge-dev-nightly.yaml
+++ b/.github/workflows/test-install-latest-xlarge-dev-nightly.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   test-install:
     name: PE nightly using ${{ matrix.architecture }} on ${{ matrix.image }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true

--- a/.github/workflows/test-install-matrix.yaml
+++ b/.github/workflows/test-install-matrix.yaml
@@ -27,7 +27,7 @@ on:
 jobs:
   test-install:
     name: PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true

--- a/.github/workflows/test-install-rhel-9.yaml
+++ b/.github/workflows/test-install-rhel-9.yaml
@@ -27,7 +27,7 @@ on:
 jobs:
   test-install:
     name: PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true

--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -22,7 +22,7 @@ on:
 jobs:
   test-install:
     name: PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true

--- a/.github/workflows/test-legacy-compilers.yaml
+++ b/.github/workflows/test-legacy-compilers.yaml
@@ -32,7 +32,7 @@ on:
 jobs:
   convert_compiler:
     name: Convert compilers to legacy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true

--- a/.github/workflows/test-legacy-upgrade.yaml
+++ b/.github/workflows/test-legacy-upgrade.yaml
@@ -32,7 +32,7 @@ on:
 jobs:
   upgrade_with_legacy_compilers:
     name: Upgrade PE with legacy compilers
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true

--- a/.github/workflows/test-replace-failed-postgresql.yaml
+++ b/.github/workflows/test-replace-failed-postgresql.yaml
@@ -27,7 +27,7 @@ on:
 jobs:
   test-replace-failed-postgresql:
     name: PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true

--- a/.github/workflows/test-upgrade-latest-dev.yaml
+++ b/.github/workflows/test-upgrade-latest-dev.yaml
@@ -32,7 +32,7 @@ jobs:
   test-upgrade:
     name: PE ${{ matrix.version }} to latest dev using ${{ matrix.architecture }}
       on ${{ matrix.image }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true

--- a/.github/workflows/test-upgrade-latest-xlarge-dev-nightly.yaml
+++ b/.github/workflows/test-upgrade-latest-xlarge-dev-nightly.yaml
@@ -7,7 +7,7 @@ jobs:
   test-upgrade:
     name: PE ${{ matrix.version }} to nightly dev using ${{ matrix.architecture }}
       on ${{ matrix.image }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true

--- a/.github/workflows/test-upgrade-matrix.yaml
+++ b/.github/workflows/test-upgrade-matrix.yaml
@@ -28,7 +28,7 @@ jobs:
   test-upgrade:
     name: PE ${{ matrix.version }} to ${{ matrix.version_to_upgrade }} ${{ matrix.architecture }}
       on ${{ matrix.image }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true

--- a/.github/workflows/test-upgrade.yaml
+++ b/.github/workflows/test-upgrade.yaml
@@ -34,7 +34,7 @@ on:
 jobs:
   test-upgrade:
     name: PE ${{ matrix.version }} ${{ matrix.architecture }} on ${{ matrix.image }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       BOLT_GEM: true
       BOLT_DISABLE_ANALYTICS: true


### PR DESCRIPTION
## Summary
Updated our Github Action workflows to use ubuntu-latest rather than ubuntu-20.04. 

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.

#### Changes include test coverage?
- [x] Yes
- [] Not needed

#### Have you updated the documentation?
- [] Yes, I've updated the appropriate docs
- [x] Not needed
