### PR TITLE
(MAINT) remove 2019 tests from matrices

### DIFF
--- a/.github/workflows/test-failover.yaml
+++ b/.github/workflows/test-failover.yaml
@@ -10,7 +10,7 @@ on:
       version:
         description: PE version to install
         required: true
-        default: 2019.8.12
+        default: 2021.7.9
       version_to_upgrade:
         description: PE version to upgrade to
         required: false

--- a/.github/workflows/test-fips-install-matrix.yaml
+++ b/.github/workflows/test-fips-install-matrix.yaml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [standard-with-dr, large, extra-large-with-dr]
-        version: [2019.8.12, 2021.7.9, 2023.8.2, 2025.2.0]
+        version: [2021.7.9, 2023.8.2, 2025.2.0]
         image: [rhel-8]
         fips: [enable]
     steps:

--- a/.github/workflows/test-install-matrix.yaml
+++ b/.github/workflows/test-install-matrix.yaml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [standard-with-dr, large, extra-large-with-dr]
-        version: [2019.8.12, 2021.7.9, 2023.8.2, 2025.2.0]
+        version: [2021.7.9, 2023.8.2, 2025.2.0]
         image: [almalinux-cloud/almalinux-8]
     steps:
       - name: Checkout Source

--- a/.github/workflows/test-upgrade-matrix.yaml
+++ b/.github/workflows/test-upgrade-matrix.yaml
@@ -37,23 +37,19 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [standard, extra-large]  # removing xl-with dr until PE-40902 is addressed
-        version: [2019.8.12, 2021.7.9, 2023.8.2]
+        version: [2021.7.9, 2023.8.2]
         version_to_upgrade: [2021.7.9, 2023.8.2, 2025.2.0]
         image: [almalinux-cloud/almalinux-8]
         download_mode: [direct]
         exclude:
-          - version: 2019.8.12
-            version_to_upgrade: 2023.8.2
-          - version: 2019.8.12
-            version_to_upgrade: 2025.2.0
           - version: 2021.7.9
             version_to_upgrade: 2021.7.9
           - version: 2021.7.9
             version_to_upgrade: 2025.2.0
-          - version: 2023.8.1
-            version_to_upgrade: 2023.8.2
           - version: 2023.8.2
             version_to_upgrade: 2021.7.9
+          - version: 2023.8.2
+            version_to_upgrade: 2023.8.2
     steps:
       - name: Start SSH session
         if: ${{ github.event.inputs.ssh-debugging == 'true' }}

--- a/.github/workflows/test-upgrade.yaml
+++ b/.github/workflows/test-upgrade.yaml
@@ -22,11 +22,11 @@ on:
       version:
         description: PE version to install initially
         required: true
-        default: 2019.8.12
+        default: 2021.7.9
       upgrade_version:
         description: PE version to upgrade to
         required: true
-        default: 2021.7.9
+        default: 2023.8.2
       ssh-debugging:
         description: Boolean; whether or not to pause for ssh debugging
         required: true


### PR DESCRIPTION
## Summary
Removing 2019 tests from matrices - taking up a lot of time testing a PE version we no longer support

## Checklist
- [] 🟢 Spec tests.
- [] 🟢 Acceptance tests.

#### Changes include test coverage?
- [x] Yes
- [] Not needed

#### Have you updated the documentation?
- [] Yes, I've updated the appropriate docs
- [x] Not needed
