### PR TITLE
Update convert_compiler_to_legacy.pp

### DIFF
--- a/plans/convert_compiler_to_legacy.pp
+++ b/plans/convert_compiler_to_legacy.pp
@@ -133,8 +133,8 @@ plan peadm::convert_compiler_to_legacy (
   ])
 
   if $remove_pdb {
-    run_command('puppet resource service puppet ensure=stopped', $convert_legacy_compiler_targets)
-    run_command('puppet resource service pe-puppetdb ensure=stopped enable=false', $convert_legacy_compiler_targets)
+    run_command('/usr/local/bin/puppet resource service puppet ensure=stopped', $convert_legacy_compiler_targets)
+    run_command('/usr/local/bin/puppet resource service pe-puppetdb ensure=stopped enable=false', $convert_legacy_compiler_targets)
   }
 
   run_task('peadm::puppet_runonce', $convert_legacy_compiler_targets)
@@ -143,8 +143,8 @@ plan peadm::convert_compiler_to_legacy (
   run_task('peadm::puppet_runonce', $all_targets)
 
   if $remove_pdb {
-    run_command('puppet resource package pe-puppetdb ensure=purged', $convert_legacy_compiler_targets)
-    run_command('puppet resource user pe-puppetdb ensure=absent', $convert_legacy_compiler_targets)
+    run_command('/usr/local/bin/puppet resource package pe-puppetdb ensure=purged', $convert_legacy_compiler_targets)
+    run_command('/usr/local/bin/puppet resource user pe-puppetdb ensure=absent', $convert_legacy_compiler_targets)
 
     run_command('rm -rf /etc/puppetlabs/puppetdb', $convert_legacy_compiler_targets)
     run_command('rm -rf /var/log/puppetlabs/puppetdb', $convert_legacy_compiler_targets)
@@ -152,7 +152,7 @@ plan peadm::convert_compiler_to_legacy (
   }
 
   run_command('systemctl start pe-puppetserver.service', $convert_legacy_compiler_targets)
-  run_command('puppet resource service puppet ensure=running', $convert_legacy_compiler_targets)
+  run_command('/usr/local/bin/puppet resource service puppet ensure=running', $convert_legacy_compiler_targets)
 
   return("Converted host ${convert_legacy_compiler_targets} to legacy compiler.")
 }


### PR DESCRIPTION
This plan fails unless the full path to puppet is provided.

## Summary
The peadm::convert_compiler_to_legacy plan fails on RedHat/AlmaLinux 8 hosts because the path to the puppet binary is not available. 

## Additional Context
I've run the plan and got 
```
bolt plan run peadm::convert_compiler_to_legacy legacy_hosts=ec2-3-249-219-230.eu-west-1.compute.amazonaws.com primary_host=ec2-108-129-106-166.eu-west-1.compute.amazonaws.com

Starting: plan peadm::convert_compiler_to_legacy
Starting: task peadm::check_pe_master_rules on ec2-108-129-106-166.eu-west-1.compute.amazonaws.com
Finished: task peadm::check_pe_master_rules with 0 failures in 3.53 sec
Starting: task peadm::get_peadm_config on ec2-108-129-106-166.eu-west-1.compute.amazonaws.com
Finished: task peadm::get_peadm_config with 0 failures in 2.48 sec
Starting: apply catalog on ec2-108-129-106-166.eu-west-1.compute.amazonaws.com
Finished: apply catalog with 0 failures in 15.9 sec
Starting: task peadm::cert_data on ec2-3-249-219-230.eu-west-1.compute.amazonaws.com
Finished: task peadm::cert_data with 0 failures in 2.85 sec
Starting: plan peadm::modify_certificate
Finished: plan peadm::modify_certificate in 0.0 sec
Starting: plan peadm::modify_certificate
Finished: plan peadm::modify_certificate in 0.0 sec
Starting: plan peadm::modify_certificate
peadm::modify_certificate: primary host: ec2-108-129-106-166.eu-west-1.compute.amazonaws.com - ec2-108-129-106-166.eu-west-1.compute.amazonaws.com - ec2-108-129-106-166.eu-west-1.compute.amazonaws.com
Starting: task peadm::cert_data on ec2-108-129-106-166.eu-west-1.compute.amazonaws.com
Finished: task peadm::cert_data with 0 failures in 2.63 sec
Starting: plan peadm::subplans::modify_certificate
Starting: task peadm::cert_data on ec2-3-249-219-230.eu-west-1.compute.amazonaws.com
Finished: task peadm::cert_data with 0 failures in 2.84 sec
ec2-3-249-219-230.eu-west-1.compute.amazonaws.com already has requested modifications; certificate will not be re-issued
Finished: plan peadm::subplans::modify_certificate in 3.12 sec
Finished: plan peadm::modify_certificate in 6.72 sec
Starting: command 'puppet resource service puppet ensure=stopped' on ec2-3-249-219-230.eu-west-1.compute.amazonaws.com
Finished: command 'puppet resource service puppet ensure=stopped' with 1 failure in 0.43 sec
Finished: plan peadm::convert_compiler_to_legacy in 32.96 sec
Failed on ec2-3-249-219-230.eu-west-1.compute.amazonaws.com:
  The command failed with exit code 127
  sh: puppet: command not found
Failed on 1 target: ec2-3-249-219-230.eu-west-1.compute.amazonaws.com
Ran on 1 target
```

I modified the plan to include the paths
```
 if $remove_pdb {
    run_command('/usr/local/bin/puppet resource service puppet ensure=stopped', $convert_legacy_compiler_targets)
    run_command('/usr/local/bin/puppet resource service pe-puppetdb ensure=stopped enable=false', $convert_legacy_compiler_targets)
  }
```
And it got through to the next failure point 
```
Finished: task peadm::puppet_runonce with 0 failures in 57.87 sec
Starting: task peadm::puppet_runonce on ec2-108-129-106-166.eu-west-1.compute.amazonaws.com, ec2-34-245-86-65.eu-west-1.compute.amazonaws.com, ec2-18-203-222-80.eu-west-1.compute.amazonaws.com, ec2-34-249-224-191.eu-west-1.compute.amazonaws.com, ec2-3-249-219-230.eu-west-1.compute.amazonaws.com
Finished: task peadm::puppet_runonce with 0 failures in 79.76 sec
Starting: command 'puppet resource package pe-puppetdb ensure=purged' on ec2-3-249-219-230.eu-west-1.compute.amazonaws.com
Finished: command 'puppet resource package pe-puppetdb ensure=purged' with 1 failure in 0.47 sec
Finished: plan peadm::convert_compiler_to_legacy in 3 min, 37 sec
Failed on ec2-3-249-219-230.eu-west-1.compute.amazonaws.com:
  The command failed with exit code 127
  sh: puppet: command not found
Failed on 1 target: ec2-3-249-219-230.eu-west-1.compute.amazonaws.com
Ran on 1 target
```
these will pass if this is changed.

```
  if $remove_pdb {
    run_command('/usr/local/bin/puppet resource package pe-puppetdb ensure=purged', $convert_legacy_compiler_targets)
    run_command('/usr/local/bin/puppet resource user pe-puppetdb ensure=absent', $convert_legacy_compiler_targets)
```

The changes proposed result in a successfull run 

```
 bolt plan run peadm::convert_compiler_to_legacy legacy_hosts=ec2-3-249-219-230.eu-west-1.compute.amazonaws.com primary_host=ec2-108-129-106-166.eu-west-1.compute.amazonaws.com
Starting: plan peadm::convert_compiler_to_legacy
Starting: task peadm::check_pe_master_rules on ec2-108-129-106-166.eu-west-1.compute.amazonaws.com
Finished: task peadm::check_pe_master_rules with 0 failures in 2.82 sec
Starting: task peadm::get_peadm_config on ec2-108-129-106-166.eu-west-1.compute.amazonaws.com
Finished: task peadm::get_peadm_config with 0 failures in 2.55 sec
Starting: apply catalog on ec2-108-129-106-166.eu-west-1.compute.amazonaws.com
Finished: apply catalog with 0 failures in 12.17 sec
Starting: task peadm::cert_data on ec2-3-249-219-230.eu-west-1.compute.amazonaws.com
Finished: task peadm::cert_data with 0 failures in 2.89 sec
Starting: plan peadm::modify_certificate
Finished: plan peadm::modify_certificate in 0.0 sec
Starting: plan peadm::modify_certificate
Finished: plan peadm::modify_certificate in 0.0 sec
Starting: plan peadm::modify_certificate
peadm::modify_certificate: primary host: ec2-108-129-106-166.eu-west-1.compute.amazonaws.com - ec2-108-129-106-166.eu-west-1.compute.amazonaws.com - ec2-108-129-106-166.eu-west-1.compute.amazonaws.com
Starting: task peadm::cert_data on ec2-108-129-106-166.eu-west-1.compute.amazonaws.com
Finished: task peadm::cert_data with 0 failures in 2.58 sec
Starting: plan peadm::subplans::modify_certificate
Starting: task peadm::cert_data on ec2-3-249-219-230.eu-west-1.compute.amazonaws.com
Finished: task peadm::cert_data with 0 failures in 2.83 sec
ec2-3-249-219-230.eu-west-1.compute.amazonaws.com already has requested modifications; certificate will not be re-issued
Finished: plan peadm::subplans::modify_certificate in 3.04 sec
Finished: plan peadm::modify_certificate in 6.6 sec
Starting: command '/usr/local/bin/puppet resource service puppet ensure=stopped' on ec2-3-249-219-230.eu-west-1.compute.amazonaws.com
Finished: command '/usr/local/bin/puppet resource service puppet ensure=stopped' with 0 failures in 2.06 sec
Starting: command '/usr/local/bin/puppet resource service pe-puppetdb ensure=stopped enable=false' on ec2-3-249-219-230.eu-west-1.compute.amazonaws.com
Finished: command '/usr/local/bin/puppet resource service pe-puppetdb ensure=stopped enable=false' with 0 failures in 2.11 sec
Starting: task peadm::puppet_runonce on ec2-3-249-219-230.eu-west-1.compute.amazonaws.com
Finished: task peadm::puppet_runonce with 0 failures in 45.02 sec
Starting: task peadm::puppet_runonce on ec2-108-129-106-166.eu-west-1.compute.amazonaws.com
Finished: task peadm::puppet_runonce with 0 failures in 54.02 sec
Starting: task peadm::puppet_runonce on ec2-108-129-106-166.eu-west-1.compute.amazonaws.com, ec2-34-245-86-65.eu-west-1.compute.amazonaws.com, ec2-18-203-222-80.eu-west-1.compute.amazonaws.com, ec2-34-249-224-191.eu-west-1.compute.amazonaws.com, ec2-3-249-219-230.eu-west-1.compute.amazonaws.com
Finished: task peadm::puppet_runonce with 0 failures in 77.29 sec
Starting: command '/usr/local/bin/puppet resource package pe-puppetdb ensure=purged' on ec2-3-249-219-230.eu-west-1.compute.amazonaws.com
Finished: command '/usr/local/bin/puppet resource package pe-puppetdb ensure=purged' with 0 failures in 3.98 sec
Starting: command '/usr/local/bin/puppet resource user pe-puppetdb ensure=absent' on ec2-3-249-219-230.eu-west-1.compute.amazonaws.com
Finished: command '/usr/local/bin/puppet resource user pe-puppetdb ensure=absent' with 0 failures in 2.0 sec
Starting: command 'rm -rf /etc/puppetlabs/puppetdb' on ec2-3-249-219-230.eu-west-1.compute.amazonaws.com
Finished: command 'rm -rf /etc/puppetlabs/puppetdb' with 0 failures in 0.43 sec
Starting: command 'rm -rf /var/log/puppetlabs/puppetdb' on ec2-3-249-219-230.eu-west-1.compute.amazonaws.com
Finished: command 'rm -rf /var/log/puppetlabs/puppetdb' with 0 failures in 0.46 sec
Starting: command 'rm -rf /opt/puppetlabs/server/data/puppetdb' on ec2-3-249-219-230.eu-west-1.compute.amazonaws.com
Finished: command 'rm -rf /opt/puppetlabs/server/data/puppetdb' with 0 failures in 0.44 sec
Starting: command 'systemctl start pe-puppetserver.service' on ec2-3-249-219-230.eu-west-1.compute.amazonaws.com
Finished: command 'systemctl start pe-puppetserver.service' with 0 failures in 0.46 sec
Starting: command '/usr/local/bin/puppet resource service puppet ensure=running' on ec2-3-249-219-230.eu-west-1.compute.amazonaws.com
Finished: command '/usr/local/bin/puppet resource service puppet ensure=running' with 0 failures in 2.11 sec
Finished: plan peadm::convert_compiler_to_legacy in 3 min, 38 sec
"Converted host [ec2-3-249-219-230.eu-west-1.compute.amazonaws.com] to legacy compiler."
```

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [X] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [X ] Not needed
