### PR TITLE
Pin i18n < 1.15.0 on Ruby < 3.2 to fix acceptance CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,9 @@ group :development do
   gem "json", '= 2.6.1',                         require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.7.2',                         require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "racc", '~> 1.4.0',                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  # i18n >= 1.15.0 uses Fiber[] (Fiber storage), which requires Ruby >= 3.2. Pin to the
+  # last 3.1-compatible release on older Rubies so rake spec_prep doesn't abort in CI.
+  gem "i18n", '< 1.15.0',                        require: false if Gem::Requirement.create('< 3.2.0').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
   gem "facterdb", '~> 1.18',                     require: false
   gem "metadata-json-lint", '~> 3.0',            require: false


### PR DESCRIPTION
## Summary

Acceptance jobs (and `main`'s scheduled nightlies) are fast-failing at the `rake spec_prep` prepare step, before any VM provisioning:

```
rake aborted!
NoMethodError: undefined method `[]' for Fiber:Class
    current = Fiber[:i18n_config] || self.config = I18n::Config.new
.../gems/i18n-1.15.0/lib/i18n.rb:58:in `config'
  <- activesupport <- github_changelog_generator 1.16.4 <- puppetlabs_spec_helper rake_tasks <- Rakefile
```

**Root cause:** `i18n` 1.15.0 uses `Fiber[]` (Fiber storage), which requires Ruby >= 3.2. The acceptance jobs run on **Ruby 3.1**. Since `Gemfile.lock` is not committed, CI resolves gems fresh on every run and started pulling the newly-released `i18n` 1.15.0. The Spec job runs on Ruby 3.2 and is unaffected.

**Fix:** a Ruby-version-conditional pin in the Gemfile (matching the existing `json`/`racc` idiom) that constrains `i18n` to the last 3.1-compatible release only on Ruby < 3.2, leaving newer Rubies unconstrained.

This is independent of any PE version bump — it unblocks acceptance CI on `main` for everyone. Surfaced while working PE-44473 (2023.8.10 / 2025.11.0 support); splitting it out so it isn't gated on that release.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [x] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [x] Not needed