### PR TITLE
[DO NOT MERGE] PE-42816 CI validation: XL+DR/2025.11.0 FIPS

### DIFF
--- a/.github/workflows/test-fips-install-matrix.yaml
+++ b/.github/workflows/test-fips-install-matrix.yaml
@@ -36,8 +36,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        architecture: [standard-with-dr, large, extra-large-with-dr]
-        version: [2021.7.9, 2023.8.10, 2025.11.0]
+        # TEMPORARY: trimmed to the single PE-42816 case for validating PR #681.
+        # Revert before merge.
+        architecture: [extra-large-with-dr]
+        version: [2025.11.0]
         image: [rhel-8]
         fips: [enable]
     steps:

--- a/plans/subplans/configure.pp
+++ b/plans/subplans/configure.pp
@@ -120,16 +120,43 @@ plan peadm::subplans::configure (
   }
 
   if $arch['disaster-recovery'] {
-    # Run the PE Replica Provision
-    run_task('peadm::provision_replica', $primary_target,
-      replica    => $replica_target.peadm::certname(),
-      token_file => $token_file,
+    # Pre-flight: wait for PuppetDB to report fully "running" (not "starting")
+    # before invoking the replica provision orchestrator, to reduce the odds
+    # of the known race described below. See PE-42816.
+    peadm::wait_until_service_ready('all', $primary_target)
+    if $primary_postgresql_host {
+      # Extra Large: PuppetDB's backend lives on a separate host.
+      peadm::wait_until_service_ready('all', $primary_postgresql_target)
+    }
 
-      # Race condition, where the provision command checks PuppetDB status and
-      # probably gets "starting", but fails out because that's not "running".
-      # Can remove flag when that issue is fixed.
-      legacy     => true,
-    )
+    # Run the PE Replica Provision
+    #
+    # Race condition, where the provision command checks PuppetDB status and
+    # probably gets "starting", but fails out because that's not "running".
+    # Can remove flag when that issue is fixed. The pre-flight wait above
+    # narrows the window; the retry below is a safety net for when it still
+    # fires (e.g. XL's extra DB-sync hop exceeds the wait budget).
+    $provision_replica_max_attempts = 3
+    $provision_replica_result = range(1, $provision_replica_max_attempts).reduce(undef) |$memo, $attempt| {
+      if $memo =~ NotUndef and $memo.ok {
+        $memo
+      } else {
+        if $attempt > 1 {
+          out::message("provision_replica not ready; retrying (attempt ${attempt}) after 15s...")
+          ctrl::sleep(15)
+        }
+        run_task('peadm::provision_replica', $primary_target,
+          replica       => $replica_target.peadm::certname(),
+          token_file    => $token_file,
+          legacy        => true,
+          _catch_errors => true,
+        )
+      }
+    }
+    unless $provision_replica_result.ok {
+      $provision_replica_error = $provision_replica_result.first.error.message
+      fail_plan("Failed to provision replica after ${provision_replica_max_attempts} attempts: ${provision_replica_error}")
+    }
   }
 
   if $ldap_config {

--- a/plans/subplans/configure.pp
+++ b/plans/subplans/configure.pp
@@ -143,6 +143,7 @@ plan peadm::subplans::configure (
       } else {
         if $attempt > 1 {
           out::message("provision_replica not ready; retrying (attempt ${attempt}) after 15s...")
+          out::message($memo.to_data)
           ctrl::sleep(15)
         }
         run_task('peadm::provision_replica', $primary_target,
@@ -155,6 +156,7 @@ plan peadm::subplans::configure (
     }
     unless $provision_replica_result.ok {
       $provision_replica_error = $provision_replica_result.first.error.message
+      out::message($provision_replica_result.to_data)
       fail_plan("Failed to provision replica after ${provision_replica_max_attempts} attempts: ${provision_replica_error}")
     }
   }

--- a/spec/plans/subplans/configure_spec.rb
+++ b/spec/plans/subplans/configure_spec.rb
@@ -17,4 +17,67 @@ describe 'peadm::subplans::configure' do
       expect(run_plan('peadm::subplans::configure', 'primary_host' => 'primary')).to be_ok
     end
   end
+
+  describe 'Standard architecture with DR' do
+    it 'waits for the primary only before provisioning the replica' do
+      allow_apply
+      allow_any_task
+      allow_any_plan
+      allow_any_command
+
+      expect_task('peadm::wait_until_service_ready').be_called_times(1)
+      expect_task('peadm::provision_replica').be_called_times(1)
+
+      expect(run_plan('peadm::subplans::configure',
+                       'primary_host' => 'primary',
+                       'replica_host' => 'replica')).to be_ok
+    end
+  end
+
+  describe 'Extra Large architecture with DR' do
+    it 'waits for the primary and the postgresql host before provisioning the replica' do
+      allow_apply
+      allow_any_task
+      allow_any_plan
+      allow_any_command
+
+      expect_task('peadm::wait_until_service_ready').be_called_times(2)
+      expect_task('peadm::provision_replica').be_called_times(1)
+
+      expect(run_plan('peadm::subplans::configure',
+                       'primary_host'             => 'primary',
+                       'replica_host'             => 'replica',
+                       'primary_postgresql_host'  => 'primary_postgresql',
+                       'replica_postgresql_host'  => 'replica_postgresql')).to be_ok
+    end
+  end
+
+  describe 'Extra Large architecture with DR, provision_replica flaky' do
+    it 'retries provision_replica and still succeeds' do
+      allow_apply
+      allow_any_task
+      allow_any_plan
+      allow_any_command
+      allow_any_out_message
+
+      attempts = 0
+      expect_task('peadm::provision_replica').return { |targets:, **|
+        attempts += 1
+        results = targets.map do |target|
+          if attempts == 1
+            Bolt::Result.new(target, error: { 'msg' => 'PuppetDB not ready', 'kind' => 'puppetlabs.tasks/race' })
+          else
+            Bolt::Result.new(target, value: {})
+          end
+        end
+        Bolt::ResultSet.new(results)
+      }.be_called_times(2)
+
+      expect(run_plan('peadm::subplans::configure',
+                       'primary_host'             => 'primary',
+                       'replica_host'             => 'replica',
+                       'primary_postgresql_host'  => 'primary_postgresql',
+                       'replica_postgresql_host'  => 'replica_postgresql')).to be_ok
+    end
+  end
 end


### PR DESCRIPTION
Throwaway PR to validate #681's `provision_replica` race mitigation against
the exact failing case from PE-42816: FIPS-enabled `extra-large-with-dr` on
PE 2025.11.0. The FIPS matrix workflow has been temporarily trimmed to just
this one combination so the job isn't buried in the other 8.

Built on top of #681's branch (jyoung/pe-42816-provision-replica-race).

Not for merge - will be closed after CI results are collected.