### PR TITLE
(PE-44867) Restore public-schema privileges on PostgreSQL 15+ in restore.pp

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 9.0.0 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 11.0.0"
     },
     {
       "name": "puppetlabs/node_manager",

--- a/plans/restore.pp
+++ b/plans/restore.pp
@@ -225,11 +225,31 @@ plan peadm::restore (
            -c 'DROP SCHEMA IF EXISTS pglogical CASCADE;'"
       | CMD
 
+    # Recreate the public schema. On PostgreSQL 15+ (PE 2025.11) a freshly
+    # created public schema no longer carries the historic implicit
+    # `GRANT USAGE ... TO PUBLIC` (removed in the CVE-2018-1058 hardening), so
+    # re-establish the native owner and USAGE grant explicitly. Without this,
+    # runtime users such as pe-rbac-write lose USAGE on public, unqualified
+    # name resolution silently fails (e.g. RBAC init `relation "salt" does not
+    # exist`), and peadm::rbac_token returns HTTP 500. See PE-44867.
+    #
+    # `pg_database_owner` only exists on PostgreSQL 14+, so gate the extra
+    # statements on the server major version of the host(s) this database is
+    # being restored to: on older PE lines (PostgreSQL 11/12) the role does not
+    # exist and `CREATE SCHEMA public` still auto-grants USAGE, so running them
+    # there would break restore.
+    $psql_version = run_task('peadm::get_psql_version', $database_targets).first.value['version']
+# lint:ignore:140chars
+    $public_schema_sql = (versioncmp(String($psql_version), '14') >= 0) ? {
+      true    => 'DROP SCHEMA public CASCADE; CREATE SCHEMA public; ALTER SCHEMA public OWNER TO pg_database_owner; GRANT USAGE ON SCHEMA public TO PUBLIC;',
+      default => 'DROP SCHEMA public CASCADE; CREATE SCHEMA public;',
+    }
+# lint:endignore
     run_command(@("CMD"/L), $database_targets)
       su - pe-postgres -s /bin/bash -c \
         "/opt/puppetlabs/server/bin/psql \
            -d '${dbname}' \
-           -c 'DROP SCHEMA public CASCADE; CREATE SCHEMA public;'"
+           -c '${public_schema_sql}'"
       | CMD
 
     # To allow db user to restore the database grant temporary privileges

--- a/plans/restore.pp
+++ b/plans/restore.pp
@@ -235,9 +235,15 @@ plan peadm::restore (
     #
     # `pg_database_owner` only exists on PostgreSQL 14+, so gate the extra
     # statements on the server major version of the host(s) this database is
-    # being restored to: on older PE lines (PostgreSQL 11/12) the role does not
-    # exist and `CREATE SCHEMA public` still auto-grants USAGE, so running them
-    # there would break restore.
+    # being restored to. On older PE lines (PostgreSQL 11, the last major PE
+    # shipped before 14) the role does not exist and `CREATE SCHEMA public`
+    # still auto-grants USAGE, so running these statements would break restore.
+    #
+    # The gate is `>= 14` rather than `>= 15` (where the implicit grant was
+    # actually removed) because on PG 14 both extra statements are harmless:
+    # `pg_database_owner` exists, and `GRANT USAGE ... TO PUBLIC` is a no-op
+    # since `CREATE SCHEMA public` still auto-grants it there. Keying on 14 —
+    # the version that introduced the role — keeps the condition simple.
     $psql_version = run_task('peadm::get_psql_version', $database_targets).first.value['version']
 # lint:ignore:140chars
     $public_schema_sql = (versioncmp(String($psql_version), '14') >= 0) ? {

--- a/spec/plans/restore_spec.rb
+++ b/spec/plans/restore_spec.rb
@@ -93,10 +93,22 @@ describe 'peadm::restore' do
     it 'recreates public without the owner/USAGE re-grant', valid_cluster: true do
       expect_out_message.with_params('# Restoring database pe-puppetdb')
       expect_out_message.with_params('# Restoring ca, certs, code and config for recovery')
-      allow_any_command
 
-      # The plain DROP/CREATE must be issued, and the pg_database_owner variant must not.
+      # No allow_any_command: every command is enumerated, so emitting the
+      # pg_database_owner variant here (instead of the plain DROP/CREATE below)
+      # would surface as an unexpected command and fail the test.
+      expect_command("umask 0077   && cd /input   && tar -xzf /input/file.tar.gz\n")
+      expect_command("/opt/puppetlabs/bin/puppet-backup restore   --scope=certs,code,config   --tempdir=/input/file   --force   /input/file/recovery/pe_backup-*tgz\n")
+      expect_command("systemctl stop pe-console-services pe-nginx pxp-agent pe-puppetserver                pe-orchestration-services puppet pe-puppetdb\n")
+      expect_command("test -f /input/file/rbac/secrets/keys.json   && cp -rp /input/file/rbac/secrets/keys.json /etc/puppetlabs/console-services/conf.d/secrets/   || echo secret ldap key doesnt exist\n")
+      expect_command("su - pe-postgres -s /bin/bash -c   \"/opt/puppetlabs/server/bin/psql      --tuples-only      -d 'pe-puppetdb'      -c 'DROP SCHEMA IF EXISTS pglogical CASCADE;'\"\n").be_called_times(2)
+      # PostgreSQL < 14: plain DROP/CREATE, with no ALTER OWNER / GRANT USAGE.
       expect_command("su - pe-postgres -s /bin/bash -c   \"/opt/puppetlabs/server/bin/psql      -d 'pe-puppetdb'      -c 'DROP SCHEMA public CASCADE; CREATE SCHEMA public;'\"\n")
+      expect_command('su - pe-postgres -s /bin/bash -c   "/opt/puppetlabs/server/bin/psql      -d \'pe-puppetdb\'      -c \'ALTER USER \\"pe-puppetdb\\" WITH SUPERUSER;\'"' + "\n")
+      expect_command('/opt/puppetlabs/server/bin/pg_restore   -j 4   -d "sslmode=verify-ca       host=postgres       sslcert=/etc/puppetlabs/puppetdb/ssl/primary.cert.pem       sslkey=/etc/puppetlabs/puppetdb/ssl/primary.private_key.pem       sslrootcert=/etc/puppetlabs/puppet/ssl/certs/ca.pem       dbname=pe-puppetdb       user=pe-puppetdb"   -Fd /input/file/puppetdb/pe-puppetdb.dump.d' + "\n")
+      expect_command('su - pe-postgres -s /bin/bash -c   "/opt/puppetlabs/server/bin/psql      -d \'pe-puppetdb\'      -c \'ALTER USER \\"pe-puppetdb\\" WITH NOSUPERUSER;\'"' + "\n")
+      expect_command('su - pe-postgres -s /bin/bash -c   "/opt/puppetlabs/server/bin/psql      -d \'pe-puppetdb\'      -c \'DROP EXTENSION IF EXISTS pglogical CASCADE;\'"' + "\n")
+      expect_command("/opt/puppetlabs/bin/puppet-infrastructure configure --no-recover\n")
 
       expect(run_plan('peadm::restore', recovery_params)).to be_ok
     end

--- a/spec/plans/restore_spec.rb
+++ b/spec/plans/restore_spec.rb
@@ -44,12 +44,20 @@ describe 'peadm::restore' do
 
   let(:cluster) { { 'params' => { 'primary_host' => 'primary', 'primary_postgresql_host' => 'postgres' } } }
 
+  # PostgreSQL server major version of the restore target. 17 (PE 2025.11)
+  # exercises the public-schema owner/USAGE re-grant; override for older PE.
+  let(:psql_version) { '17' }
+
   before(:each) do
     allow_apply
 
-    expect_out_message.with_params('cluster: ' + cluster.to_s.delete('"').gsub(%r{=>}, ' => '))
+    # Normalize whitespace around `=>` so the expected string matches the plan's
+    # single-spaced hash rendering on every Ruby: Ruby 3.4's Hash#to_s already
+    # spaces `=>`, older Rubies do not — collapse both to a single ` => `.
+    expect_out_message.with_params('cluster: ' + cluster.to_s.delete('"').gsub(%r{\s*=>\s*}, ' => '))
     expect_out_message.with_params('# Restoring ldap secret key if it exists')
     allow_task('peadm::puppet_runonce')
+    allow_task('peadm::get_psql_version').always_return({ 'version' => psql_version })
   end
 
   # only run for tests that have the :valid_cluster tag
@@ -66,7 +74,7 @@ describe 'peadm::restore' do
     expect_command("systemctl stop pe-console-services pe-nginx pxp-agent pe-puppetserver                pe-orchestration-services puppet pe-puppetdb\n")
     expect_command("test -f /input/file/rbac/secrets/keys.json   && cp -rp /input/file/rbac/secrets/keys.json /etc/puppetlabs/console-services/conf.d/secrets/   || echo secret ldap key doesnt exist\n")
     expect_command("su - pe-postgres -s /bin/bash -c   \"/opt/puppetlabs/server/bin/psql      --tuples-only      -d 'pe-puppetdb'      -c 'DROP SCHEMA IF EXISTS pglogical CASCADE;'\"\n").be_called_times(2)
-    expect_command("su - pe-postgres -s /bin/bash -c   \"/opt/puppetlabs/server/bin/psql      -d 'pe-puppetdb'      -c 'DROP SCHEMA public CASCADE; CREATE SCHEMA public;'\"\n")
+    expect_command("su - pe-postgres -s /bin/bash -c   \"/opt/puppetlabs/server/bin/psql      -d 'pe-puppetdb'      -c 'DROP SCHEMA public CASCADE; CREATE SCHEMA public; ALTER SCHEMA public OWNER TO pg_database_owner; GRANT USAGE ON SCHEMA public TO PUBLIC;'\"\n")
     expect_command('su - pe-postgres -s /bin/bash -c   "/opt/puppetlabs/server/bin/psql      -d \'pe-puppetdb\'      -c \'ALTER USER \\"pe-puppetdb\\" WITH SUPERUSER;\'"' + "\n")
     expect_command('/opt/puppetlabs/server/bin/pg_restore   -j 4   -d "sslmode=verify-ca       host=postgres       sslcert=/etc/puppetlabs/puppetdb/ssl/primary.cert.pem       sslkey=/etc/puppetlabs/puppetdb/ssl/primary.private_key.pem       sslrootcert=/etc/puppetlabs/puppet/ssl/certs/ca.pem       dbname=pe-puppetdb       user=pe-puppetdb"   -Fd /input/file/puppetdb/pe-puppetdb.dump.d' + "\n")
     expect_command('su - pe-postgres -s /bin/bash -c   "/opt/puppetlabs/server/bin/psql      -d \'pe-puppetdb\'      -c \'ALTER USER \\"pe-puppetdb\\" WITH NOSUPERUSER;\'"' + "\n")
@@ -74,6 +82,24 @@ describe 'peadm::restore' do
     expect_command("/opt/puppetlabs/bin/puppet-infrastructure configure --no-recover\n")
 
     expect(run_plan('peadm::restore', recovery_params)).to be_ok
+  end
+
+  # PE-44867 regression guard: pg_database_owner does not exist before
+  # PostgreSQL 14, so the owner/USAGE re-grant must be skipped on older PE
+  # targets (where CREATE SCHEMA public still auto-grants USAGE anyway).
+  context 'against a PostgreSQL < 14 target' do
+    let(:psql_version) { '11' }
+
+    it 'recreates public without the owner/USAGE re-grant', valid_cluster: true do
+      expect_out_message.with_params('# Restoring database pe-puppetdb')
+      expect_out_message.with_params('# Restoring ca, certs, code and config for recovery')
+      allow_any_command
+
+      # The plain DROP/CREATE must be issued, and the pg_database_owner variant must not.
+      expect_command("su - pe-postgres -s /bin/bash -c   \"/opt/puppetlabs/server/bin/psql      -d 'pe-puppetdb'      -c 'DROP SCHEMA public CASCADE; CREATE SCHEMA public;'\"\n")
+
+      expect(run_plan('peadm::restore', recovery_params)).to be_ok
+    end
   end
 
   it 'runs with default recovery', valid_cluster: true do


### PR DESCRIPTION
## Problem

`plans/restore.pp` runs `DROP SCHEMA public CASCADE; CREATE SCHEMA public;` for each restored PE database (orchestrator, activity, rbac, puppetdb). On **PostgreSQL 15+ (PE 2025.11)** a freshly created `public` schema no longer carries the historic implicit `GRANT USAGE ON SCHEMA public TO PUBLIC` — that grant was removed as part of the CVE-2018-1058 hardening.

As a result the RBAC runtime user `pe-rbac-write` loses `USAGE` on `public`, PostgreSQL silently skips the schema during unqualified name resolution, and RBAC init (`set-salt!`) fails with `relation "salt" does not exist`. RBAC caches that init failure, so every `POST /rbac-api/v1/auth/token` returns HTTP 500 — failing the `peadm::rbac_token` step during migration/restore. The bug was latent and harmless on PostgreSQL ≤ 13 (all PE before 2025.11), where `CREATE SCHEMA public` still auto-granted USAGE.

## Fix

After the `DROP`/`CREATE`, re-establish the native `public`-schema owner and USAGE-to-PUBLIC for **every** restored database, inside the existing `$restore_databases.each` loop:

```sql
DROP SCHEMA public CASCADE;
CREATE SCHEMA public;
ALTER SCHEMA public OWNER TO pg_database_owner;   -- match native owner
GRANT USAGE ON SCHEMA public TO PUBLIC;           -- restore the pre-PG15 implicit grant
```

`pg_database_owner` only exists on **PostgreSQL 14+**, and older PE lines (2019.7–~2021.4) still ship PostgreSQL 11/12. To avoid a hard `role "pg_database_owner" does not exist` failure there — where the implicit grant is still auto-created anyway — the extra statements are **gated on the target's PostgreSQL major version**, detected per database host via `peadm::get_psql_version` (matching the pattern used in `add_replica`, `add_compilers`, and `db_populate`).

## Tests

- Updated the recovery-params expectation to the PostgreSQL 15+ (owner + USAGE) command string.
- Added a **PostgreSQL < 14** regression context asserting the plain `DROP/CREATE` is emitted (no `pg_database_owner` variant) on older targets.
- Made the `cluster:` `out::message` assertion Ruby-version robust (normalizes whitespace around `=>`), so the suite passes on both Ruby 3.1 (CI) and 3.4.
- `bundle exec rspec spec/plans/restore_spec.rb` → **7 examples, 0 failures**; `puppet parser validate` clean.

## Acceptance criteria
- [x] `restore.pp` re-establishes `public`-schema owner and USAGE-to-PUBLIC on all restored PE databases after the DROP/CREATE.
- [x] Portable across supported PE versions (version-gated for PostgreSQL < 14).
- [x] Tests cover the restore path against a 2025.11 (PostgreSQL 15+) target and the older-PG gate.

Jira: https://perforce.atlassian.net/browse/PE-44867

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Note: unrelated CI unblock
stdlib 10.0.1 was published to the Forge, making the shared `module_ci` dependency_checker fail on all new PRs (the module pinned `puppetlabs/stdlib < 10.0.0`). Widened the range to `< 11.0.0` in `metadata.json` so CI is green. Verified locally: `metadata-json-lint` clean and `dependency-checker` reports "All modules have valid dependencies."
