### PR TITLE
(PE-40350) add plan parameters to log stream

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -32,7 +32,9 @@
 * [`peadm::generate_pe_conf`](#peadm--generate_pe_conf): Generate a pe.conf file in JSON format
 * [`peadm::get_pe_conf`](#peadm--get_pe_conf)
 * [`peadm::get_targets`](#peadm--get_targets): Accept undef or a SingleTargetSpec, and return an Array[Target, 1, 0]. This differs from get_target() in that:   - It returns an Array[Target
+* [`peadm::log_plan_parameters`](#peadm--log_plan_parameters)
 * [`peadm::migration_opts_default`](#peadm--migration_opts_default)
+* [`peadm::module_version`](#peadm--module_version)
 * [`peadm::node_manager_yaml_location`](#peadm--node_manager_yaml_location)
 * [`peadm::oid`](#peadm--oid)
 * [`peadm::pe_db_names`](#peadm--pe_db_names)
@@ -786,6 +788,24 @@ Data type: `Optional[Integer[1,1]]`
 
 
 
+### <a name="peadm--log_plan_parameters"></a>`peadm::log_plan_parameters`
+
+Type: Puppet Language
+
+The peadm::log_plan_parameters function.
+
+#### `peadm::log_plan_parameters(Hash $params)`
+
+The peadm::log_plan_parameters function.
+
+Returns: `Any`
+
+##### `params`
+
+Data type: `Hash`
+
+
+
 ### <a name="peadm--migration_opts_default"></a>`peadm::migration_opts_default`
 
 Type: Puppet Language
@@ -795,6 +815,18 @@ The peadm::migration_opts_default function.
 #### `peadm::migration_opts_default()`
 
 The peadm::migration_opts_default function.
+
+Returns: `Any`
+
+### <a name="peadm--module_version"></a>`peadm::module_version`
+
+Type: Ruby 4.x API
+
+The peadm::module_version function.
+
+#### `peadm::module_version()`
+
+The peadm::module_version function.
 
 Returns: `Any`
 

--- a/functions/log_plan_parameters.pp
+++ b/functions/log_plan_parameters.pp
@@ -1,0 +1,6 @@
+function peadm::log_plan_parameters(Hash $params) {
+  out::message("PEADM Module version: ${peadm::module_version()}")
+  $params.each |$key, $value| {
+    out::message("Parameter '${key}': [${value}]")
+  }
+}

--- a/lib/puppet/functions/peadm/module_version.rb
+++ b/lib/puppet/functions/peadm/module_version.rb
@@ -1,0 +1,9 @@
+Puppet::Functions.create_function(:'peadm::module_version', Puppet::Functions::InternalFunction) do
+  dispatch :module_version do
+    scope_param
+  end
+
+  def module_version(scope)
+    scope.compiler.environment.module('peadm').version
+  end
+end

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -75,6 +75,17 @@ plan peadm::install (
   Boolean                    $permit_unsafe_versions = false,
   String                     $token_lifetime         = '1y',
 ) {
+  # Log parameters for debugging 
+  peadm::log_plan_parameters({
+    'primary_host' => $primary_host,
+    'replica_host' => $replica_host,
+    'compiler_hosts' => $compiler_hosts,
+    'legacy_compilers' => $legacy_compilers,
+    'primary_postgresql_host' => $primary_postgresql_host,
+    'replica_postgresql_host' => $replica_postgresql_host,
+    'version' => $version,
+  })
+
   peadm::assert_supported_bolt_version()
 
   peadm::assert_supported_pe_version($version, $permit_unsafe_versions)

--- a/plans/migrate.pp
+++ b/plans/migrate.pp
@@ -22,6 +22,16 @@ plan peadm::migrate (
   Optional[Peadm::SingleTargetSpec] $primary_postgresql_host = undef,
   Optional[Peadm::SingleTargetSpec] $replica_postgresql_host = undef,
 ) {
+  # Log parameters for debugging 
+  peadm::log_plan_parameters({
+    'old_primary_host' => $old_primary_host,
+    'new_primary_host' => $new_primary_host,
+    'replica_host' => $replica_host,
+    'primary_postgresql_host' => $primary_postgresql_host,
+    'replica_postgresql_host' => $replica_postgresql_host,
+    'upgrade_version' => $upgrade_version,
+  })
+
   # pre-migration checks
   out::message('This plan is a work in progress and it is not recommended to be used until it is fully implemented and supported')
   peadm::assert_supported_bolt_version()

--- a/plans/replace_failed_postgresql.pp
+++ b/plans/replace_failed_postgresql.pp
@@ -12,6 +12,15 @@ plan peadm::replace_failed_postgresql(
   Peadm::SingleTargetSpec   $failed_postgresql_host,
   Peadm::SingleTargetSpec   $replacement_postgresql_host,
 ) {
+  # Log parameters for debugging 
+  peadm::log_plan_parameters({
+    'primary_host' => $primary_host,
+    'replica_host' => $replica_host,
+    'working_postgresql_host' => $working_postgresql_host,
+    'failed_postgresql_host' => $failed_postgresql_host,
+    'replacement_postgresql_host' => $replacement_postgresql_host,
+  })
+
   $all_hosts = peadm::flatten_compact([
       $primary_host,
       $replica_host,

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -62,6 +62,16 @@ plan peadm::upgrade (
 
   Optional[Peadm::UpgradeSteps] $begin_at_step = undef,
 ) {
+  # Log parameters for debugging
+  peadm::log_plan_parameters({
+    'primary_host' => $primary_host,
+    'replica_host' => $replica_host,
+    'compiler_hosts' => $compiler_hosts,
+    'primary_postgresql_host' => $primary_postgresql_host,
+    'replica_postgresql_host' => $replica_postgresql_host,
+    'version' => $version,
+  })
+
   out::message('# Validating inputs')
 
   # Ensure input valid for a supported architecture

--- a/spec/plans/install_spec.rb
+++ b/spec/plans/install_spec.rb
@@ -5,6 +5,7 @@ describe 'peadm::install' do
 
   describe 'basic functionality' do
     it 'runs successfully with the minimum required parameters' do
+      allow_out_message
       expect_plan('peadm::subplans::install')
       expect_plan('peadm::subplans::configure')
       expect(run_plan('peadm::install', 'primary_host' => 'primary', 'console_password' => 'puppetLabs123!', 'version' => '2021.7.9')).to be_ok


### PR DESCRIPTION
## Summary
Parameters requested to be added to log in upgrade and install plans:
[] The peadm version being used
[] The nodes involved in the plan and their assigned roles
[] The PE version being installed.
[] The PE version being upgraded.



## Additional Context
Add any additional context about the problem here.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [ ] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [ ] Not needed
