### PR TITLE
(PE-44022) Add cloud_database_host parameter for cloud-DB-backed installs

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2175,6 +2175,7 @@ The following parameters are available in the `peadm::install` plan:
 * [`final_agent_state`](#-peadm--install--final_agent_state)
 * [`stagingdir`](#-peadm--install--stagingdir)
 * [`uploaddir`](#-peadm--install--uploaddir)
+* [`cloud_database_host`](#-peadm--install--cloud_database_host)
 * [`primary_host`](#-peadm--install--primary_host)
 * [`replica_host`](#-peadm--install--replica_host)
 * [`compiler_hosts`](#-peadm--install--compiler_hosts)
@@ -2272,6 +2273,21 @@ Data type: `Optional[String]`
 
 Directory the installer tarball will be uploaded to or expected to be in
 for offline usage.
+
+Default value: `undef`
+
+##### <a name="-peadm--install--cloud_database_host"></a>`cloud_database_host`
+
+Data type: `Optional[Stdlib::Host]`
+
+When set, declares that the PE PostgreSQL database is hosted externally
+(e.g. on Google Cloud SQL) at the given host. PEADM will not create or
+manage the PE Database node group and will not write the primary's
+certname into puppetdb's database_host on any classifier group. The
+cloud database host is propagated to the compiler classifier groups so
+that compilers can reach PuppetDB's external database. Leave unset for
+the default on-prem topology where Postgres runs on the primary or on a
+managed external Postgres target.
 
 Default value: `undef`
 

--- a/manifests/setup/node_manager.pp
+++ b/manifests/setup/node_manager.pp
@@ -12,7 +12,7 @@
 #                 environments => ["production", "staging", "development"],
 #               }'
 #
-# @param compiler_pool_address 
+# @param compiler_pool_address
 #   The service address used by agents to connect to compilers, or the Puppet
 #   service. Typically this is a load balancer.
 # @param internal_compiler_a_pool_address
@@ -24,6 +24,17 @@
 #   compilers. This is used for DR configuration in large and extra large
 #   architectures.
 # @param node_group_environment the environment that will be assigned to all the PE Infra node groups
+# @param cloud_database_host
+#   When set, declares that PE's PostgreSQL database is hosted externally at
+#   the given host (e.g. Google Cloud SQL). The PE Database node group is
+#   not created (the cloud endpoint is not a PEADM-managed target), the
+#   puppet_enterprise::profile::puppetdb entry is omitted from the PE
+#   Primary A and PE Primary B classifier config_data (the cloud DB host is
+#   expected to be authoritatively declared in pe_install's PE PuppetDB
+#   classifier group instead), and the puppet_enterprise::profile::puppetdb
+#   database_host class parameter on PE Compiler Group A/B is set to this
+#   value so compilers reach the external database. Leave unset for the
+#   default on-prem topology.
 #
 class peadm::setup::node_manager (
   String[1] $primary_host,
@@ -38,6 +49,8 @@ class peadm::setup::node_manager (
   Optional[String[1]] $internal_compiler_a_pool_address = $server_a_host,
   Optional[String[1]] $internal_compiler_b_pool_address = $server_b_host,
   String[1]           $node_group_environment           = 'production',
+
+  Optional[Stdlib::Host] $cloud_database_host           = undef,
 ) {
   # "Not-configured" placeholder string. This will be used in places where we
   # cannot set an explicit null, and need to supply some kind of value.
@@ -90,24 +103,30 @@ class peadm::setup::node_manager (
   }
 
   # This group should pin the primary, and also map to any pe-postgresql nodes
-  # which are part of the architecture.
-  node_group { 'PE Database':
-    rule => ['or',
-      ['and', ['=', ['trusted', 'extensions', peadm::oid('peadm_role')], 'puppet/puppetdb-database']],
-      ['=', 'name', $primary_host],
-    ],
+  # which are part of the architecture. When PE's database is hosted externally
+  # (cloud_database_host is set), there is no PEADM-managed Postgres node to
+  # classify here, so the group is omitted entirely.
+  unless $cloud_database_host {
+    node_group { 'PE Database':
+      rule => ['or',
+        ['and', ['=', ['trusted', 'extensions', peadm::oid('peadm_role')], 'puppet/puppetdb-database']],
+        ['=', 'name', $primary_host],
+      ],
+    }
   }
 
   # Create data-only groups to store PuppetDB PostgreSQL database configuration
   # information specific to the primary and primary replica nodes.
-  node_group { 'PE Primary A':
-    ensure => present,
-    parent => 'PE Infrastructure',
-    rule   => ['and',
-      ['=', ['trusted', 'extensions', peadm::oid('peadm_role')], 'puppet/server'],
-      ['=', ['trusted', 'extensions', peadm::oid('peadm_availability_group')], 'A'],
-    ],
-    data   => {
+  #
+  # In cloud database mode, the puppet_enterprise::profile::puppetdb entry is
+  # omitted from this group's config_data. The authoritative cloud DB host
+  # belongs in pe_install's PE PuppetDB classifier group; if PEADM also writes
+  # it via config_data here, the two declarations conflict in the classifier's
+  # flattened resolution view. The adjacent primary_master_replica
+  # database_host_puppetdb entry still tells the replica where PuppetDB's
+  # database lives, so it carries the cloud DB host instead.
+  $primary_a_data = $cloud_database_host ? {
+    undef   => {
       'puppet_enterprise::profile::primary_master_replica' => {
         'database_host_puppetdb' => pick($postgresql_a_host, $notconf),
       },
@@ -115,7 +134,27 @@ class peadm::setup::node_manager (
         'database_host' => pick($postgresql_a_host, $notconf),
       },
     },
+    default => {
+      'puppet_enterprise::profile::primary_master_replica' => {
+        'database_host_puppetdb' => $cloud_database_host,
+      },
+    },
   }
+
+  node_group { 'PE Primary A':
+    ensure => present,
+    parent => 'PE Infrastructure',
+    rule   => ['and',
+      ['=', ['trusted', 'extensions', peadm::oid('peadm_role')], 'puppet/server'],
+      ['=', ['trusted', 'extensions', peadm::oid('peadm_availability_group')], 'A'],
+    ],
+    data   => $primary_a_data,
+  }
+
+  # Compilers must know where puppetdb's database lives to talk to it directly.
+  # When a cloud database host is supplied, prefer it; otherwise fall back to
+  # the existing postgresql_a_host value.
+  $compiler_a_puppetdb_database_host = pick($cloud_database_host, $postgresql_a_host, $notconf)
 
   # Configure the A pool for compilers. There are up to two pools for DR, each
   # having an affinity for one "availability zone" or the other.
@@ -129,7 +168,7 @@ class peadm::setup::node_manager (
     ],
     classes        => {
       'puppet_enterprise::profile::puppetdb' => {
-        'database_host' => pick($postgresql_a_host, $notconf),
+        'database_host' => $compiler_a_puppetdb_database_host,
       },
       'puppet_enterprise::profile::master'   => {
         # lint:ignore:single_quote_string_with_variables
@@ -161,14 +200,10 @@ class peadm::setup::node_manager (
     variables => { 'peadm_replica' => true },
   }
 
-  node_group { 'PE Primary B':
-    ensure => present,
-    parent => 'PE Infrastructure',
-    rule   => ['and',
-      ['=', ['trusted', 'extensions', peadm::oid('peadm_role')], 'puppet/server'],
-      ['=', ['trusted', 'extensions', peadm::oid('peadm_availability_group')], 'B'],
-    ],
-    data   => {
+  # See PE Primary A above; the same cloud-DB treatment applies to the B
+  # availability group.
+  $primary_b_data = $cloud_database_host ? {
+    undef   => {
       'puppet_enterprise::profile::primary_master_replica' => {
         'database_host_puppetdb' => pick($postgresql_b_host, $notconf),
       },
@@ -176,7 +211,24 @@ class peadm::setup::node_manager (
         'database_host' => pick($postgresql_b_host, $notconf),
       },
     },
+    default => {
+      'puppet_enterprise::profile::primary_master_replica' => {
+        'database_host_puppetdb' => $cloud_database_host,
+      },
+    },
   }
+
+  node_group { 'PE Primary B':
+    ensure => present,
+    parent => 'PE Infrastructure',
+    rule   => ['and',
+      ['=', ['trusted', 'extensions', peadm::oid('peadm_role')], 'puppet/server'],
+      ['=', ['trusted', 'extensions', peadm::oid('peadm_availability_group')], 'B'],
+    ],
+    data   => $primary_b_data,
+  }
+
+  $compiler_b_puppetdb_database_host = pick($cloud_database_host, $postgresql_b_host, $notconf)
 
   node_group { 'PE Compiler Group B':
     ensure         => 'present',
@@ -188,7 +240,7 @@ class peadm::setup::node_manager (
     ],
     classes        => {
       'puppet_enterprise::profile::puppetdb' => {
-        'database_host' => pick($postgresql_b_host, $notconf),
+        'database_host' => $compiler_b_puppetdb_database_host,
       },
       'puppet_enterprise::profile::master'   => {
         # lint:ignore:single_quote_string_with_variables

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -30,6 +30,15 @@
 # @param uploaddir
 #   Directory the installer tarball will be uploaded to or expected to be in
 #   for offline usage.
+# @param cloud_database_host
+#   When set, declares that the PE PostgreSQL database is hosted externally
+#   (e.g. on Google Cloud SQL) at the given host. PEADM will not create or
+#   manage the PE Database node group and will not write the primary's
+#   certname into puppetdb's database_host on any classifier group. The
+#   cloud database host is propagated to the compiler classifier groups so
+#   that compilers can reach PuppetDB's external database. Leave unset for
+#   the default on-prem topology where Postgres runs on the primary or on a
+#   managed external Postgres target.
 #
 plan peadm::install (
   # Standard
@@ -43,6 +52,9 @@ plan peadm::install (
   # Extra Large
   Optional[Peadm::SingleTargetSpec] $primary_postgresql_host = undef,
   Optional[Peadm::SingleTargetSpec] $replica_postgresql_host = undef,
+
+  # Cloud Database
+  Optional[Stdlib::Host]            $cloud_database_host = undef,
 
   # Common Configuration
   String                            $console_password,
@@ -148,6 +160,9 @@ plan peadm::install (
     internal_compiler_b_pool_address => $internal_compiler_b_pool_address,
     deploy_environment               => $deploy_environment,
     ldap_config                      => $ldap_config,
+
+    # Cloud Database
+    cloud_database_host              => $cloud_database_host,
 
     # Other
     stagingdir                       => $stagingdir,

--- a/plans/subplans/configure.pp
+++ b/plans/subplans/configure.pp
@@ -19,6 +19,11 @@
 # @param final_agent_state
 #   Configures the state the puppet agent should be in on infrastructure nodes
 #   after PE is configured successfully.
+# @param cloud_database_host
+#   When set, declares that the PE PostgreSQL database is hosted externally
+#   at the given host. Propagated to peadm::setup::node_manager so the
+#   classifier groups it manages do not pin the primary's certname as the
+#   puppetdb database host. Leave unset for the default on-prem topology.
 #
 plan peadm::subplans::configure (
   # Standard
@@ -32,6 +37,9 @@ plan peadm::subplans::configure (
   # Extra Large
   Optional[Peadm::SingleTargetSpec] $primary_postgresql_host = undef,
   Optional[Peadm::SingleTargetSpec] $replica_postgresql_host = undef,
+
+  # Cloud Database
+  Optional[Stdlib::Host]            $cloud_database_host = undef,
 
   # Common Configuration
   String                       $compiler_pool_address            = $primary_host.peadm::certname(),
@@ -106,6 +114,7 @@ plan peadm::subplans::configure (
       compiler_pool_address            => $compiler_pool_address,
       internal_compiler_a_pool_address => $internal_compiler_a_pool_address,
       internal_compiler_b_pool_address => $internal_compiler_b_pool_address,
+      cloud_database_host              => $cloud_database_host,
       require                          => Class['peadm::setup::node_manager_yaml'],
     }
   }

--- a/spec/classes/setup/node_manager_spec.rb
+++ b/spec/classes/setup/node_manager_spec.rb
@@ -1,0 +1,131 @@
+require 'spec_helper'
+
+describe 'peadm::setup::node_manager' do
+  # spec_helper_local.rb calls BoltSpec::Plans.init, which sets
+  # Puppet[:tasks] = true (Bolt's plan/script mode). In that mode the
+  # initial manifest import treats resource statements as illegal,
+  # blocking catalogue compilation for class specs. Restore catalog mode
+  # for every example in this describe.
+  before(:each) { Puppet[:tasks] = false }
+
+  let(:primary_host) { 'primary.example.com' }
+  let(:base_params) do
+    {
+      'primary_host'  => primary_host,
+      'server_a_host' => primary_host,
+    }
+  end
+
+  # PEADM's compiler-group classes property always carries both the puppetdb
+  # entry (whose database_host is the value under test) and a master entry
+  # that varies with the internal_compiler_*_pool_address parameters.
+  # rspec-puppet's `.with_X` matcher compares for strict equality, not
+  # partial match, so we provide the full expected hash here.
+  let(:compiler_master_a) do
+    {
+      # In this fixture server_b_host is undef, so
+      # internal_compiler_b_pool_address resolves to undef and is filtered.
+      'puppetdb_host' => ["${trusted['certname']}"],
+      'puppetdb_port' => [8081],
+    }
+  end
+  let(:compiler_master_b) do
+    {
+      # server_a_host is set, so internal_compiler_a_pool_address resolves to it.
+      'puppetdb_host' => ["${trusted['certname']}", primary_host],
+      'puppetdb_port' => [8081],
+    }
+  end
+
+  # Each example triggers an independent catalogue compile. Puppet's type
+  # autoloader and APL initialisation may misbehave on the FIRST compile in
+  # an rspec process for this module (e.g. "Resource type not found: Node_group"
+  # before the node_manager fixture's custom type is registered), but
+  # succeeds on subsequent compiles thanks to cached state. Consolidating
+  # each context's assertions into a single `it` block keeps every context
+  # to a single compile, sidestepping the first-compile fragility.
+
+  # The very first catalogue compile in a process tends to fail with
+  # "Resource type not found: Node_group" before Puppet's type loader has
+  # populated its cache from the node_manager fixture; subsequent compiles
+  # in the same process succeed. This throwaway example absorbs the
+  # first-compile fragility so the real assertions below run against a
+  # primed loader.
+  context 'warm-up to prime the Puppet type loader' do
+    let(:params) { base_params }
+    it 'attempts a catalogue compile and tolerates a first-compile failure' do
+      catalogue
+    rescue
+      # Intentionally swallowed; only the next compile onward matters.
+    end
+  end
+
+  context 'when cloud_database_host is set' do
+    let(:cloud_host) { 'cloud-sql.example.com' }
+    let(:params) { base_params.merge('cloud_database_host' => cloud_host) }
+
+    it 'routes all puppetdb database_host references to the cloud DB and omits the local-Postgres groups' do
+      is_expected.not_to contain_node_group('PE Database')
+
+      is_expected.to contain_node_group('PE Primary A').with_data(
+        'puppet_enterprise::profile::primary_master_replica' => {
+          'database_host_puppetdb' => cloud_host,
+        },
+      )
+
+      is_expected.to contain_node_group('PE Primary B').with_data(
+        'puppet_enterprise::profile::primary_master_replica' => {
+          'database_host_puppetdb' => cloud_host,
+        },
+      )
+
+      is_expected.to contain_node_group('PE Compiler Group A').with_classes(
+        'puppet_enterprise::profile::puppetdb' => { 'database_host' => cloud_host },
+        'puppet_enterprise::profile::master'   => compiler_master_a,
+      )
+
+      is_expected.to contain_node_group('PE Compiler Group B').with_classes(
+        'puppet_enterprise::profile::puppetdb' => { 'database_host' => cloud_host },
+        'puppet_enterprise::profile::master'   => compiler_master_b,
+      )
+    end
+  end
+
+  context 'in the default on-prem topology (cloud_database_host unset)' do
+    let(:params) { base_params }
+
+    it 'produces the expected classifier groups for an on-prem PostgreSQL topology' do
+      # postgresql_b_host is undef in this fixture, so the b-side pick falls
+      # through to the $notconf placeholder.
+      is_expected.to contain_node_group('PE Database')
+
+      is_expected.to contain_node_group('PE Primary A').with_data(
+        'puppet_enterprise::profile::primary_master_replica' => {
+          'database_host_puppetdb' => primary_host,
+        },
+        'puppet_enterprise::profile::puppetdb' => {
+          'database_host' => primary_host,
+        },
+      )
+
+      is_expected.to contain_node_group('PE Primary B').with_data(
+        'puppet_enterprise::profile::primary_master_replica' => {
+          'database_host_puppetdb' => 'not-configured',
+        },
+        'puppet_enterprise::profile::puppetdb' => {
+          'database_host' => 'not-configured',
+        },
+      )
+
+      is_expected.to contain_node_group('PE Compiler Group A').with_classes(
+        'puppet_enterprise::profile::puppetdb' => { 'database_host' => primary_host },
+        'puppet_enterprise::profile::master'   => compiler_master_a,
+      )
+
+      is_expected.to contain_node_group('PE Compiler Group B').with_classes(
+        'puppet_enterprise::profile::puppetdb' => { 'database_host' => 'not-configured' },
+        'puppet_enterprise::profile::master'   => compiler_master_b,
+      )
+    end
+  end
+end

--- a/spec/classes/setup/node_manager_spec.rb
+++ b/spec/classes/setup/node_manager_spec.rb
@@ -53,6 +53,7 @@ describe 'peadm::setup::node_manager' do
   # primed loader.
   context 'warm-up to prime the Puppet type loader' do
     let(:params) { base_params }
+
     it 'attempts a catalogue compile and tolerates a first-compile failure' do
       catalogue
     rescue

--- a/spec/classes/setup/node_manager_spec.rb
+++ b/spec/classes/setup/node_manager_spec.rb
@@ -37,26 +37,28 @@ describe 'peadm::setup::node_manager' do
     }
   end
 
-  # Each example triggers an independent catalogue compile. Puppet's type
-  # autoloader and APL initialisation may misbehave on the FIRST compile in
-  # an rspec process for this module (e.g. "Resource type not found: Node_group"
-  # before the node_manager fixture's custom type is registered), but
-  # succeeds on subsequent compiles thanks to cached state. Consolidating
-  # each context's assertions into a single `it` block keeps every context
-  # to a single compile, sidestepping the first-compile fragility.
-
-  # The very first catalogue compile in a process tends to fail with
-  # "Resource type not found: Node_group" before Puppet's type loader has
-  # populated its cache from the node_manager fixture; subsequent compiles
-  # in the same process succeed. This throwaway example absorbs the
-  # first-compile fragility so the real assertions below run against a
-  # primed loader.
-  context 'warm-up to prime the Puppet type loader' do
+  # WORKAROUND: the *first* catalogue compile in this rspec process fails with
+  # "Resource type not found: Node_group" even though the node_manager
+  # fixture's custom type is on the load path and in Puppet::Type's registry.
+  # The cause is spec_helper_local.rb calling BoltSpec::Plans.init, which runs
+  # Bolt::PAL.load_puppet and sets Puppet[:tasks] = true at load time. Bolt's
+  # own source warns this is "probably not safe to do in modules that also
+  # test Puppet manifest code" (bolt gem: lib/bolt_spec/plans.rb). That
+  # initialisation leaves the environment's resource-type loader unable to
+  # resolve the native type until one compile has run; the act of compiling
+  # once repairs it for the remainder of the process.
+  #
+  # peadm is otherwise a Bolt-plan module, so this is its only catalogue
+  # spec and the only place the contamination surfaces. A single throwaway
+  # compile primes the loader for every example that follows -- only the very
+  # first compile in the process is affected, not the first compile per
+  # context, so granular examples below are safe.
+  context 'warm-up to prime the contaminated resource-type loader' do
     let(:params) { base_params }
 
-    it 'attempts a catalogue compile and tolerates a first-compile failure' do
+    it 'absorbs the first-compile failure caused by BoltSpec::Plans.init' do
       catalogue
-    rescue
+    rescue StandardError
       # Intentionally swallowed; only the next compile onward matters.
     end
   end

--- a/spec/plans/install_spec.rb
+++ b/spec/plans/install_spec.rb
@@ -11,4 +11,25 @@ describe 'peadm::install' do
       expect(run_plan('peadm::install', 'primary_host' => 'primary', 'console_password' => 'puppetLabs123!', 'version' => '2021.7.9')).to be_ok
     end
   end
+
+  describe 'cloud_database_host plumbing' do
+    # bolt-spec's `with_params` compares for strict equality and does not
+    # honour rspec matchers like hash_including, so fine-grained param
+    # assertions are awkward here. Confirm at minimum that providing
+    # cloud_database_host does not break the install plan; the more
+    # specific tests for the parameter's effect live in
+    # spec/classes/setup/node_manager_spec.rb (verifying what the value
+    # produces) and the configure subplan accepts the same parameter
+    # signature by virtue of compiling.
+    it 'accepts cloud_database_host and runs the plan to completion' do
+      allow_out_message
+      expect_plan('peadm::subplans::install')
+      expect_plan('peadm::subplans::configure')
+      expect(run_plan('peadm::install',
+        'primary_host'        => 'primary',
+        'console_password'    => 'puppetLabs123!',
+        'version'             => '2021.7.9',
+        'cloud_database_host' => 'cloud-sql.example.com')).to be_ok
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Adds an optional `cloud_database_host` parameter to `peadm::install`, threaded through `peadm::subplans::configure` into `peadm::setup::node_manager`.
- When set, PEADM stops claiming authority over the puppetdb database host: skips the `PE Database` classifier group, omits the conflicting `puppet_enterprise::profile::puppetdb` entry from `PE Primary A`/`PE Primary B`'s `config_data` (their `primary_master_replica.database_host_puppetdb` is routed to the cloud DB host instead), and substitutes the cloud DB host on `PE Compiler Group A`/`PE Compiler Group B`'s `puppet_enterprise::profile::puppetdb.database_host`.
- Default behaviour (parameter unset) is byte-for-byte unchanged.
- New class spec coverage for both topologies; existing plan specs preserved.

Jira: [PE-44022](https://perforce.atlassian.net/browse/PE-44022)
Epic: [PE-41124](https://perforce.atlassian.net/browse/PE-41124)
Related: [PE-43923](https://perforce.atlassian.net/browse/PE-43923) — the parallel `pe_install` change in `puppet-enterprise-modules`. Both must land together to deliver an end-to-end cloud DB install: the `pe_install` change makes `PE PuppetDB` declare the cloud DB host authoritatively, and this PEADM change stops `PE Primary A`/`B` from declaring a conflicting value.

## Test plan

- [x] \`bundle exec rake spec_standalone\` — 108 examples, 0 failures (6 pre-existing pending)
- [x] \`bundle exec rake syntax lint\` — clean on changed files
- [x] End-to-end install on Ubuntu 24.04 SUT against Google Cloud SQL (single-primary topology), combined with PE-43923's \`pe_install\` changes — no classifier conflict, all services running and \`db_up: true\`, two consecutive \`puppet agent -t\` runs idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)