### PR TITLE
(PE-41341) Allow primary postgres host to be the failure

### DIFF
--- a/.github/workflows/test-replace-failed-postgresql.yaml
+++ b/.github/workflows/test-replace-failed-postgresql.yaml
@@ -99,6 +99,14 @@ jobs:
             version=${{ matrix.version }} \
             console_password=${{ secrets.CONSOLE_PASSWORD }} \
             code_manager_auto_configure=true
+      - name: Uninstall on primary-pdb-postgresql to emulate it failing
+        run: |
+          primary_pdb_postgresql_host=$(yq '.groups[].targets[] | select(.vars.role == "primary-pdb-postgresql") | .name' spec/fixtures/litmus_inventory.yaml)
+          bundle exec bolt plan run peadm::uninstall \
+            --inventoryfile spec/fixtures/litmus_inventory.yaml \
+            --modulepath spec/fixtures/modules \
+            -t $primary_pdb_postgresql_host \
+          --no-host-key-check
       - name: Replace failed PostgreSQL
         run: |
           echo ::group::prepare

--- a/spec/acceptance/peadm_spec/plans/test_replace_failed_postgres.pp
+++ b/spec/acceptance/peadm_spec/plans/test_replace_failed_postgres.pp
@@ -5,16 +5,8 @@ plan peadm_spec::test_replace_failed_postgres(
   Peadm::SingleTargetSpec   $failed_postgresql_host,
   Peadm::SingleTargetSpec   $replacement_postgresql_host,
 ) {
-  # run infra status on the primary
-  out::message("Running peadm::status on primary host ${primary_host}")
-  $primary_status = run_plan('peadm::status', $primary_host, { 'format' => 'json' })
-  out::message($primary_status)
-
-  if empty($primary_status['failed']) {
-    out::message('Cluster is healthy, continuing')
-  } else {
-    fail_plan('Cluster is not healthy, aborting')
-  }
+  # run puppet once on working_postgresql_host - gives some time in CI
+  run_task('peadm::puppet_runonce', $working_postgresql_host)
 
   # replace the failed postgres server
   run_plan('peadm::replace_failed_postgresql',


### PR DESCRIPTION
## Summary
The Bolt plan for replacing a failed postgres host was not working properly when the primary was the host that had failed.

## Checklist
- [] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.

#### Changes include test coverage?
- [x] Yes
- [] Not needed

#### Have you updated the documentation?
- [] Yes, I've updated the appropriate docs
- [x] Not needed
