### PR TITLE
fix url to AL2023 installer

### DIFF
--- a/tasks/precheck.sh
+++ b/tasks/precheck.sh
@@ -13,6 +13,9 @@ else
   osfamily="el"
   if grep -qi amazon /etc/os-release && grep -qi 'VERSION_ID="2"' /etc/os-release; then
     version=7
+  elif grep -qi amazon /etc/os-release && grep -qi 'VERSION_ID="2023"' /etc/os-release; then
+    osfamily="amazon"
+    version=2023
   fi
 fi
 


### PR DESCRIPTION
## Summary
currently, peadm is trying to download AL2023 installer from wrong url

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [ ] Yes
- [ ] Not needed

#### Have you updated the documentation?
- [ ] Yes, I've updated the appropriate docs
- [ ] Not needed
