### PR TITLE
(PE-44595) Don't emit empty dns_alt_names flag in subplans::install

### DIFF
--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -137,7 +137,17 @@ plan peadm::subplans::install (
     $legacy_b_targets   = []
   }
 
-  $dns_alt_names_csv = $dns_alt_names.reduce |$csv,$x| { "${csv},${x}" }
+  # Only set dns_alt_names when the operator actually supplied some. Emitting
+  # `main:dns_alt_names=` with an empty value writes a present-but-empty
+  # `dns_alt_names = ` line into the agent's puppet.conf. That line later
+  # crashes `puppetserver ca generate` (puppetserver-ca munge_alt_names reads
+  # the key as nil rather than the absent-key default) when console/SAML certs
+  # are generated during a DR replica promotion, bricking pe-console-services.
+  # See PE-44595. Mirrors the guard in subplans/prepare_agent.pp.
+  $dns_alt_names_flag = $dns_alt_names.empty ? {
+    true    => [],
+    default => ["main:dns_alt_names=${dns_alt_names.join(',')}"],
+  }
 
   # Process user input for r10k private key (file or content) and set
   # appropriate value in $r10k_private_key. The value of this variable should
@@ -413,9 +423,8 @@ plan peadm::subplans::install (
   parallelize($agent_installer_targets) |$target| {
     $common_install_flags = [
       '--puppet-service-ensure', 'stopped',
-      "main:dns_alt_names=${dns_alt_names_csv}",
       "main:certname=${target.peadm::certname()}",
-    ]
+    ] + $dns_alt_names_flag
 
     # Get an agent installed and cert signed
     run_task('peadm::agent_install', $target,

--- a/spec/plans/subplans/install_spec.rb
+++ b/spec/plans/subplans/install_spec.rb
@@ -96,4 +96,46 @@ describe 'peadm::subplans::install' do
     }
     expect(run_plan('peadm::subplans::install', params)).to be_ok
   end
+
+  # PE-44595: when no dns_alt_names are supplied we must NOT emit a
+  # `main:dns_alt_names=` flag, which would write a present-but-empty
+  # `dns_alt_names = ` line into the agent's puppet.conf and later crash
+  # `puppetserver ca generate` during a DR replica promotion.
+  it 'omits the dns_alt_names install flag when none are supplied' do
+    params = {
+      'primary_host' => 'primary',
+      'compiler_hosts' => ['compiler1'],
+      'console_password' => 'puppetLabs123!',
+      'version' => '2023.8.9',
+    }
+
+    expect_task('peadm::agent_install')
+      .with_params({ 'server'        => 'primary',
+                     'install_flags' => [
+                       '--puppet-service-ensure', 'stopped',
+                       'main:certname=compiler1'
+                     ] })
+
+    expect(run_plan('peadm::subplans::install', params)).to be_ok
+  end
+
+  it 'sets the dns_alt_names install flag when alt names are supplied' do
+    params = {
+      'primary_host' => 'primary',
+      'compiler_hosts' => ['compiler1'],
+      'console_password' => 'puppetLabs123!',
+      'version' => '2023.8.9',
+      'dns_alt_names' => ['puppet', 'alt.example.com'],
+    }
+
+    expect_task('peadm::agent_install')
+      .with_params({ 'server'        => 'primary',
+                     'install_flags' => [
+                       '--puppet-service-ensure', 'stopped',
+                       'main:certname=compiler1',
+                       'main:dns_alt_names=puppet,alt.example.com'
+                     ] })
+
+    expect(run_plan('peadm::subplans::install', params)).to be_ok
+  end
 end


### PR DESCRIPTION
## Problem

On a `standard-with-dr` install, every agent-installer target (compilers and the **replica**) is installed with these flags from `peadm::subplans::install`:

```puppet
$dns_alt_names_csv = $dns_alt_names.reduce |$csv,$x| { "${csv},${x}" }
...
"main:dns_alt_names=${dns_alt_names_csv}",
```

When the operator supplies no `dns_alt_names` (the default `[]`), `[].reduce` returns `undef`, so the flag interpolates to a bare `main:dns_alt_names=`. `peadm::agent_install` then runs `puppet config set dns_alt_names ''`, writing a **present-but-empty** line into the agent's `puppet.conf`:

```
dns_alt_names =
```

## Impact (PE-44595, Blocker)

On a replica that is later **promoted during DR failover**, `puppet infrastructure promote` runs `puppetserver ca generate` to create the console/SAML certs. The vendored `puppetserver-ca` gem reads the present-but-empty key as `nil` (rather than the `''` default that an *absent* key yields), and `munge_alt_names(nil)` raises:

```
puppetserver/ca/utils/config.rb:12:in `munge_alt_names':
  undefined method `split' for nil:NilClass (NoMethodError)
```

The console/SAML certs are never written, `pe-console-services` crash-loops on init (`saml-cert.cert.pem does not exist`), the Node Manager goes down, catalog compilation fails with HTTP 500, and the promoted primary's console UI is unavailable. The original primary is unaffected because it is installed by the PE installer (not `agent_install`) and so has **no** `dns_alt_names` line at all.

## Fix

Only emit the `main:dns_alt_names=...` flag when alt names are actually supplied, mirroring the existing guard in `subplans/prepare_agent.pp`. When the array is empty, omit the key entirely — matching what the primary already does.

## Testing

- `bundle exec rspec spec/plans/subplans/install_spec.rb` — 7 examples, 0 failures.
- Two new examples assert the flag is **omitted** when no alt names are supplied and **present** (`main:dns_alt_names=puppet,alt.example.com`) when they are.
- `puppet-lint plans/subplans/install.pp` clean.

## Notes

This is the PE-side half of PE-44595. A companion defensive fix is proposed upstream in `puppetserver-ca-cli` so that *any* caller is tolerant of a present-but-empty `dns_alt_names`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)