### PR TITLE
Install required packages and locales before installation

### DIFF
--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -237,6 +237,8 @@ plan peadm::subplans::install (
     )
   }
 
+  run_task('peadm::preinstall', $all_targets)
+
   if $pe_installer_source {
     $pe_tarball_name = $pe_installer_source.split('/')[-1]
     $pe_tarball_source = $pe_installer_source

--- a/tasks/preinstall.json
+++ b/tasks/preinstall.json
@@ -1,0 +1,8 @@
+{
+  "puppet_task_version": 1,
+  "supports_noop": false,
+  "description": "Installs required packages, and configuration required before PE can be installed.",
+  "implementations": [
+    {"name": "preinstall.sh"}
+  ]
+}

--- a/tasks/preinstall.sh
+++ b/tasks/preinstall.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Setup required packages
+packages="curl gnupg"
+if command -v apt-get >/dev/null 2>&1; then
+    apt-get update
+    apt-get install -y ${packages} locales
+
+    # Generate en_US.UTF-8 locale for PuppetDB
+    if ! locale-gen en_US.UTF-8; then
+        echo "Failed to generate locale en_US.UTF-8" >&2
+        exit 1
+    fi
+elif command -v yum >/dev/null 2>&1; then
+    yum install -y ${packages} glibc-langpack-en
+else
+    echo "No supported package manager found (apt-get or yum required)." >&2
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
Some operating systems don't have all required packages and locales installed by default.

This PR ensures `curl` and `gnupg` are installed for the enterprise install script, and that locale `en_US.UTF-8` is generated for PuppetDB.

## Checklist
- [ ] 🟢 Spec tests.
- [X] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [X] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [X] Not needed
