### PR TITLE
(PE-41821) remove Ubuntu 18.04 and 20.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -68,9 +68,8 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04",
-        "20.04",
-        "22.04"
+        "22.04",
+        "24.04"
       ]
     },
     {


### PR DESCRIPTION
## Summary
Update supported Ubuntu OSs to remove 18.04 and 20.04 as they are EOL

## Checklist
- [] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.

#### Changes include test coverage?
- [x] Yes
- [] Not needed

#### Have you updated the documentation?
- [] Yes, I've updated the appropriate docs
- [x] Not needed
