### PR TITLE
(PE-40508) Add infra-assistant to add_database plan

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,23 +1,23 @@
 ---
 fixtures:
   forge_modules:
-    ruby_task_helper: "puppetlabs/ruby_task_helper"
-    service: "puppetlabs/service"
-    package: "puppetlabs/package"
-    reboot: "puppetlabs/reboot"
-    inifile: "puppetlabs/inifile"
+    ruby_task_helper: puppetlabs/ruby_task_helper
+    service: puppetlabs/service
+    package: puppetlabs/package
+    reboot: puppetlabs/reboot
+    inifile: puppetlabs/inifile
   repositories:
-    facts: "https://github.com/puppetlabs/puppetlabs-facts.git"
-    puppet_agent: "https://github.com/puppetlabs/puppetlabs-puppet_agent.git"
+    facts: https://github.com/puppetlabs/puppetlabs-facts.git
+    puppet_agent: https://github.com/puppetlabs/puppetlabs-puppet_agent.git
     provision:
-      repo: "https://github.com/puppetlabs/provision.git"
-      ref: "v3.0.1" 
-    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-    apply_helpers: "https://github.com/puppetlabs/puppetlabs-apply_helpers"
-    bolt_shim: "https://github.com/puppetlabs/puppetlabs-bolt_shim"
-    format: "https://github.com/voxpupuli/puppet-format"
-    container_inventory: "https://gitlab.com/nwops/bolt-container_inventory.git"
-    node_manager: "https://github.com/puppetlabs/puppetlabs-node_manager.git"
+      repo: https://github.com/puppetlabs/provision.git
+      ref: v3.0.1
+    stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
+    apply_helpers: https://github.com/puppetlabs/puppetlabs-apply_helpers
+    bolt_shim: https://github.com/puppetlabs/puppetlabs-bolt_shim
+    format: https://github.com/voxpupuli/puppet-format
+    container_inventory: https://gitlab.com/nwops/bolt-container_inventory.git
+    node_manager: https://github.com/puppetlabs/puppetlabs-node_manager.git
   symlinks:
-    "peadm": "#{source_dir}"
-    "peadm_spec": "#{source_dir}/spec/acceptance/peadm_spec"
+    peadm: '#{source_dir}'
+    peadm_spec: '#{source_dir}/spec/acceptance/peadm_spec'

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,7 +9,9 @@ fixtures:
   repositories:
     facts: "https://github.com/puppetlabs/puppetlabs-facts.git"
     puppet_agent: "https://github.com/puppetlabs/puppetlabs-puppet_agent.git"
-    provision: "https://github.com/puppetlabs/provision.git"
+    provision:
+      repo: "https://github.com/puppetlabs/provision.git"
+      ref: "v3.0.1" 
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     apply_helpers: "https://github.com/puppetlabs/puppetlabs-apply_helpers"
     bolt_shim: "https://github.com/puppetlabs/puppetlabs-bolt_shim"

--- a/functions/pe_db_names.pp
+++ b/functions/pe_db_names.pp
@@ -9,10 +9,20 @@ function peadm::pe_db_names (
     'pe-rbac',
   ]
 
+  $pe_2025_3_or_later = SemVerRange('>= 2025.3.0')
   $pe_2025_or_later = SemVerRange('>= 2025.0.0')
   $pe_2023_8_or_later = SemVerRange('>= 2023.8.0')
 
   case $pe_ver {
+    # The infra-assistant was added in 2025.3.0
+    $pe_2025_3_or_later: {
+      $original_db_names + [
+        'pe-hac',
+        'pe-patching',
+        'pe-infra-assistant',
+      ]
+    }
+
     # The patching service was added in 2025.0.0
     $pe_2025_or_later: {
       $original_db_names + [


### PR DESCRIPTION
## Summary
Adding the Infra Assistant DB following just as was done with PE Patching in https://github.com/puppetlabs/puppetlabs-peadm/pull/531.


## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [x] Not needed
