### PR TITLE
(PE-45390) Add code coverage reporting to CI

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -127,7 +127,6 @@ jobs:
       - name: Run parallel_spec tests
         run: |-
           bundle exec rake parallel_spec
-
   Coverage:
     name: Code Coverage
     if: ${{ github.repository_owner == 'puppetlabs' }}

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -88,3 +88,35 @@ jobs:
       - name: Run parallel_spec tests
         run: |-
           bundle exec rake parallel_spec
+  Coverage:
+    name: Code Coverage
+    if: ${{ github.repository_owner == 'puppetlabs' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      code-quality: write
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v4
+      - name: Activate Ruby 3.1
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+      # puppetlabs_spec_helper has no parallel_spec equivalent of the spec:simplecov task, so
+      # coverage runs as its own single, non-parallelized job rather than joining the Spec
+      # matrix above.
+      - name: Run rspec with coverage
+        run: bundle exec rake spec:simplecov
+      - name: Upload Ruby code coverage
+        uses: actions/upload-code-coverage@v1
+        with:
+          file: coverage/coverage.xml
+          language: Ruby
+          label: code-coverage/rspec
+      - name: Upload Puppet manifest coverage
+        uses: actions/upload-code-coverage@v1
+        with:
+          file: coverage/puppet-coverage.xml
+          language: Puppet
+          label: code-coverage/rspec-puppet

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -127,3 +127,36 @@ jobs:
       - name: Run parallel_spec tests
         run: |-
           bundle exec rake parallel_spec
+
+  Coverage:
+    name: Code Coverage
+    if: ${{ github.repository_owner == 'puppetlabs' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      code-quality: write
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v4
+      - name: Activate Ruby 3.1
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+      # puppetlabs_spec_helper has no parallel_spec equivalent of the spec:simplecov task, so
+      # coverage runs as its own single, non-parallelized job rather than joining the Spec
+      # matrix above.
+      - name: Run rspec with coverage
+        run: bundle exec rake spec:simplecov
+      - name: Upload Ruby code coverage
+        uses: actions/upload-code-coverage@v1
+        with:
+          file: coverage/coverage.xml
+          language: Ruby
+          label: code-coverage/rspec
+      - name: Upload Puppet manifest coverage
+        uses: actions/upload-code-coverage@v1
+        with:
+          file: coverage/puppet-coverage.xml
+          language: Puppet
+          label: code-coverage/rspec-puppet

--- a/.sync.yml
+++ b/.sync.yml
@@ -14,6 +14,8 @@ Gemfile:
       # resolve the dependency in unexpected ways and causes issues in CI
       - gem: orchestrator_client
         version: < 0.7.1
+      - gem: simplecov-cobertura
+        version: '~> 3.2'
 Rakefile:
   changelog_since_tag: 2.5.0
   default_disabled_lint_checks:
@@ -24,6 +26,98 @@ Rakefile:
       "vendor/**/*"]
 spec/spec_helper.rb:
   mock_with: :rspec
+  spec_overrides:
+    - |
+      # puppetlabs_spec_helper's module_spec_helper hardcodes SimpleCov.formatters to
+      # [HTMLFormatter, Console, Codecov] when ENV['SIMPLECOV'] == 'yes' (see
+      # `rake spec:simplecov`). Override it here to drop Codecov -- there's no
+      # CODECOV_TOKEN configured anywhere in this repo, so that formatter does nothing
+      # but attempt (and fail) a real network upload to codecov.io on every coverage run
+      # -- and add CoberturaFormatter instead, whose XML output CI uploads via GitHub's
+      # native code coverage feature.
+      if ENV['SIMPLECOV'] == 'yes'
+        require 'simplecov-cobertura'
+
+        SimpleCov.formatters = [
+          SimpleCov::Formatter::HTMLFormatter,
+          SimpleCov::Formatter::Console,
+          SimpleCov::Formatter::CoberturaFormatter,
+        ]
+      end
+    - |
+      # Ruby's Coverage library (which SimpleCov/CoberturaFormatter above rely on) can only
+      # instrument .rb files -- it can't measure coverage of Puppet manifests (.pp). rspec-puppet
+      # tracks its own "resource coverage" instead: which resources declared across compiled
+      # catalogs were touched by at least one example (see the `RSpec::Puppet::Coverage.report!`
+      # call above). Convert that per-resource data -- each resource carries its declaring file and
+      # line from the catalog -- into Cobertura XML, so manifest coverage rides the same GitHub
+      # code-coverage upload step as the Ruby coverage above.
+      #
+      # Caveat: this is resource-declaration-line coverage, not true statement coverage -- a .pp
+      # file with N declared resources gets N reported lines, not one per source line.
+      if ENV['SIMPLECOV'] == 'yes'
+        require 'pathname'
+        require 'rexml/document'
+
+        RSpec.configure do |c|
+          c.after(:suite) do
+            collection = RSpec::Puppet::Coverage.instance.instance_variable_get(:@collection)
+            repo_root = Pathname.new(Dir.pwd).realpath
+
+            lines_by_file = Hash.new { |h, k| h[k] = Hash.new(0) }
+            collection.each_value do |wrapper|
+              resource = wrapper.resource
+              next unless resource.file && resource.line
+
+              begin
+                relative_path = Pathname.new(resource.file).realpath.relative_path_from(repo_root).to_s
+              rescue Errno::ENOENT
+                next
+              end
+              next if relative_path.start_with?('..')
+
+              lines_by_file[relative_path][resource.line] += wrapper.touched? ? 1 : 0
+            end
+
+            doc = REXML::Document.new
+            doc << REXML::XMLDecl.new('1.0')
+            doc.add(REXML::DocType.new(['coverage', 'SYSTEM', 'http://cobertura.sourceforge.net/xml/coverage-04.dtd']))
+
+            total_lines = 0
+            covered_lines = 0
+
+            coverage_el = doc.add_element('coverage', 'version' => '0', 'timestamp' => Time.now.to_i.to_s)
+            coverage_el.add_element('sources').add_element('source').text = '.'
+            package_el = coverage_el.add_element('packages').add_element('package', 'name' => 'manifests')
+            classes_el = package_el.add_element('classes')
+
+            lines_by_file.sort.each do |file, lines|
+              file_covered = lines.count { |_, hits| hits > 0 }
+              total_lines += lines.size
+              covered_lines += file_covered
+
+              class_line_rate = lines.empty? ? 1.0 : file_covered.to_f / lines.size
+              class_el = classes_el.add_element(
+                'class', 'name' => File.basename(file), 'filename' => file, 'line-rate' => class_line_rate.to_s
+              )
+              class_el.add_element('methods')
+              lines_el = class_el.add_element('lines')
+              lines.sort.each do |line_number, hits|
+                lines_el.add_element('line', 'number' => line_number.to_s, 'hits' => hits.to_s)
+              end
+            end
+
+            overall_line_rate = (total_lines > 0) ? covered_lines.to_f / total_lines : 1.0
+            coverage_el.add_attribute('line-rate', overall_line_rate.to_s)
+            coverage_el.add_attribute('lines-covered', covered_lines.to_s)
+            coverage_el.add_attribute('lines-valid', total_lines.to_s)
+            package_el.add_attribute('line-rate', overall_line_rate.to_s)
+
+            FileUtils.mkdir_p('coverage')
+            File.write('coverage/puppet-coverage.xml', doc.to_s)
+          end
+        end
+      end
 .gitignore:
   paths:
     - .rerun.json

--- a/.sync.yml
+++ b/.sync.yml
@@ -15,7 +15,7 @@ Gemfile:
       - gem: orchestrator_client
         version: < 0.7.1
       - gem: simplecov-cobertura
-        version: '~> 3.2'
+        version: ~> 3.2
 Rakefile:
   changelog_since_tag: 2.5.0
   default_disabled_lint_checks:
@@ -37,7 +37,6 @@ spec/spec_helper.rb:
       # native code coverage feature.
       if ENV['SIMPLECOV'] == 'yes'
         require 'simplecov-cobertura'
-
         SimpleCov.formatters = [
           SimpleCov::Formatter::HTMLFormatter,
           SimpleCov::Formatter::Console,
@@ -58,44 +57,35 @@ spec/spec_helper.rb:
       if ENV['SIMPLECOV'] == 'yes'
         require 'pathname'
         require 'rexml/document'
-
         RSpec.configure do |c|
           c.after(:suite) do
             collection = RSpec::Puppet::Coverage.instance.instance_variable_get(:@collection)
             repo_root = Pathname.new(Dir.pwd).realpath
-
             lines_by_file = Hash.new { |h, k| h[k] = Hash.new(0) }
             collection.each_value do |wrapper|
               resource = wrapper.resource
               next unless resource.file && resource.line
-
               begin
                 relative_path = Pathname.new(resource.file).realpath.relative_path_from(repo_root).to_s
               rescue Errno::ENOENT
                 next
               end
               next if relative_path.start_with?('..')
-
               lines_by_file[relative_path][resource.line] += wrapper.touched? ? 1 : 0
             end
-
             doc = REXML::Document.new
             doc << REXML::XMLDecl.new('1.0')
             doc.add(REXML::DocType.new(['coverage', 'SYSTEM', 'http://cobertura.sourceforge.net/xml/coverage-04.dtd']))
-
             total_lines = 0
             covered_lines = 0
-
             coverage_el = doc.add_element('coverage', 'version' => '0', 'timestamp' => Time.now.to_i.to_s)
             coverage_el.add_element('sources').add_element('source').text = '.'
             package_el = coverage_el.add_element('packages').add_element('package', 'name' => 'manifests')
             classes_el = package_el.add_element('classes')
-
             lines_by_file.sort.each do |file, lines|
               file_covered = lines.count { |_, hits| hits > 0 }
               total_lines += lines.size
               covered_lines += file_covered
-
               class_line_rate = lines.empty? ? 1.0 : file_covered.to_f / lines.size
               class_el = classes_el.add_element(
                 'class', 'name' => File.basename(file), 'filename' => file, 'line-rate' => class_line_rate.to_s
@@ -106,13 +96,11 @@ spec/spec_helper.rb:
                 lines_el.add_element('line', 'number' => line_number.to_s, 'hits' => hits.to_s)
               end
             end
-
             overall_line_rate = (total_lines > 0) ? covered_lines.to_f / total_lines : 1.0
             coverage_el.add_attribute('line-rate', overall_line_rate.to_s)
             coverage_el.add_attribute('lines-covered', covered_lines.to_s)
             coverage_el.add_attribute('lines-valid', total_lines.to_s)
             package_el.add_attribute('line-rate', overall_line_rate.to_s)
-
             FileUtils.mkdir_p('coverage')
             File.write('coverage/puppet-coverage.xml', doc.to_s)
           end

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :development do
   gem "puppetlabs_spec_helper", '~> 6.0',        require: false
   gem "rspec-puppet-facts", '~> 2.0',            require: false
   gem "codecov", '~> 0.2',                       require: false
+  gem "simplecov-cobertura", '~> 3.2',            require: false
   gem "dependency_checker", '~> 1.0.0',          require: false
   gem "parallel_tests", '= 3.12.1',              require: false
   gem "pry", '~> 0.10',                          require: false

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :development do
   gem "puppetlabs_spec_helper", '~> 6.0',        require: false
   gem "rspec-puppet-facts", '~> 2.0',            require: false
   gem "codecov", '~> 0.2',                       require: false
+  gem "simplecov-cobertura", '~> 3.2',            require: false
   gem "dependency_checker", '~> 1.0.0',          require: false
   gem "parallel_tests", '= 3.12.1',              require: false
   gem "pry", '~> 0.10',                          require: false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,3 +72,93 @@ def ensure_module_defined(module_name)
 end
 
 # 'spec_overrides' from sync.yml will appear below this line
+# puppetlabs_spec_helper's module_spec_helper hardcodes SimpleCov.formatters to
+# [HTMLFormatter, Console, Codecov] when ENV['SIMPLECOV'] == 'yes' (see
+# `rake spec:simplecov`). Override it here to drop Codecov -- there's no
+# CODECOV_TOKEN configured anywhere in this repo, so that formatter does nothing
+# but attempt (and fail) a real network upload to codecov.io on every coverage run
+# -- and add CoberturaFormatter instead, whose XML output CI uploads via GitHub's
+# native code coverage feature.
+if ENV['SIMPLECOV'] == 'yes'
+  require 'simplecov-cobertura'
+
+  SimpleCov.formatters = [
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::Console,
+    SimpleCov::Formatter::CoberturaFormatter,
+  ]
+end
+
+# Ruby's Coverage library (which SimpleCov/CoberturaFormatter above rely on) can only
+# instrument .rb files -- it can't measure coverage of Puppet manifests (.pp). rspec-puppet
+# tracks its own "resource coverage" instead: which resources declared across compiled
+# catalogs were touched by at least one example (see the `RSpec::Puppet::Coverage.report!`
+# call above). Convert that per-resource data -- each resource carries its declaring file and
+# line from the catalog -- into Cobertura XML, so manifest coverage rides the same GitHub
+# code-coverage upload step as the Ruby coverage above.
+#
+# Caveat: this is resource-declaration-line coverage, not true statement coverage -- a .pp
+# file with N declared resources gets N reported lines, not one per source line.
+if ENV['SIMPLECOV'] == 'yes'
+  require 'pathname'
+  require 'rexml/document'
+
+  RSpec.configure do |c|
+    c.after(:suite) do
+      collection = RSpec::Puppet::Coverage.instance.instance_variable_get(:@collection)
+      repo_root = Pathname.new(Dir.pwd).realpath
+
+      lines_by_file = Hash.new { |h, k| h[k] = Hash.new(0) }
+      collection.each_value do |wrapper|
+        resource = wrapper.resource
+        next unless resource.file && resource.line
+
+        begin
+          relative_path = Pathname.new(resource.file).realpath.relative_path_from(repo_root).to_s
+        rescue Errno::ENOENT
+          next
+        end
+        next if relative_path.start_with?('..')
+
+        lines_by_file[relative_path][resource.line] += wrapper.touched? ? 1 : 0
+      end
+
+      doc = REXML::Document.new
+      doc << REXML::XMLDecl.new('1.0')
+      doc.add(REXML::DocType.new(['coverage', 'SYSTEM', 'http://cobertura.sourceforge.net/xml/coverage-04.dtd']))
+
+      total_lines = 0
+      covered_lines = 0
+
+      coverage_el = doc.add_element('coverage', 'version' => '0', 'timestamp' => Time.now.to_i.to_s)
+      coverage_el.add_element('sources').add_element('source').text = '.'
+      package_el = coverage_el.add_element('packages').add_element('package', 'name' => 'manifests')
+      classes_el = package_el.add_element('classes')
+
+      lines_by_file.sort.each do |file, lines|
+        file_covered = lines.count { |_, hits| hits > 0 }
+        total_lines += lines.size
+        covered_lines += file_covered
+
+        class_line_rate = lines.empty? ? 1.0 : file_covered.to_f / lines.size
+        class_el = classes_el.add_element(
+          'class', 'name' => File.basename(file), 'filename' => file, 'line-rate' => class_line_rate.to_s
+        )
+        class_el.add_element('methods')
+        lines_el = class_el.add_element('lines')
+        lines.sort.each do |line_number, hits|
+          lines_el.add_element('line', 'number' => line_number.to_s, 'hits' => hits.to_s)
+        end
+      end
+
+      overall_line_rate = (total_lines > 0) ? covered_lines.to_f / total_lines : 1.0
+      coverage_el.add_attribute('line-rate', overall_line_rate.to_s)
+      coverage_el.add_attribute('lines-covered', covered_lines.to_s)
+      coverage_el.add_attribute('lines-valid', total_lines.to_s)
+      package_el.add_attribute('line-rate', overall_line_rate.to_s)
+
+      FileUtils.mkdir_p('coverage')
+      File.write('coverage/puppet-coverage.xml', doc.to_s)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- peadm currently has **zero** code coverage instrumentation — no `COVERAGE`/`SIMPLECOV` env var is set anywhere in CI, so the `RSpec::Puppet::Coverage.report!(0)` call already sitting in `spec/spec_helper.rb`'s `after(:suite)` hook is a no-op.
- `.github/workflows/ci.yml` just delegates to the shared, externally-owned `puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main` reusable workflow — out of scope to edit here.
- `.github/workflows/spec.yml` is peadm's own workflow, but it runs `bundle exec rake parallel_spec` across a Puppet/Ruby matrix, and `puppetlabs_spec_helper` 6.0.3 has no `parallel_spec:simplecov` task (only non-parallel `spec:simplecov`). Added a dedicated single-leg `Coverage` job that runs `rake spec:simplecov` on its own, rather than risk unverified SimpleCov-under-`parallel_tests` merging.
- Checked `.sync.yml`: it lists `.github/workflows/spec.yml` as `unmanaged: false`, but the actual `puppetlabs/pdk-templates` repo (checked directly, `main` branch) has no `spec.yml.erb` at all — that entry is inert, and `spec.yml` is safe to hand-edit. `Gemfile`/`spec/spec_helper.rb`, by contrast, genuinely are template-generated from `.sync.yml`'s `optional:`/`spec_overrides:` keys, so those are updated there too.
- Same Codecov-formatter trap as `puppetlabs/comply` (CISC-7437/puppetlabs/comply#677): no `CODECOV_TOKEN` exists in this repo, so `module_spec_helper`'s hardcoded `Codecov` formatter would silently attempt (and fail) a real network call every run. Dropped it, added `CoberturaFormatter` (`simplecov-cobertura` gem) instead.
- Ported the `.pp` manifest resource-coverage → Cobertura converter from the same PR (plain REXML, no new gem): `rspec-puppet`'s existing `RSpec::Puppet::Coverage` tracks which catalog resources were touched by at least one example; this converts that into a second Cobertura report uploaded alongside the Ruby one.

Note: peadm's `.pp` surface (`spec/classes/setup` only) is much smaller than its plans/functions/tasks — `RSpec::Puppet::Coverage` tracks catalog resources compiled from manifests, not plan execution, so this doesn't cover the bulk of the module. Still correct and additive for what it does cover.

Relates to CISC-7435 (scarp), CISC-7436 (comply-ui), CISC-7437 (comply, puppetlabs/comply#677) — same coverage-reporting initiative, ported to this stack. Jira: PE-45390.

## Test plan
- [x] Verified locally against the real `spec/classes/setup/node_manager_spec.rb`: 4 examples passed, rspec-puppet resource coverage reported 12 resources / 5 touched (41.67%), and the ported converter produced valid Cobertura XML for `manifests/setup/node_manager.pp` with matching hit counts on the correct declaration lines.
- [x] Confirmed no `codecov.io` network call is attempted with the formatter override in place.
- [ ] CI: confirm the new `Coverage` job passes and the code coverage checks/PR comment appear (full `spec_prep` Forge-module download couldn't be verified locally due to an unrelated sandbox limitation — see PR description context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)