### PR TITLE
allow puppet/format 2.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppet/format",
-      "version_requirement": ">= 0.1.0 < 2.0.0"
+      "version_requirement": ">= 0.1.0 < 3.0.0"
     },
     {
       "name": "puppetlabs/service",


### PR DESCRIPTION
## Summary

PE-ADM metadata updated

## Additional Context

```
r10k puppetfile install -v
├─┬ puppetlabs-peadm (v3.34.0)
│ ├── puppet-format (v2.0.0)  invalid
```

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [ ] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [x] Not needed
