### PR TITLE
MAINT try docker for provisioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,5 @@ jobs:
     needs: Spec
     uses: puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main
     with:
-      flags: --provision-service
+      flags: --docker
     secrets: inherit

--- a/.github/workflows/test-add-compiler-matrix.yml
+++ b/.github/workflows/test-add-compiler-matrix.yml
@@ -37,7 +37,8 @@ jobs:
       matrix:
         architecture: [standard, large, extra-large]
         version: [2021.7.9, 2023.8.2, 2025.1.0]
-        image: [almalinux-cloud/almalinux-8]
+        image: ['litmusimage/ubuntu:24.04']
+        download_mode: [bolthost]
     steps:
       - name: Checkout Source
         uses: actions/checkout@v4
@@ -65,9 +66,12 @@ jobs:
           echo ::group::provision
             bundle exec bolt plan run peadm_spec::provision_test_cluster \
               --modulepath spec/fixtures/modules \
-              provider=provision_service \
+              provider=docker \
               image=${{ matrix.image }} \
               architecture=${{ matrix.architecture }}-with-extra-compiler
+          echo ::endgroup::
+          echo ::group::mv inventory.yaml to ./spec/fixtures/litmus_inventory.yaml
+            mv inventory.yaml spec/fixtures/litmus_inventory.yaml
           echo ::endgroup::
           echo ::group::info:request
             cat request.json || true; echo
@@ -82,6 +86,7 @@ jobs:
             --inventoryfile spec/fixtures/litmus_inventory.yaml \
             --modulepath spec/fixtures/modules \
             architecture=${{ matrix.architecture }} \
+            download_mode=${{ matrix.download_mode }} \
             console_password=${{ secrets.CONSOLE_PASSWORD }} \
             version=${{ matrix.version }}
       - name: Run add_compilers plan

--- a/.github/workflows/test-add-compiler.yaml
+++ b/.github/workflows/test-add-compiler.yaml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       image:
-        description: GCP image for test cluster
+        description: Docker image for test cluster
         required: true
-        default: almalinux-cloud/almalinux-8
+        default: litmusimage/ubuntu:24.04
       architecture:
         description: PE architecture to test
         required: true
@@ -66,7 +66,7 @@ jobs:
           echo ::group::provision
             bundle exec bolt plan run peadm_spec::provision_test_cluster \
               --modulepath spec/fixtures/modules \
-              provider=provision_service \
+              provider=docker \
               image=${{ matrix.image }} \
               architecture=${{ matrix.architecture }}-with-extra-compiler
           echo ::endgroup::

--- a/.github/workflows/test-add-replica-matrix.yaml
+++ b/.github/workflows/test-add-replica-matrix.yaml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         architecture: [standard, standard-with-dr, large, extra-large]
         version: [2023.8.2, 2025.1.0]
-        image: [almalinux-cloud/almalinux-8]
+        image: [litmusimage/ubuntu:24.04]
     steps:
       - name: Checkout Source
         uses: actions/checkout@v4
@@ -65,7 +65,7 @@ jobs:
           echo ::group::provision
             bundle exec bolt plan run peadm_spec::provision_test_cluster \
               --modulepath spec/fixtures/modules \
-              provider=provision_service \
+              provider=docker \
               image=${{ matrix.image }} \
               architecture=${{ matrix.architecture }}-and-spare-replica
           echo ::endgroup::

--- a/.github/workflows/test-add-replica.yaml
+++ b/.github/workflows/test-add-replica.yaml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       image:
-        description: GCP image for test cluster
+        description: Docker image for test cluster
         required: true
-        default: almalinux-cloud/almalinux-8
+        default: litmusimage/ubuntu:24.04
       architecture:
         description: PE architecture to test
         required: true
@@ -66,7 +66,7 @@ jobs:
           echo ::group::provision
             bundle exec bolt plan run peadm_spec::provision_test_cluster \
               --modulepath spec/fixtures/modules \
-              provider=provision_service \
+              provider=docker \
               image=${{ matrix.image }} \
               architecture=${{ matrix.architecture }}-and-spare-replica
           echo ::endgroup::

--- a/.github/workflows/test-backup-restore-migration.yaml
+++ b/.github/workflows/test-backup-restore-migration.yaml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       image:
-        description: GCP image for test cluster
+        description: Docker image for test cluster
         required: true
-        default: almalinux-cloud/almalinux-8
+        default: litmusimage/ubuntu:24.04
       architecture:
         description: PE architecture to test
         required: true
@@ -61,7 +61,7 @@ jobs:
           echo ::group::provision
               bundle exec bolt plan run peadm_spec::provision_test_cluster \
                 --modulepath spec/fixtures/modules \
-                provider=provision_service \
+                provider=docker \
                 image=${{ inputs.image }} \
                 architecture=${{ inputs.architecture }}
           echo ::endgroup::
@@ -170,7 +170,7 @@ jobs:
           echo ::group::provision
               bundle exec bolt plan run peadm_spec::provision_test_cluster \
                 --modulepath spec/fixtures/modules \
-                provider=provision_service \
+                provider=docker \
                 image=${{ inputs.image }} \
                 architecture=${{ inputs.architecture }}
           echo ::endgroup::

--- a/.github/workflows/test-backup-restore.yaml
+++ b/.github/workflows/test-backup-restore.yaml
@@ -2,13 +2,33 @@
 name: Backup and restore test
 on:
   pull_request:
-    types: [ready_for_review]
+    paths:
+      - .github/workflows/**/*
+      - spec/**/*
+      - lib/**/*
+      - tasks/**/*
+      - functions/**/*
+      - types/**/*
+      - plans/**/*
+      - hiera/**/*
+      - manifests/**/*
+      - templates/**/*
+      - files/**/*
+      - metadata.json
+      - Rakefile
+      - Gemfile
+      - provision.yaml
+      - .rspec
+      - .rubocop.yml
+      - .puppet-lint.rc
+      - .fixtures.yml
+    branches: [main]
   workflow_dispatch:
     inputs:
       image:
-        description: GCP image for test cluster
+        description: Docker image for test cluster
         required: true
-        default: almalinux-cloud/almalinux-8
+        default: litmusimage/ubuntu:24.04
       architecture:
         description: PE architecture to test
         required: true
@@ -32,7 +52,7 @@ on:
 jobs:
   backup-restore-test:
     name: "Backup, break and restore cluster: PE ${{ github.event.inputs.version || '2025.1.0' }}\
-      \ ${{ github.event.inputs.architecture || 'extra-large' }} on ${{ github.event.inputs.image || 'almalinux-cloud/almalinux-8' }}"
+      \ ${{ github.event.inputs.architecture || 'extra-large' }} on ${{ github.event.inputs.image || 'litmusimage/ubuntu:24.04' }}"
     runs-on: ubuntu-latest
     env:
       BOLT_GEM: true
@@ -71,8 +91,8 @@ jobs:
           echo ::group::provision
               bundle exec bolt plan run peadm_spec::provision_test_cluster \
                 --modulepath spec/fixtures/modules \
-                provider=provision_service \
-                image=${{ github.event.inputs.image || 'almalinux-cloud/almalinux-8' }} \
+                provider=docker \
+                image=${{ github.event.inputs.image || 'litmusimage/ubuntu:24.04' }} \
                 architecture=${{ github.event.inputs.architecture || 'extra-large' }}
           echo ::endgroup::
           echo ::group::info:request

--- a/.github/workflows/test-failover.yaml
+++ b/.github/workflows/test-failover.yaml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       image:
-        description: GCP image for test cluster
+        description: Docker image for test cluster
         required: true
-        default: almalinux-cloud/almalinux-8
+        default: litmusimage/ubuntu:24.04
       version:
         description: PE version to install
         required: true
@@ -70,7 +70,7 @@ jobs:
           echo ::group::provision
             bundle exec bolt plan run peadm_spec::provision_test_cluster \
               --modulepath spec/fixtures/modules \
-              provider=provision_service \
+              provider=docker \
               image=${{ matrix.image }} \
               architecture=${{ matrix.architecture }}-and-spare-replica
           echo ::endgroup::

--- a/.github/workflows/test-install-latest-dev.yaml
+++ b/.github/workflows/test-install-latest-dev.yaml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       image:
-        description: GCP image for test cluster
+        description: Docker image for test cluster
         required: true
-        default: almalinux-cloud/almalinux-8
+        default: litmusimage/ubuntu:24.04
       architecture:
         type: choice
         required: true
@@ -69,7 +69,7 @@ jobs:
           echo ::group::provision
             bundle exec bolt plan run peadm_spec::provision_test_cluster \
               --modulepath spec/fixtures/modules \
-              provider=provision_service \
+              provider=docker \
               image=${{ matrix.image }} \
               architecture=${{ matrix.architecture }}
           echo ::endgroup::

--- a/.github/workflows/test-install-latest-xlarge-dev-nightly.yaml
+++ b/.github/workflows/test-install-latest-xlarge-dev-nightly.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [extra-large-with-dr]
-        image: [almalinux-cloud/almalinux-8]
+        image: [litmusimage/ubuntu:24.04]
     steps:
       - name: Start SSH session
         if: ${{ github.event.inputs.ssh-debugging == 'true' }}
@@ -55,7 +55,7 @@ jobs:
           echo ::group::provision
             bundle exec bolt plan run peadm_spec::provision_test_cluster \
               --modulepath spec/fixtures/modules \
-              provider=provision_service \
+              provider=docker \
               image=${{ matrix.image }} \
               architecture=${{ matrix.architecture }}
           echo ::endgroup::

--- a/.github/workflows/test-install-matrix.yaml
+++ b/.github/workflows/test-install-matrix.yaml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         architecture: [standard-with-dr, large, extra-large-with-dr]
         version: [2019.8.12, 2021.7.9, 2023.8.2, 2025.1.0]
-        image: [almalinux-cloud/almalinux-8]
+        image: [litmusimage/ubuntu:24.04]
     steps:
       - name: Checkout Source
         uses: actions/checkout@v4
@@ -65,7 +65,7 @@ jobs:
           echo ::group::provision
             bundle exec bolt plan run peadm_spec::provision_test_cluster \
               --modulepath spec/fixtures/modules \
-              provider=provision_service \
+              provider=docker \
               image=${{ matrix.image }} \
               architecture=${{ matrix.architecture }} \
               --log-level trace

--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       image:
-        description: GCP image for test cluster
+        description: Docker image for test cluster
         required: true
-        default: almalinux-cloud/almalinux-8
+        default: litmusimage/ubuntu:24.04
       architecture:
         description: PE architecture to test
         required: true
@@ -66,7 +66,7 @@ jobs:
           echo ::group::provision
             bundle exec bolt plan run peadm_spec::provision_test_cluster \
               --modulepath spec/fixtures/modules \
-              provider=provision_service \
+              provider=docker \
               image=${{ matrix.image }} \
               architecture=${{ matrix.architecture }}
           echo ::endgroup::

--- a/.github/workflows/test-migration.yaml
+++ b/.github/workflows/test-migration.yaml
@@ -44,11 +44,11 @@ jobs:
             # - large-with-dr
             # - extra-large-with-dr
         version: [2021.7.9, 2023.8.2, 2025.1.0]
-        image: [almalinux-cloud/almalinux-8]
+        image: [litmusimage/ubuntu:24.04]
         include:
           - architecture: standard
             version: 2023.8.0
-            image: almalinux-cloud/almalinux-8
+            image: litmusimage/ubuntu:22.04
             new_pe_version: 2025.0.0
     steps:
       - name: Checkout Source
@@ -79,7 +79,7 @@ jobs:
           echo ::group::provision
             bundle exec bolt plan run peadm_spec::provision_test_cluster \
               --modulepath spec/fixtures/modules \
-              provider=provision_service \
+              provider=docker \
               image=${{ matrix.image }} \
               architecture=${{ matrix.architecture }}-migration \
               --log-level trace

--- a/.github/workflows/test-replace-failed-postgresql.yaml
+++ b/.github/workflows/test-replace-failed-postgresql.yaml
@@ -38,7 +38,7 @@ jobs:
         architecture: [extra-large-with-dr-and-spare-replica]
         install_architecture: [extra-large-with-dr]
         version: [2021.7.9, 2023.8.2, 2025.1.0]
-        image: [almalinux-cloud/almalinux-8]
+        image: [litmusimage/ubuntu:24.04]
     steps:
       - name: Checkout Source
         uses: actions/checkout@v4
@@ -68,7 +68,7 @@ jobs:
           echo ::group::provision
             bundle exec bolt plan run peadm_spec::provision_test_cluster \
               --modulepath spec/fixtures/modules \
-              provider=provision_service \
+              provider=docker \
               image=${{ matrix.image }} \
               architecture=${{ matrix.architecture }} \
               --log-level trace

--- a/.github/workflows/test-upgrade-latest-dev.yaml
+++ b/.github/workflows/test-upgrade-latest-dev.yaml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       image:
-        description: GCP image for test cluster
+        description: Docker image for test cluster
         required: true
-        default: almalinux-cloud/almalinux-8
+        default: litmusimage/ubuntu:24.04
       architecture:
         type: choice
         required: true
@@ -76,7 +76,7 @@ jobs:
           echo ::group::provision
               bundle exec bolt plan run peadm_spec::provision_test_cluster \
                 --modulepath spec/fixtures/modules \
-                provider=provision_service \
+                provider=docker \
                 image=${{ matrix.image }} \
                 architecture=${{ matrix.architecture }}
           echo ::endgroup::

--- a/.github/workflows/test-upgrade-latest-xlarge-dev-nightly.yaml
+++ b/.github/workflows/test-upgrade-latest-xlarge-dev-nightly.yaml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         architecture: [extra-large-with-dr]
         version: [2023.8.2]
-        image: [almalinux-cloud/almalinux-8]
+        image: [litmusimage/ubuntu:24.04]
     steps:
       - name: Checkout Source
         uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
           echo ::group::provision
             bundle exec bolt plan run peadm_spec::provision_test_cluster \
               --modulepath spec/fixtures/modules \
-              provider=provision_service \
+              provider=docker \
               image=${{ matrix.image }} \
               architecture=${{ matrix.architecture }}
           echo ::endgroup::

--- a/.github/workflows/test-upgrade-matrix.yaml
+++ b/.github/workflows/test-upgrade-matrix.yaml
@@ -39,7 +39,7 @@ jobs:
         architecture: [standard, extra-large-with-dr]
         version: [2019.8.12, 2021.7.9, 2023.8.2]
         version_to_upgrade: [2021.7.9, 2023.8.2, 2025.1.0]
-        image: [almalinux-cloud/almalinux-8]
+        image: [litmusimage/ubuntu:24.04]
         download_mode: [direct]
         exclude:
           - version: 2019.8.12
@@ -91,7 +91,7 @@ jobs:
           echo ::group::provision
             bundle exec bolt plan run peadm_spec::provision_test_cluster \
               --modulepath spec/fixtures/modules \
-              provider=provision_service \
+              provider=docker \
               image=${{ matrix.image }} \
               architecture=${{ matrix.architecture }}
           echo ::endgroup::

--- a/.github/workflows/test-upgrade.yaml
+++ b/.github/workflows/test-upgrade.yaml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       image:
-        description: GCP image for test cluster
+        description: Docker image for test cluster
         required: true
-        default: almalinux-cloud/almalinux-8
+        default: litmusimage/ubuntu:24.04
       architecture:
         type: choice
         required: true
@@ -80,7 +80,7 @@ jobs:
           echo ::group::provision
               bundle exec bolt plan run peadm_spec::provision_test_cluster \
                 --modulepath spec/fixtures/modules \
-                provider=provision_service \
+                provider=docker \
                 image=${{ matrix.image }} \
                 architecture=${{ matrix.architecture }}
           echo ::endgroup::

--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -246,7 +246,7 @@ plan peadm::subplans::install (
   }
 
   $upload_tarball_path = "${uploaddir}/${pe_tarball_name}"
-
+  out::message("in sub - download_mode:${download_mode}")
   if $download_mode == 'bolthost' {
     # Download the PE tarball and send it to the nodes that need it
     run_plan('peadm::util::retrieve_and_upload', $pe_installer_targets,

--- a/spec/acceptance/peadm_spec/plans/install_test_cluster.pp
+++ b/spec/acceptance/peadm_spec/plans/install_test_cluster.pp
@@ -8,6 +8,7 @@ plan peadm_spec::install_test_cluster (
   Enum['enable', 'disable'] $fips                   = 'disable',
   String                    $console_password
 ) {
+  out::message("download_mode:${download_mode}")
   $t = get_targets('*')
   wait_until_available($t)
 
@@ -75,7 +76,7 @@ plan peadm_spec::install_test_cluster (
     } }
     default: { fail('Invalid architecture!') }
   }
-
+  out::message("common_params:${common_params}")
   $install_result =
     run_plan('peadm::install', $arch_params + $common_params)
 


### PR DESCRIPTION
## Summary
CI tests very often fail the provisioning step when we opt to use the provisioning_service via litmus to provision VMs in GCP. To try to alleviate the load we put on that GCP service we will move the tests that can run in Docker over there. 

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.

#### Changes include test coverage?
- [x] Yes
- [] Not needed

#### Have you updated the documentation?
- [] Yes, I've updated the appropriate docs
- [x] Not needed
