### PR TITLE
(PE-43987) Preserve availability group identity in convert after a role swap

### DIFF
--- a/functions/availability_group_for.pp
+++ b/functions/availability_group_for.pp
@@ -1,0 +1,31 @@
+# @summary Determine which availability group ('A' or 'B') a node should be
+#   stamped with, preserving whatever value is already present on its
+#   certificate rather than deriving it from which plan parameter (e.g.
+#   primary_host vs replica_host) the node was passed as.
+#
+# This keeps A/B a stable, topological identity across role swaps performed
+# with PE's own switch_primary tooling: if a node already carries a valid A
+# or B extension, that value is kept even if it no longer matches the node's
+# current operational role. Only a node with no existing extension falls
+# back to $default (e.g. on a fresh conversion, where there's nothing yet to
+# preserve).
+#
+# @param cert_extensions Hash of certname => extensions hash, as gathered by peadm::cert_data
+# @param certname The certname of the node being classified
+# @param default The group to assign if the node has no existing valid group
+function peadm::availability_group_for(
+  Hash             $cert_extensions,
+  Optional[String] $certname,
+  Enum['A', 'B']   $default,
+) >> Enum['A', 'B'] {
+  $existing = $certname ? {
+    undef   => undef,
+    default => $cert_extensions.dig($certname, peadm::oid('peadm_availability_group')),
+  }
+
+  $existing ? {
+    'A'     => 'A',
+    'B'     => 'B',
+    default => $default,
+  }
+}

--- a/plans/convert.pp
+++ b/plans/convert.pp
@@ -134,6 +134,78 @@ plan peadm::convert (
 # lint:endignore
   }
 
+  # Guard against inconsistent or partially-stamped availability-group state
+  # before making any changes. A pair with no existing peadm_availability_group
+  # extensions at all is expected on a fresh conversion and is not a problem --
+  # both members will be assigned a fresh A/B pairing below. But if only one
+  # member already has a group, or both members already claim the *same*
+  # group, convert should not guess; it should fail fast so the operator can
+  # confirm the correct topology (this can happen if, for example, the wrong
+  # host was passed as primary/replica after a role swap).
+  $primary_certname            = $primary_target.peadm::certname()
+  $replica_certname            = $replica_target.peadm::certname()
+  $primary_postgresql_certname = $primary_postgresql_target.peadm::certname()
+  $replica_postgresql_certname = $replica_postgresql_target.peadm::certname()
+
+  $primary_group            = $cert_extensions.dig($primary_certname, peadm::oid('peadm_availability_group'))
+  $replica_group            = $cert_extensions.dig($replica_certname, peadm::oid('peadm_availability_group'))
+  $primary_postgresql_group = $cert_extensions.dig($primary_postgresql_certname, peadm::oid('peadm_availability_group'))
+  $replica_postgresql_group = $cert_extensions.dig($replica_postgresql_certname, peadm::oid('peadm_availability_group'))
+
+  if ($replica_certname) and (($primary_group in ['A', 'B']) or ($replica_group in ['A', 'B'])) {
+    if $primary_group == $replica_group {
+# lint:ignore:strict_indent
+      fail_plan(@("EOL"/L))
+        The primary (${primary_certname}) and replica (${replica_certname}) both \
+        have availability group '${primary_group}' set on their certificates. \
+        This is invalid; please confirm these are really the correct \
+        primary/replica pair before running convert.
+        | EOL
+    }
+    if !($primary_group in ['A', 'B']) or !($replica_group in ['A', 'B']) {
+      fail_plan(@("EOL"/L))
+        The primary (${primary_certname}) and replica (${replica_certname}) have \
+        inconsistent availability group state: one has an existing \
+        peadm_availability_group certificate extension and the other does not. \
+        Please resolve this manually before running convert.
+        | EOL
+    }
+# lint:endignore
+  }
+
+  if ($replica_postgresql_certname) and (($primary_postgresql_group in ['A', 'B']) or ($replica_postgresql_group in ['A', 'B'])) {
+    if $primary_postgresql_group == $replica_postgresql_group {
+# lint:ignore:strict_indent
+      fail_plan(@("EOL"/L))
+        The primary PostgreSQL host (${primary_postgresql_certname}) and replica \
+        PostgreSQL host (${replica_postgresql_certname}) both have availability \
+        group '${primary_postgresql_group}' set on their certificates. This is \
+        invalid; please confirm these are really the correct pair before running \
+        convert.
+        | EOL
+    }
+    if !($primary_postgresql_group in ['A', 'B']) or !($replica_postgresql_group in ['A', 'B']) {
+      fail_plan(@("EOL"/L))
+        The primary PostgreSQL host (${primary_postgresql_certname}) and replica \
+        PostgreSQL host (${replica_postgresql_certname}) have inconsistent \
+        availability group state: one has an existing peadm_availability_group \
+        certificate extension and the other does not. Please resolve this \
+        manually before running convert.
+        | EOL
+    }
+# lint:endignore
+  }
+
+  # Determine the availability group each node should carry, preserving an
+  # existing extension where present instead of deriving it from which plan
+  # parameter (primary_host vs replica_host) the node was passed as. Used
+  # both to (re)stamp certificates below and to classify node groups, so the
+  # two stay in sync (mirrors the approach peadm::upgrade already uses).
+  $primary_avail_group            = peadm::availability_group_for($cert_extensions, $primary_certname, 'A')
+  $replica_avail_group            = peadm::availability_group_for($cert_extensions, $replica_certname, 'B')
+  $primary_postgresql_avail_group = peadm::availability_group_for($cert_extensions, $primary_postgresql_certname, 'A')
+  $replica_postgresql_avail_group = peadm::availability_group_for($cert_extensions, $replica_postgresql_certname, 'B')
+
   # Clusters A and B are used to divide PuppetDB availability for compilers. If
   # the compilers given already have peadm_availability_group facts designating
   # them A or B, use that. Otherwise, divide them by modulus of 2.
@@ -209,7 +281,7 @@ plan peadm::convert (
       primary_host   => $primary_target,
       add_extensions => {
         peadm::oid('peadm_role')               => 'puppet/server',
-        peadm::oid('peadm_availability_group') => 'A',
+        peadm::oid('peadm_availability_group') => $primary_avail_group,
       },
     )
   }
@@ -230,7 +302,7 @@ plan peadm::convert (
           primary_host   => $primary_target,
           add_extensions => {
             peadm::oid('peadm_role')               => 'puppet/server',
-            peadm::oid('peadm_availability_group') => 'B',
+            peadm::oid('peadm_availability_group') => $replica_avail_group,
           },
         )
       },
@@ -239,7 +311,7 @@ plan peadm::convert (
           primary_host   => $primary_target,
           add_extensions => {
             peadm::oid('peadm_role')               => 'puppet/puppetdb-database',
-            peadm::oid('peadm_availability_group') => 'A',
+            peadm::oid('peadm_availability_group') => $primary_postgresql_avail_group,
           },
         )
       },
@@ -248,7 +320,7 @@ plan peadm::convert (
           primary_host   => $primary_target,
           add_extensions => {
             peadm::oid('peadm_role')               => 'puppet/puppetdb-database',
-            peadm::oid('peadm_availability_group') => 'B',
+            peadm::oid('peadm_availability_group') => $replica_postgresql_avail_group,
           },
         )
       },
@@ -304,6 +376,28 @@ plan peadm::convert (
       $rules_formatted = stdlib::to_json_pretty(parsejson($rules))
       out::message("WARNING: The following existing rules on the PE Infrastructure Agent group will be overwritten with default values:\n ${rules_formatted}")
 
+      # Node groups are keyed by which host actually carries the 'A'/'B'
+      # certificate extension, not by which plan parameter it was passed as,
+      # so that classification stays consistent with the certs just stamped
+      # above even when an existing availability group was preserved.
+      $server_a_host = $primary_avail_group ? {
+        'A'     => $primary_certname,
+        default => $replica_certname,
+      }
+      $server_b_host = $server_a_host ? {
+        $primary_certname => $replica_certname,
+        default           => $primary_certname,
+      }
+
+      $postgresql_a_host = $primary_postgresql_avail_group ? {
+        'A'     => $primary_postgresql_certname,
+        default => $replica_postgresql_certname,
+      }
+      $postgresql_b_host = $postgresql_a_host ? {
+        $primary_postgresql_certname => $replica_postgresql_certname,
+        default                      => $primary_postgresql_certname,
+      }
+
       apply($primary_target) {
         class { 'peadm::setup::node_manager_yaml':
           primary_host => $primary_target.peadm::certname(),
@@ -311,10 +405,10 @@ plan peadm::convert (
 
         class { 'peadm::setup::node_manager':
           primary_host                     => $primary_target.peadm::certname(),
-          server_a_host                    => $primary_target.peadm::certname(),
-          server_b_host                    => $replica_target.peadm::certname(),
-          postgresql_a_host                => $primary_postgresql_target.peadm::certname(),
-          postgresql_b_host                => $replica_postgresql_target.peadm::certname(),
+          server_a_host                    => $server_a_host,
+          server_b_host                    => $server_b_host,
+          postgresql_a_host                => $postgresql_a_host,
+          postgresql_b_host                => $postgresql_b_host,
           compiler_pool_address            => $compiler_pool_address,
           internal_compiler_a_pool_address => $internal_compiler_a_pool_address,
           internal_compiler_b_pool_address => $internal_compiler_b_pool_address,

--- a/plans/convert.pp
+++ b/plans/convert.pp
@@ -134,14 +134,6 @@ plan peadm::convert (
 # lint:endignore
   }
 
-  # Guard against inconsistent or partially-stamped availability-group state
-  # before making any changes. A pair with no existing peadm_availability_group
-  # extensions at all is expected on a fresh conversion and is not a problem --
-  # both members will be assigned a fresh A/B pairing below. But if only one
-  # member already has a group, or both members already claim the *same*
-  # group, convert should not guess; it should fail fast so the operator can
-  # confirm the correct topology (this can happen if, for example, the wrong
-  # host was passed as primary/replica after a role swap).
   $primary_certname            = $primary_target.peadm::certname()
   $replica_certname            = $replica_target.peadm::certname()
   $primary_postgresql_certname = $primary_postgresql_target.peadm::certname()
@@ -152,48 +144,66 @@ plan peadm::convert (
   $primary_postgresql_group = $cert_extensions.dig($primary_postgresql_certname, peadm::oid('peadm_availability_group'))
   $replica_postgresql_group = $cert_extensions.dig($replica_postgresql_certname, peadm::oid('peadm_availability_group'))
 
-  if ($replica_certname) and (($primary_group in ['A', 'B']) or ($replica_group in ['A', 'B'])) {
-    if $primary_group == $replica_group {
+  # Guard against inconsistent or partially-stamped availability-group state
+  # before making any changes. A pair with no existing peadm_availability_group
+  # extensions at all is expected on a fresh conversion and is not a problem --
+  # both members will be assigned a fresh A/B pairing below. But if only one
+  # member already has a group, or both members already claim the *same*
+  # group, convert should not guess; it should fail fast so the operator can
+  # confirm the correct topology (this can happen if, for example, the wrong
+  # host was passed as primary/replica after a role swap).
+  #
+  # Only enforced on a fresh run (or one explicitly restarted at the first
+  # step). A run resumed with begin_at_step past 'modify-primary-cert' may be
+  # observing this plan's own partial progress from an earlier, interrupted
+  # invocation (e.g. the primary got stamped but the replica didn't before an
+  # orchestrator hiccup) rather than genuine operator error, and re-running
+  # this validation would permanently lock the operator out with no way to
+  # resume.
+  if ($begin_at_step == undef) or ($begin_at_step == 'modify-primary-cert') {
+    if ($replica_certname) and (($primary_group in ['A', 'B']) or ($replica_group in ['A', 'B'])) {
+      if $primary_group == $replica_group {
 # lint:ignore:strict_indent
-      fail_plan(@("EOL"/L))
-        The primary (${primary_certname}) and replica (${replica_certname}) both \
-        have availability group '${primary_group}' set on their certificates. \
-        This is invalid; please confirm these are really the correct \
-        primary/replica pair before running convert.
-        | EOL
-    }
-    if !($primary_group in ['A', 'B']) or !($replica_group in ['A', 'B']) {
-      fail_plan(@("EOL"/L))
-        The primary (${primary_certname}) and replica (${replica_certname}) have \
-        inconsistent availability group state: one has an existing \
-        peadm_availability_group certificate extension and the other does not. \
-        Please resolve this manually before running convert.
-        | EOL
-    }
+        fail_plan(@("EOL"/L))
+          The primary (${primary_certname}) and replica (${replica_certname}) both \
+          have availability group '${primary_group}' set on their certificates. \
+          This is invalid; please confirm these are really the correct \
+          primary/replica pair before running convert.
+          | EOL
+      }
+      if !($primary_group in ['A', 'B']) or !($replica_group in ['A', 'B']) {
+        fail_plan(@("EOL"/L))
+          The primary (${primary_certname}) and replica (${replica_certname}) have \
+          inconsistent availability group state: one has an existing \
+          peadm_availability_group certificate extension and the other does not. \
+          Please resolve this manually before running convert.
+          | EOL
+      }
 # lint:endignore
-  }
+    }
 
-  if ($replica_postgresql_certname) and (($primary_postgresql_group in ['A', 'B']) or ($replica_postgresql_group in ['A', 'B'])) {
-    if $primary_postgresql_group == $replica_postgresql_group {
+    if ($replica_postgresql_certname) and (($primary_postgresql_group in ['A', 'B']) or ($replica_postgresql_group in ['A', 'B'])) {
+      if $primary_postgresql_group == $replica_postgresql_group {
 # lint:ignore:strict_indent
-      fail_plan(@("EOL"/L))
-        The primary PostgreSQL host (${primary_postgresql_certname}) and replica \
-        PostgreSQL host (${replica_postgresql_certname}) both have availability \
-        group '${primary_postgresql_group}' set on their certificates. This is \
-        invalid; please confirm these are really the correct pair before running \
-        convert.
-        | EOL
-    }
-    if !($primary_postgresql_group in ['A', 'B']) or !($replica_postgresql_group in ['A', 'B']) {
-      fail_plan(@("EOL"/L))
-        The primary PostgreSQL host (${primary_postgresql_certname}) and replica \
-        PostgreSQL host (${replica_postgresql_certname}) have inconsistent \
-        availability group state: one has an existing peadm_availability_group \
-        certificate extension and the other does not. Please resolve this \
-        manually before running convert.
-        | EOL
-    }
+        fail_plan(@("EOL"/L))
+          The primary PostgreSQL host (${primary_postgresql_certname}) and replica \
+          PostgreSQL host (${replica_postgresql_certname}) both have availability \
+          group '${primary_postgresql_group}' set on their certificates. This is \
+          invalid; please confirm these are really the correct pair before running \
+          convert.
+          | EOL
+      }
+      if !($primary_postgresql_group in ['A', 'B']) or !($replica_postgresql_group in ['A', 'B']) {
+        fail_plan(@("EOL"/L))
+          The primary PostgreSQL host (${primary_postgresql_certname}) and replica \
+          PostgreSQL host (${replica_postgresql_certname}) have inconsistent \
+          availability group state: one has an existing peadm_availability_group \
+          certificate extension and the other does not. Please resolve this \
+          manually before running convert.
+          | EOL
+      }
 # lint:endignore
+    }
   }
 
   # Determine the availability group each node should carry, preserving an
@@ -380,22 +390,29 @@ plan peadm::convert (
       # certificate extension, not by which plan parameter it was passed as,
       # so that classification stays consistent with the certs just stamped
       # above even when an existing availability group was preserved.
-      $server_a_host = $primary_avail_group ? {
-        'A'     => $primary_certname,
+      #
+      # Only swap when a genuine pair exists (a replica/replica-postgresql
+      # host was actually given). Without a real pair there's nothing to
+      # preserve, and swapping on a stray leftover 'B' extension on a lone
+      # primary would point server_a_host/postgresql_a_host at the
+      # nonexistent replica (undef), which peadm::setup::node_manager
+      # requires to be a String[1] and would crash inside apply().
+      $server_a_host = ($replica_certname and $primary_avail_group == 'B') ? {
+        true    => $replica_certname,
+        default => $primary_certname,
+      }
+      $server_b_host = ($replica_certname and $primary_avail_group == 'B') ? {
+        true    => $primary_certname,
         default => $replica_certname,
       }
-      $server_b_host = $server_a_host ? {
-        $primary_certname => $replica_certname,
-        default           => $primary_certname,
-      }
 
-      $postgresql_a_host = $primary_postgresql_avail_group ? {
-        'A'     => $primary_postgresql_certname,
-        default => $replica_postgresql_certname,
+      $postgresql_a_host = ($replica_postgresql_certname and $primary_postgresql_avail_group == 'B') ? {
+        true    => $replica_postgresql_certname,
+        default => $primary_postgresql_certname,
       }
-      $postgresql_b_host = $postgresql_a_host ? {
-        $primary_postgresql_certname => $replica_postgresql_certname,
-        default                      => $primary_postgresql_certname,
+      $postgresql_b_host = ($replica_postgresql_certname and $primary_postgresql_avail_group == 'B') ? {
+        true    => $primary_postgresql_certname,
+        default => $replica_postgresql_certname,
       }
 
       apply($primary_target) {

--- a/spec/functions/availability_group_for_spec.rb
+++ b/spec/functions/availability_group_for_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'peadm::availability_group_for' do
+  let(:oid) { '1.3.6.1.4.1.34380.1.1.9813' }
+
+  it 'assigns the default when there is no extensions hash for the certname' do
+    is_expected.to run.with_params({}, 'primary', 'A').and_return('A')
+  end
+
+  it 'assigns the default when the certname has no availability group extension' do
+    cert_extensions = { 'primary' => {} }
+    is_expected.to run.with_params(cert_extensions, 'primary', 'A').and_return('A')
+  end
+
+  it 'assigns the default when certname is undef' do
+    is_expected.to run.with_params({}, nil, 'A').and_return('A')
+  end
+
+  it 'preserves an existing "A" extension even when the default is "B"' do
+    cert_extensions = { 'primary' => { oid => 'A' } }
+    is_expected.to run.with_params(cert_extensions, 'primary', 'B').and_return('A')
+  end
+
+  it 'preserves an existing "B" extension even when the default is "A"' do
+    cert_extensions = { 'replica' => { oid => 'B' } }
+    is_expected.to run.with_params(cert_extensions, 'replica', 'A').and_return('B')
+  end
+
+  it 'falls back to the default when the existing extension value is neither "A" nor "B"' do
+    cert_extensions = { 'primary' => { oid => 'garbage' } }
+    is_expected.to run.with_params(cert_extensions, 'primary', 'A').and_return('A')
+  end
+end

--- a/spec/plans/convert_spec.rb
+++ b/spec/plans/convert_spec.rb
@@ -30,4 +30,105 @@ describe 'peadm::convert' do
 
     expect(run_plan('peadm::convert', params)).to be_ok
   end
+
+  # Regression coverage for PE-43987: peadm::convert used to derive each
+  # node's availability group ('A'/'B') purely from which plan parameter it
+  # was passed as (primary_host => 'A', replica_host => 'B'), ignoring any
+  # peadm_availability_group extension already on the node's certificate.
+  # After a customer performs a role swap (via PE's switch_primary tooling,
+  # outside this repo) and then runs convert, that overwrote the node's real
+  # identity and corrupted the A/B topology.
+  context 'availability group handling with a primary and replica' do
+    let(:avail_group_oid) { '1.3.6.1.4.1.34380.1.1.9813' }
+    let(:role_oid) { '1.3.6.1.4.1.34380.1.1.9812' }
+
+    let(:primary_replica_params) do
+      { 'primary_host' => 'primary', 'replica_host' => 'replica' }
+    end
+
+    def allow_standard_non_returning_calls
+      allow_out_message
+      allow_any_command
+      allow_any_task
+      allow_apply
+    end
+
+    before(:each) do
+      allow_standard_non_returning_calls
+      expect_task('peadm::read_file').with_params('path' => '/opt/puppetlabs/server/pe_version').always_return({ 'content' => '2021.7.9' })
+      expect_task('peadm::read_file').with_params('path' => '/etc/puppetlabs/enterprise/conf.d/pe.conf').always_return({ 'content' => '{}' })
+    end
+
+    # Records the availability group stamped onto each certname across all
+    # peadm::modify_certificate invocations. Several of those invocations
+    # (postgresql hosts, compilers) are no-ops in this primary/replica-only
+    # scenario and carry an empty targets list; skip those.
+    def capture_stamped_avail_groups(stamped)
+      allow_plan('peadm::modify_certificate').return do |params:, **|
+        targets = Array(params['targets'])
+        unless targets.empty?
+          certname = targets.first.name
+          stamped[certname] = params['add_extensions'][avail_group_oid] if params['add_extensions']&.key?(avail_group_oid)
+        end
+        Bolt::PlanResult.new({}, 'success')
+      end
+    end
+
+    it 'assigns primary=A/replica=B on a fresh conversion with no existing extensions' do
+      expect_task('peadm::cert_data').return_for_targets(
+        'primary' => { 'extensions' => {} },
+        'replica' => { 'extensions' => {} },
+      ).be_called_times(2)
+      expect_task('peadm::get_group_rules').return_for_targets('primary' => { '_output' => '{"rules": []}' })
+
+      stamped = {}
+      capture_stamped_avail_groups(stamped)
+
+      expect(run_plan('peadm::convert', primary_replica_params)).to be_ok
+      expect(stamped['primary']).to eq('A')
+      expect(stamped['replica']).to eq('B')
+    end
+
+    it 'preserves an existing availability group after a role swap instead of overwriting it by position' do
+      # Simulate a prior role swap: 'primary' (now primary) already carries
+      # the 'B' extension from before the swap, and 'replica' (now replica)
+      # already carries 'A'.
+      expect_task('peadm::cert_data').return_for_targets(
+        'primary' => { 'extensions' => { avail_group_oid => 'B', role_oid => 'puppet/server' } },
+        'replica' => { 'extensions' => { avail_group_oid => 'A', role_oid => 'puppet/server' } },
+      ).be_called_times(2)
+      expect_task('peadm::get_group_rules').return_for_targets('primary' => { '_output' => '{"rules": []}' })
+
+      stamped = {}
+      capture_stamped_avail_groups(stamped)
+
+      expect(run_plan('peadm::convert', primary_replica_params)).to be_ok
+      expect(stamped['primary']).to eq('B')
+      expect(stamped['replica']).to eq('A')
+    end
+
+    it 'fails fast when primary and replica already claim the same availability group' do
+      expect_task('peadm::cert_data').return_for_targets(
+        'primary' => { 'extensions' => { avail_group_oid => 'A', role_oid => 'puppet/server' } },
+        'replica' => { 'extensions' => { avail_group_oid => 'A', role_oid => 'puppet/server' } },
+      ).be_called_times(2)
+
+      result = run_plan('peadm::convert', primary_replica_params)
+
+      expect(result).not_to be_ok
+      expect(result.value.msg).to match(%r{both have availability group 'A'})
+    end
+
+    it 'fails fast when only one of primary/replica has an existing availability group extension' do
+      expect_task('peadm::cert_data').return_for_targets(
+        'primary' => { 'extensions' => { avail_group_oid => 'A', role_oid => 'puppet/server' } },
+        'replica' => { 'extensions' => {} },
+      ).be_called_times(2)
+
+      result = run_plan('peadm::convert', primary_replica_params)
+
+      expect(result).not_to be_ok
+      expect(result.value.msg).to match(%r{inconsistent availability group state})
+    end
+  end
 end

--- a/spec/plans/convert_spec.rb
+++ b/spec/plans/convert_spec.rb
@@ -130,5 +130,134 @@ describe 'peadm::convert' do
       expect(result).not_to be_ok
       expect(result.value.msg).to match(%r{inconsistent availability group state})
     end
+
+    it 'still stamps the primary cert with its preserved group when there is no replica at all' do
+      # No replica at all (Standard architecture). If the primary happens to
+      # carry a leftover 'B' extension (e.g. it was a replica before a prior
+      # role swap, and the old primary/replica has since been decommissioned),
+      # there's no genuine pair to preserve, so peadm::convert must not
+      # attempt to swap server_a_host/postgresql_a_host to the (nonexistent)
+      # replica's certname -- doing so would resolve to undef, which
+      # peadm::setup::node_manager requires to be a String[1] and would raise
+      # a type-check error inside apply(). The cert stamping asserted here
+      # still happens regardless of that logic (it's independent of it);
+      # BoltSpec's allow_apply fully stubs the apply() block, so this suite
+      # can't directly assert on the class parameters passed to
+      # node_manager -- only that the plan completes and stamps certs as
+      # expected. See PE-43987 review discussion.
+      expect_task('peadm::cert_data').return_for_targets(
+        'primary' => { 'extensions' => { avail_group_oid => 'B', role_oid => 'puppet/server' } },
+      ).be_called_times(2)
+      expect_task('peadm::get_group_rules').return_for_targets('primary' => { '_output' => '{"rules": []}' })
+
+      stamped = {}
+      capture_stamped_avail_groups(stamped)
+
+      expect(run_plan('peadm::convert', { 'primary_host' => 'primary' })).to be_ok
+      expect(stamped['primary']).to eq('B')
+    end
+  end
+
+  # Regression coverage for PE-43987: the same positional-derivation bug, and
+  # its fix, applies independently to the dedicated PostgreSQL hosts used in
+  # the Extra Large architecture.
+  context 'availability group handling with dedicated PostgreSQL hosts' do
+    let(:avail_group_oid) { '1.3.6.1.4.1.34380.1.1.9813' }
+    let(:role_oid) { '1.3.6.1.4.1.34380.1.1.9812' }
+
+    let(:extra_large_params) do
+      {
+        'primary_host'             => 'primary',
+        'replica_host'             => 'replica',
+        'primary_postgresql_host'  => 'pg_primary',
+        'replica_postgresql_host'  => 'pg_replica',
+      }
+    end
+
+    def allow_standard_non_returning_calls
+      allow_out_message
+      allow_any_command
+      allow_any_task
+      allow_apply
+    end
+
+    before(:each) do
+      allow_standard_non_returning_calls
+      expect_task('peadm::read_file').with_params('path' => '/opt/puppetlabs/server/pe_version').always_return({ 'content' => '2021.7.9' })
+      expect_task('peadm::read_file').with_params('path' => '/etc/puppetlabs/enterprise/conf.d/pe.conf').always_return({ 'content' => '{}' })
+    end
+
+    def capture_stamped_avail_groups(stamped)
+      allow_plan('peadm::modify_certificate').return do |params:, **|
+        targets = Array(params['targets'])
+        unless targets.empty?
+          certname = targets.first.name
+          stamped[certname] = params['add_extensions'][avail_group_oid] if params['add_extensions']&.key?(avail_group_oid)
+        end
+        Bolt::PlanResult.new({}, 'success')
+      end
+    end
+
+    it 'assigns pg_primary=A/pg_replica=B on a fresh conversion with no existing extensions' do
+      expect_task('peadm::cert_data').return_for_targets(
+        'primary'    => { 'extensions' => {} },
+        'replica'    => { 'extensions' => {} },
+        'pg_primary' => { 'extensions' => {} },
+        'pg_replica' => { 'extensions' => {} },
+      ).be_called_times(2)
+      expect_task('peadm::get_group_rules').return_for_targets('primary' => { '_output' => '{"rules": []}' })
+
+      stamped = {}
+      capture_stamped_avail_groups(stamped)
+
+      expect(run_plan('peadm::convert', extra_large_params)).to be_ok
+      expect(stamped['pg_primary']).to eq('A')
+      expect(stamped['pg_replica']).to eq('B')
+    end
+
+    it 'preserves an existing PostgreSQL-host availability group after a role swap instead of overwriting it by position' do
+      expect_task('peadm::cert_data').return_for_targets(
+        'primary'    => { 'extensions' => {} },
+        'replica'    => { 'extensions' => {} },
+        'pg_primary' => { 'extensions' => { avail_group_oid => 'B', role_oid => 'puppet/puppetdb-database' } },
+        'pg_replica' => { 'extensions' => { avail_group_oid => 'A', role_oid => 'puppet/puppetdb-database' } },
+      ).be_called_times(2)
+      expect_task('peadm::get_group_rules').return_for_targets('primary' => { '_output' => '{"rules": []}' })
+
+      stamped = {}
+      capture_stamped_avail_groups(stamped)
+
+      expect(run_plan('peadm::convert', extra_large_params)).to be_ok
+      expect(stamped['pg_primary']).to eq('B')
+      expect(stamped['pg_replica']).to eq('A')
+    end
+
+    it 'fails fast when the PostgreSQL primary and replica already claim the same availability group' do
+      expect_task('peadm::cert_data').return_for_targets(
+        'primary'    => { 'extensions' => {} },
+        'replica'    => { 'extensions' => {} },
+        'pg_primary' => { 'extensions' => { avail_group_oid => 'A', role_oid => 'puppet/puppetdb-database' } },
+        'pg_replica' => { 'extensions' => { avail_group_oid => 'A', role_oid => 'puppet/puppetdb-database' } },
+      ).be_called_times(2)
+
+      result = run_plan('peadm::convert', extra_large_params)
+
+      expect(result).not_to be_ok
+      expect(result.value.msg).to match(%r{both have availability group 'A'})
+    end
+
+    it 'fails fast when only one of the PostgreSQL primary/replica has an existing availability group extension' do
+      expect_task('peadm::cert_data').return_for_targets(
+        'primary'    => { 'extensions' => {} },
+        'replica'    => { 'extensions' => {} },
+        'pg_primary' => { 'extensions' => { avail_group_oid => 'A', role_oid => 'puppet/puppetdb-database' } },
+        'pg_replica' => { 'extensions' => {} },
+      ).be_called_times(2)
+
+      result = run_plan('peadm::convert', extra_large_params)
+
+      expect(result).not_to be_ok
+      expect(result.value.msg).to match(%r{inconsistent availability group state})
+    end
   end
 end


### PR DESCRIPTION
## Summary

`peadm::convert` stamped each node's A/B availability group based purely on which plan parameter it was passed as (`primary_host` => `'A'`, `replica_host` => `'B'`), ignoring any `peadm_availability_group` extension already present on its certificate.

If a customer performed a role swap via PE's `switch_primary` tooling and then ran `convert` (correctly naming the new primary), this overwrote the node's real, pre-existing identity and corrupted the A/B topology — causing an undesired configuration and potential unplanned downtime (Case# 01566445, reported by HSBC Global Services).

- Add `peadm::availability_group_for`, a shared function that preserves an existing group value where one is present on the cert, defaulting only when nothing is stamped yet — mirroring the approach `peadm::upgrade` already uses.
- Use it both for cert stamping and for node-group classification (`server_a_host`/`server_b_host`/`postgresql_a_host`/`postgresql_b_host`), which had the same positional-derivation bug independently — without this second fix, PE's classification would have disagreed with what was actually stamped on the certs.
- Add a pre-flight guard in `convert.pp` that fails fast with a clear message if the primary/replica (or their PostgreSQL hosts) already carry inconsistent availability-group state (both claim the same group, or only one is stamped), rather than guessing. A fresh conversion with no existing extensions is unaffected and still defaults to primary=A/replica=B.

Compiler A/B bucketing (`compiler_a_targets`/`compiler_b_targets`) was already correctly cert-extension-aware and is unchanged.

## Test plan

- [x] New `spec/functions/availability_group_for_spec.rb` — unit tests for the new function (preserves existing 'A'/'B', defaults when absent/undef/invalid).
- [x] New tests in `spec/plans/convert_spec.rb`:
  - fresh conversion with no existing extensions still assigns primary=A/replica=B (no regression)
  - an existing availability group is preserved after a simulated role swap instead of being overwritten by position
  - convert fails fast when primary and replica already claim the same group
  - convert fails fast when only one of primary/replica has an existing extension
- [x] Confirmed the new "preserves after role swap" test fails against the pre-fix code (temporarily reverted `convert.pp` and re-ran) — the test genuinely catches the regression.
- [x] `bundle exec puppet-lint` and `bundle exec rake syntax:manifests` clean (one pre-existing long-line warning on an unrelated line, confirmed present on `main` too).
- [x] All directly relevant spec files pass (38 examples, 0 failures): `convert_spec.rb`, `upgrade_spec.rb`, `add_replica_spec.rb`, `modify_certificate_spec.rb`, `modify_cert_extensions_spec.rb`, `oid_spec.rb`, `availability_group_for_spec.rb`, `assert_supported_architecture_spec.rb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)