### PR TITLE
(PE-40379) fix issue on RBAC restore

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2476,6 +2476,7 @@ The following parameters are available in the `peadm::restore` plan:
 * [`restore_type`](#-peadm--restore--restore_type)
 * [`restore`](#-peadm--restore--restore)
 * [`input_file`](#-peadm--restore--input_file)
+* [`console_password`](#-peadm--restore--console_password)
 
 ##### <a name="-peadm--restore--targets"></a>`targets`
 
@@ -2504,6 +2505,14 @@ Default value: `{}`
 Data type: `Pattern[/.*\.tar\.gz$/]`
 
 The file containing the backup to restore from
+
+##### <a name="-peadm--restore--console_password"></a>`console_password`
+
+Data type: `Optional[String]`
+
+
+
+Default value: `undef`
 
 ### <a name="peadm--restore_ca"></a>`peadm::restore_ca`
 

--- a/functions/migration_opts_default.pp
+++ b/functions/migration_opts_default.pp
@@ -7,6 +7,6 @@ function peadm::migration_opts_default () {
     'config'       => false,
     'orchestrator' => true,
     'puppetdb'     => true,
-    'rbac'         => false,
+    'rbac'         => true,
   }
 }

--- a/plans/migrate.pp
+++ b/plans/migrate.pp
@@ -77,9 +77,10 @@ plan peadm::migrate (
   })
 
   run_plan('peadm::restore', {
-      targets => $new_primary_host,
-      restore_type => 'migration',
-      input_file => $remote_backup_path,
+      targets          => $new_primary_host,
+      restore_type     => 'migration',
+      input_file       => $remote_backup_path,
+      console_password => $old_primary_password,
   })
 
   $node_types = {

--- a/spec/plans/restore_spec.rb
+++ b/spec/plans/restore_spec.rb
@@ -64,7 +64,7 @@ describe 'peadm::restore' do
     expect_command("umask 0077   && cd /input   && tar -xzf /input/file.tar.gz\n")
     expect_command("/opt/puppetlabs/bin/puppet-backup restore   --scope=certs,code,config   --tempdir=/input/file   --force   /input/file/recovery/pe_backup-*tgz\n")
     expect_command("systemctl stop pe-console-services pe-nginx pxp-agent pe-puppetserver                pe-orchestration-services puppet pe-puppetdb\n")
-    expect_command("test -f /input/file/rbac/keys.json   && cp -rp /input/file/keys.json /etc/puppetlabs/console-services/conf.d/secrets/   || echo secret ldap key doesnt exist\n")
+    expect_command("test -f /input/file/rbac/secrets/keys.json   && cp -rp /input/file/rbac/secrets/keys.json /etc/puppetlabs/console-services/conf.d/secrets/   || echo secret ldap key doesnt exist\n")
     expect_command("su - pe-postgres -s /bin/bash -c   \"/opt/puppetlabs/server/bin/psql      --tuples-only      -d 'pe-puppetdb'      -c 'DROP SCHEMA IF EXISTS pglogical CASCADE;'\"\n").be_called_times(2)
     expect_command("su - pe-postgres -s /bin/bash -c   \"/opt/puppetlabs/server/bin/psql      -d 'pe-puppetdb'      -c 'DROP SCHEMA public CASCADE; CREATE SCHEMA public;'\"\n")
     expect_command('su - pe-postgres -s /bin/bash -c   "/opt/puppetlabs/server/bin/psql      -d \'pe-puppetdb\'      -c \'ALTER USER \\"pe-puppetdb\\" WITH SUPERUSER;\'"' + "\n")


### PR DESCRIPTION
## Summary
There were a few issues with restoring rbac:
1. the code was not looking in the right location to restore the keys.json file
2. on the system we migrate to the rbac token was revoked so the `puppet-db import` command was failing

## Checklist
- [] 🟢 Spec tests.
- [] 🟢 Acceptance tests.

#### Changes include test coverage?
- [x] Yes
- [] Not needed

#### Have you updated the documentation?
- [] Yes, I've updated the appropriate docs
- [x] Not needed
