### PR TITLE
(PE-42025) addressing rexml CVE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,4 @@ jobs:
     if: ${{ github.repository_owner == 'puppetlabs' }}
     needs: Spec
     uses: puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main
-    with:
-      flags: --provision-service
     secrets: inherit

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,6 +13,4 @@ jobs:
     if: ${{ github.repository_owner == 'puppetlabs' }}
     needs: Spec
     uses: puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main
-    with:
-      flags: --provision-service
     secrets: inherit

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,40 +1,40 @@
 ---
-require:
-- rubocop-performance
-- rubocop-rspec
+plugins:
+  - rubocop-performance
+  - rubocop-rspec
+  - rubocop-rspec_rails
+  - rubocop-factory_bot
+  - rubocop-capybara
 AllCops:
   Newcops: enable
   ExtraDetails: true
   DisplayStyleGuide: true
   DisplayCopNames: true
   TargetRubyVersion: '2.7'
-  Include:
-  - "**/*.rb"
+  Include: ['**/*.rb']
   Exclude:
-  - bin/*
-  - ".vendor/**/*"
-  - "**/Gemfile"
-  - "**/Rakefile"
-  - pkg/**/*
-  - spec/fixtures/**/*
-  - vendor/**/*
-  - "**/Puppetfile"
-  - "**/Vagrantfile"
-  - "**/Guardfile"
+    - bin/*
+    - .vendor/**/*
+    - '**/Gemfile'
+    - '**/Rakefile'
+    - pkg/**/*
+    - spec/fixtures/**/*
+    - vendor/**/*
+    - '**/Puppetfile'
+    - '**/Vagrantfile'
+    - '**/Guardfile'
 Layout/LineLength:
   Description: People have wide screens, use them.
   Max: 200
 RSpec/BeforeAfterAll:
   Description: Beware of using after(:all) as it may cause state to leak between tests.
     A necessary evil in acceptance testing.
-  Exclude:
-  - spec/acceptance/**/*.rb
+  Exclude: [spec/acceptance/**/*.rb]
 RSpec/HookArgument:
   Description: Prefer explicit :each argument, matching existing module's style
   EnforcedStyle: each
 RSpec/DescribeSymbol:
-  Exclude:
-  - spec/unit/facter/**/*.rb
+  Exclude: [spec/unit/facter/**/*.rb]
 Style/BlockDelimiters:
   Description: Prefer braces for chaining. Mostly an aesthetical choice. Better to
     be consistent then.
@@ -77,9 +77,7 @@ Style/SymbolArray:
 RSpec/MessageSpies:
   EnforcedStyle: receive
 Style/Documentation:
-  Exclude:
-  - lib/puppet/parser/functions/**/*
-  - spec/**/*
+  Exclude: [lib/puppet/parser/functions/**/*, spec/**/*]
 Style/WordArray:
   EnforcedStyle: brackets
 Performance/AncestorsInclude:
@@ -296,7 +294,7 @@ Performance/UriDefaultParser:
   Enabled: false
 RSpec/Be:
   Enabled: false
-RSpec/Capybara/FeatureMethods:
+RSpec/Dialect:
   Enabled: false
 RSpec/ContainExactly:
   Enabled: false
@@ -318,15 +316,17 @@ RSpec/ExampleLength:
   Enabled: false
 RSpec/ExampleWithoutDescription:
   Enabled: false
+RSpec/ExampleWording:
+  Enabled: false
 RSpec/ExpectChange:
   Enabled: false
 RSpec/ExpectInHook:
   Enabled: false
-RSpec/FactoryBot/AttributeDefinedStatically:
+FactoryBot/AttributeDefinedStatically:
   Enabled: false
-RSpec/FactoryBot/CreateList:
+FactoryBot/CreateList:
   Enabled: false
-RSpec/FactoryBot/FactoryClassName:
+FactoryBot/FactoryClassName:
   Enabled: false
 RSpec/HooksBeforeExamples:
   Enabled: false
@@ -464,6 +464,8 @@ Style/RedundantSelfAssignment:
   Enabled: false
 Style/RedundantSort:
   Enabled: false
+Style/RedundantReturn:
+  Enabled: false
 Style/RescueStandardError:
   Enabled: false
 Style/SingleArgumentDig:
@@ -598,13 +600,15 @@ RSpec/ClassCheck:
   Enabled: false
 RSpec/DuplicatedMetadata:
   Enabled: false
+RSpec/MetadataStyle:
+  Enabled: false
 RSpec/ExcessiveDocstringSpacing:
   Enabled: false
-RSpec/FactoryBot/ConsistentParenthesesStyle:
+FactoryBot/ConsistentParenthesesStyle:
   Enabled: false
-RSpec/FactoryBot/FactoryNameStyle:
+FactoryBot/FactoryNameStyle:
   Enabled: false
-RSpec/FactoryBot/SyntaxMethods:
+FactoryBot/SyntaxMethods:
   Enabled: false
 RSpec/IdenticalEqualityAssertion:
   Enabled: false
@@ -612,15 +616,15 @@ RSpec/NoExpectationExample:
   Enabled: false
 RSpec/PendingWithoutReason:
   Enabled: false
-RSpec/Rails/AvoidSetupHook:
+RSpecRails/AvoidSetupHook:
   Enabled: false
-RSpec/Rails/HaveHttpStatus:
+RSpecRails/HaveHttpStatus:
   Enabled: false
-RSpec/Rails/InferredSpecType:
+RSpecRails/InferredSpecType:
   Enabled: false
-RSpec/Rails/MinitestAssertions:
+RSpecRails/MinitestAssertions:
   Enabled: false
-RSpec/Rails/TravelAround:
+RSpecRails/TravelAround:
   Enabled: false
 RSpec/RedundantAround:
   Enabled: false
@@ -723,4 +727,146 @@ Style/SelectByRegexp:
 Style/StringChars:
   Enabled: false
 Style/SwapValues:
+  Enabled: false
+Gemspec/AddRuntimeDependency:  # new in 1.65
+  Enabled: false
+Gemspec/AttributeAssignment:  # new in 1.77
+  Enabled: false
+Layout/EmptyLinesAfterModuleInclusion:  # new in 1.79
+  Enabled: false
+Lint/ArrayLiteralInRegexp:  # new in 1.71
+  Enabled: false
+Lint/ConstantReassignment:  # new in 1.70
+  Enabled: false
+Lint/CopDirectiveSyntax:  # new in 1.72
+  Enabled: false
+Lint/DuplicateMatchPattern:  # new in 1.50
+  Enabled: false
+Lint/DuplicateSetElement:  # new in 1.67
+  Enabled: false
+Lint/HashNewWithKeywordArgumentsAsDefault:  # new in 1.69
+  Enabled: false
+Lint/ItWithoutArgumentsInBlock:  # new in 1.59
+  Enabled: false
+Lint/LiteralAssignmentInCondition:  # new in 1.58
+  Enabled: false
+Lint/MixedCaseRange:  # new in 1.53
+  Enabled: false
+Lint/NumericOperationWithConstantResult:  # new in 1.69
+  Enabled: false
+Lint/RedundantRegexpQuantifiers:  # new in 1.53
+  Enabled: false
+Lint/RedundantTypeConversion:  # new in 1.72
+  Enabled: false
+Lint/SharedMutableDefault:  # new in 1.70
+  Enabled: false
+Lint/SuppressedExceptionInNumberConversion:  # new in 1.72
+  Enabled: false
+Lint/UnescapedBracketInRegexp:  # new in 1.68
+  Enabled: false
+Lint/UselessConstantScoping:  # new in 1.72
+  Enabled: false
+Lint/UselessDefaultValueArgument:  # new in 1.76
+  Enabled: false
+Lint/UselessDefined:  # new in 1.69
+  Enabled: false
+Lint/UselessNumericOperation:  # new in 1.66
+  Enabled: false
+Lint/UselessOr:  # new in 1.76
+  Enabled: false
+Naming/PredicateMethod:  # new in 1.76
+  Enabled: false
+Style/AmbiguousEndlessMethodDefinition:  # new in 1.68
+  Enabled: false
+Style/BitwisePredicate:  # new in 1.68
+  Enabled: false
+Style/CollectionQuerying:  # new in 1.77
+  Enabled: false
+Style/CombinableDefined:  # new in 1.68
+  Enabled: false
+Style/ComparableBetween:  # new in 1.74
+  Enabled: false
+Style/DataInheritance:  # new in 1.49
+  Enabled: false
+Style/DigChain:  # new in 1.69
+  Enabled: false
+Style/EmptyStringInsideInterpolation:  # new in 1.76
+  Enabled: false
+Style/ExactRegexpMatch:  # new in 1.51
+  Enabled: false
+Style/FileNull:  # new in 1.69
+  Enabled: false
+Style/FileTouch:  # new in 1.69
+  Enabled: false
+Style/HashFetchChain:  # new in 1.75
+  Enabled: false
+Style/HashSlice:  # new in 1.71
+  Enabled: false
+Style/ItAssignment:  # new in 1.70
+  Enabled: false
+Style/ItBlockParameter:  # new in 1.75
+  Enabled: false
+Style/KeywordArgumentsMerging:  # new in 1.68
+  Enabled: false
+Style/MapIntoArray:  # new in 1.63
+  Enabled: false
+Style/RedundantArrayConstructor:  # new in 1.52
+  Enabled: false
+Style/RedundantArrayFlatten:  # new in 1.76
+  Enabled: false
+Style/RedundantCurrentDirectoryInPath:  # new in 1.53
+  Enabled: false
+Style/RedundantFilterChain:  # new in 1.52
+  Enabled: false
+Style/RedundantFormat:  # new in 1.72
+  Enabled: false
+Style/RedundantInterpolationUnfreeze:  # new in 1.66
+  Enabled: false
+Style/RedundantLineContinuation:  # new in 1.49
+  Enabled: false
+Style/RedundantRegexpArgument:  # new in 1.53
+  Enabled: false
+Style/RedundantRegexpConstructor:  # new in 1.52
+  Enabled: false
+Style/ReturnNilInPredicateMethodDefinition:  # new in 1.53
+  Enabled: false
+Style/SafeNavigationChainLength:  # new in 1.68
+  Enabled: false
+Style/SendWithLiteralMethodName:  # new in 1.64
+  Enabled: false
+Style/SingleLineDoEndBlock:  # new in 1.57
+  Enabled: false
+Style/SuperArguments:  # new in 1.64
+  Enabled: false
+Style/SuperWithArgsParentheses:  # new in 1.58
+  Enabled: false
+Style/YAMLFileRead:  # new in 1.53
+  Enabled: false
+Performance/MapMethodChain:  # new in 1.19
+  Enabled: false
+Performance/StringBytesize:  # new in 1.23
+  Enabled: false
+Performance/ZipWithoutBlock:  # new in 1.24
+  Enabled: false
+RSpec/IncludeExamples:  # new in 3.6
+  Enabled: false
+RSpecRails/NegationBeValid:  # new in 2.23
+  Enabled: false
+FactoryBot/AssociationStyle:  # new in 2.23
+  Enabled: false
+FactoryBot/ExcessiveCreateList:  # new in 2.25
+  Enabled: false
+FactoryBot/FactoryAssociationWithStrategy:  # new in 2.23
+  Enabled: false
+FactoryBot/IdSequence:  # new in 2.24
+  Enabled: false
+FactoryBot/RedundantFactoryOption:  # new in 2.23
+  Enabled: false
+Capybara/FindAllFirst:  # new in 2.22
+  Enabled: false
+Capybara/NegationMatcherAfterVisit:  # new in 2.22
+  Enabled: false
+Capybara/RedundantWithinFind:  # new in 2.20
+  Enabled: false
+Capybara/RSpec/HaveSelector:  # new in 2.19
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -31,11 +31,14 @@ group :development do
   gem "pry", '~> 0.10',                          require: false
   gem "simplecov-console", '~> 0.5',             require: false
   gem "puppet-debugger", '~> 1.0',               require: false
-  gem "rubocop", '= 1.48.1',                     require: false
-  gem "rubocop-performance", '= 1.16.0',         require: false
-  gem "rubocop-rspec", '= 2.19.0',               require: false
+  gem "rubocop", '= 1.79.0',                     require: false
+  gem "rubocop-performance", '= 1.25.0',         require: false
+  gem "rubocop-rspec", '= 3.6.0',                require: false
+  gem "rubocop-rspec_rails", '~> 2.31.0',        require: false
+  gem "rubocop-factory_bot", '~> 2.27.1',        require: false
+  gem "rubocop-capybara", '~> 2.22.1',           require: false
   gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "bolt", '>= 3.27.2',                       require: false
+  gem "bolt", '>= 4.0.0',                        require: false
   gem "github_changelog_generator", '1.16.4',    require: false
   gem "octokit", '4.21.0',                       require: false
   gem "orchestrator_client", '< 0.7.1',          require: false

--- a/spec/plans/subplans/install_spec.rb
+++ b/spec/plans/subplans/install_spec.rb
@@ -26,7 +26,7 @@ describe 'peadm::subplans::install' do
 
     #########
     ## <🤮>
-    # rubocop:disable AnyInstance
+    # rubocop:disable RSpec/AnyInstance
     allow(Tempfile).to receive(:new).and_call_original
     allow(Pathname).to receive(:new).and_call_original
     allow(Puppet::FileSystem).to receive(:exist?).and_call_original
@@ -40,7 +40,7 @@ describe 'peadm::subplans::install' do
     allow_any_instance_of(BoltSpec::Plans::MockExecutor).to receive(:module_file_id).with('/mock').and_return('/mock')
 
     allow_upload('/mock')
-    # rubocop:enable AnyInstance
+    # rubocop:enable RSpec/AnyInstance
     ## </🤮>
     ##########
   end

--- a/spec/plans/util/retrieve_and_upload_spec.rb
+++ b/spec/plans/util/retrieve_and_upload_spec.rb
@@ -15,7 +15,7 @@ describe 'peadm::util::retrieve_and_upload' do
 
     #########
     ## <🤮>
-    # rubocop:disable AnyInstance
+    # rubocop:disable RSpec/AnyInstance
     allow(Pathname).to receive(:new).and_call_original
     allow(Puppet::FileSystem).to receive(:exist?).and_call_original
     allow_any_instance_of(BoltSpec::Plans::MockExecutor).to receive(:module_file_id).and_call_original
@@ -36,7 +36,7 @@ describe 'peadm::util::retrieve_and_upload' do
         Bolt::ResultSet.new(results)
       end
 
-    # rubocop:enable AnyInstance
+    # rubocop:enable RSpec/AnyInstance
     ## </🤮>
     ##########
 


### PR DESCRIPTION
## Summary
Gem version bumps to address rexml CVE flagged by [PE Mend scan](https://saas-eu.whitesourcesoftware.com/Wss/WSS.html#!librarySecurityAlertsReport)

## Checklist
- [] 🟢 Spec tests.
- [] 🟢 Acceptance tests.

#### Changes include test coverage?
- [] Yes
- [x] Not needed

#### Have you updated the documentation?
- [] Yes, I've updated the appropriate docs
- [x] Not needed
