### PR TITLE
(PE-45431) Complete CA storage migration for split topologies

### DIFF
--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -448,6 +448,94 @@ plan peadm::subplans::install (
   peadm::wait_until_service_ready('pe-master', $primary_target)
   run_task('peadm::puppet_runonce', $primary_target)
 
+  # PE-45431 (ca-db-default epic): On Large/XL/external-Postgres topologies,
+  # peadm runs peadm::pe_install on $primary_target before $database_targets
+  # (above), so pe-ca does not exist when the primary's installer runs --
+  # pe-installer-shim's own migration (PE-45430) checks
+  # ca_storage_backend_reachable, finds it unreachable, and skips loudly:
+  # "The orchestrating installer (for example, peadm) must complete the
+  # database migration once pe-ca is reachable." Complete it here, now that
+  # $database_targets are installed and converged (the wait() above) and the
+  # primary is confirmed ready (the puppet_runonce/wait_until_service_ready
+  # sequence above).
+  #
+  # peadm installs PE versions that predate this feature entirely -- neither
+  # the puppet_enterprise::ca_storage_import plan nor the ca_storage_backend
+  # classifier param exist on those versions, and no ship version for this
+  # feature has been finalized as of this writing, so this cannot be a
+  # hardcoded SemVerRange gate (peadm::assert_supported_pe_version's usual
+  # pattern) without risking a wrong guess before GA. Probe for the plan file
+  # directly instead: a PE version that ships this feature already has it in
+  # the pe-installer's own Boltdir (the same one PE-45430's shim migration
+  # reuses, and the same mechanism `puppet infrastructure run` uses for CA
+  # plans); one that doesn't fails the probe and this step no-ops. Uses
+  # `stat`, not `test -f`: `test -f` exits 1 identically (with empty stderr)
+  # whether the file is genuinely absent or exists but is unreadable (e.g. a
+  # permissions problem on the installer's own Boltdir) -- confirmed
+  # empirically. `stat` exits 1 for both cases too, but its stderr text
+  # differs ("No such file or directory" vs "Permission denied" -- also
+  # confirmed empirically), which is the only way to tell "old PE version"
+  # apart from "real infrastructure problem" here.
+  #
+  # Safe to call again on every topology, including Standard, where the shim
+  # (above, PE-45430) has already migrated when pe-ca was reachable at
+  # install time: ca_storage_import's bulk/delta import steps use upsert
+  # semantics and its Classifier write sets the same value again with no
+  # functional effect. Not a true no-op, though -- the plan unconditionally
+  # re-runs the Puppet agent, restarts pe-puppetserver, and polls readiness
+  # (up to ~145s: 29 retries x 5s between attempts) every time it's invoked,
+  # migrated-already or not. That's an accepted, small fixed cost on every
+  # peadm install, not something this step tries to skip.
+  $ca_storage_import_plan_file = '/opt/puppetlabs/installer/share/Boltdir/modules/puppet_enterprise/plans/ca_storage_import.pp'
+  $ca_storage_import_probe = run_command(
+    "stat '${ca_storage_import_plan_file}'",
+    $primary_target,
+    '_catch_errors' => true,
+  ).first
+
+  if $ca_storage_import_probe.ok {
+    out::message('Completing the Certificate Authority database storage migration (puppet_enterprise::ca_storage_import)...')
+# lint:ignore:strict_indent
+    run_command(@("CMD"/L), $primary_target)
+      BOLT_DISABLE_ANALYTICS=true BOLT_GEM=true /opt/puppetlabs/installer/bin/bolt \
+        --project /opt/puppetlabs/installer/share/Boltdir plan run \
+        puppet_enterprise::ca_storage_import targets=localhost
+      | CMD
+# lint:endignore
+  } elsif $ca_storage_import_probe.error.kind == 'puppetlabs.tasks/command-error' {
+    # The probe command ran (as opposed to failing to reach the target at
+    # all -- that's the else branch below), so a 'stderr' key is guaranteed
+    # present here (Bolt's for_command result always includes it). Only
+    # stat's own "No such file or directory" confirms the file is genuinely
+    # absent, not merely unreadable -- see the stat-vs-test-f rationale
+    # above. Anything else (e.g. "Permission denied") is a real problem with
+    # the installer's own Boltdir on a PE version that likely does ship
+    # this feature, and must fail loudly instead of being treated as "old
+    # PE version, nothing to do."
+    $ca_storage_import_probe_stderr = $ca_storage_import_probe['stderr']
+    if $ca_storage_import_probe_stderr =~ /No such file or directory/ {
+      # out::message, not out::verbose: an install running on a PE version
+      # that predates this feature should visibly say so in a normal run,
+      # not only under elevated Bolt verbosity -- matching how most
+      # status/skip messages in this repo's plans/ are logged (the handful
+      # of existing out::verbose calls in add_database.pp/
+      # util/update_classification.pp are internal step-tracing notes and
+      # config/state dumps, not messages an operator needs to notice by
+      # default).
+      out::message("puppet_enterprise::ca_storage_import is not present on ${primary_target} (this PE version predates the CA database storage feature) -- skipping.") # lint:ignore:140chars
+    } else {
+      fail_plan("Could not confirm ${primary_target} predates the CA database storage feature: ${ca_storage_import_probe_stderr}") # lint:ignore:140chars
+    }
+  } else {
+    # Any other failure kind (e.g. a transport/connect error) means the
+    # probe itself couldn't run at all -- no 'stderr' key exists on that
+    # kind of result, so it's never safe to read unconditionally. This is a
+    # real infrastructure problem, not "old PE version," and must not be
+    # silently treated as a no-op.
+    $ca_storage_import_probe_error = $ca_storage_import_probe.error.message
+    fail_plan("Could not check whether ${primary_target} has the ca_storage_import plan available: ${ca_storage_import_probe_error}") # lint:ignore:140chars
+  }
+
   # Cleanup temp bootstrapping config
   parallelize(['primary', 'primary_postgresql', 'replica_postgresql']) |$var| {
     $target  = getvar("${var}_target", [])

--- a/spec/plans/subplans/install_spec.rb
+++ b/spec/plans/subplans/install_spec.rb
@@ -8,6 +8,7 @@ describe 'peadm::subplans::install' do
     allow_any_task
     allow_any_plan
     allow_any_command
+    allow_out_message
 
     allow_task('peadm::precheck').return_for_targets(
       'primary' => {
@@ -137,5 +138,128 @@ describe 'peadm::subplans::install' do
                      ] })
 
     expect(run_plan('peadm::subplans::install', params)).to be_ok
+  end
+
+  # PE-45431: on Large/XL/external-Postgres topologies the primary's installer
+  # runs before $database_targets exist, so pe-installer-shim's own
+  # migration (PE-45430) finds pe-ca unreachable and skips loudly -- peadm
+  # must complete it once $database_targets have converged.
+  describe 'ca_storage_import (PE-45431)' do
+    let(:params) do
+      {
+        'primary_host' => 'primary',
+        'console_password' => 'puppetLabs123!',
+        'version' => '2023.8.10',
+      }
+    end
+    let(:plan_file) { '/opt/puppetlabs/installer/share/Boltdir/modules/puppet_enterprise/plans/ca_storage_import.pp' }
+    let(:probe_command) { "stat '#{plan_file}'" }
+    # The exact literal command text the @("CMD"/L) heredoc in install.pp
+    # produces: margin-trimmed backslash-continuation joins leave the
+    # multi-space gaps below, and the heredoc always keeps its trailing
+    # newline -- both confirmed by directly capturing the real command via
+    # a temporary allow_any_command.return block, and consistent with the
+    # same artifact already accepted verbatim in this repo's other heredoc-
+    # backed command specs (e.g. restore_spec.rb, backup_spec.rb).
+    let(:migration_command) do
+      'BOLT_DISABLE_ANALYTICS=true BOLT_GEM=true /opt/puppetlabs/installer/bin/bolt   ' \
+        '--project /opt/puppetlabs/installer/share/Boltdir plan run   ' \
+        "puppet_enterprise::ca_storage_import targets=localhost\n"
+    end
+
+    # error_with/always_return can't simulate a real nonzero-exit command
+    # result with custom stderr (BoltSpec's CommandStub#result_for hardcodes
+    # exit_code to 0 either way) -- construct the Bolt::Result directly via
+    # a .return block instead, matching how Bolt's own Result.for_command
+    # builds a real command failure (stdout/stderr preserved, 'puppetlabs.
+    # tasks/command-error' kind attached only when exit_code != 0).
+    def stub_probe_command_failure(stderr:)
+      expect_command(probe_command).with_targets('primary').return do |targets:, command:, params:| # rubocop:disable Lint/UnusedBlockArgument
+        value = { 'stdout' => '', 'stderr' => stderr, 'exit_code' => 1 }
+        Bolt::ResultSet.new(targets.map { |target| Bolt::Result.for_command(target, value, 'command', command, []) })
+      end
+    end
+
+    it 'runs the migration on the primary when this PE version ships the plan' do
+      expect_command(probe_command).with_targets('primary')
+      expect_command(migration_command).with_targets('primary')
+
+      expect(run_plan('peadm::subplans::install', params)).to be_ok
+    end
+
+    # Extra Large / external-Postgres: $database_targets is non-empty and
+    # $primary_target is installed before it (see plans/subplans/install.pp,
+    # peadm::pe_install on $primary_target then on $database_targets) --
+    # this is the exact ordering that leaves pe-ca unreachable from the
+    # shim's own migration (PE-45430), motivating this step in the first
+    # place. Confirms the migration still targets the primary correctly
+    # once a database target is in the mix.
+    it 'runs the migration on the primary on a split (external-Postgres) topology' do
+      xl_params = params.merge('primary_postgresql_host' => 'postgres')
+      allow_task('peadm::precheck').return_for_targets(
+        'primary' => { 'hostname' => 'primary', 'platform' => 'el-7.11-x86_64' },
+        'postgres' => { 'hostname' => 'postgres', 'platform' => 'el-7.11-x86_64' },
+      )
+
+      expect_command(probe_command).with_targets('primary')
+      expect_command(migration_command).with_targets('primary')
+
+      expect(run_plan('peadm::subplans::install', xl_params)).to be_ok
+    end
+
+    it 'no-ops without running the migration when this PE version predates the feature' do
+      stub_probe_command_failure(stderr: "stat: cannot stat '#{plan_file}': No such file or directory")
+      expect_command(migration_command).not_be_called
+
+      expect(run_plan('peadm::subplans::install', params)).to be_ok
+    end
+
+    # The whole reason this probes with `stat` instead of `test -f`: a real
+    # permissions problem on the installer's own Boltdir exits non-zero
+    # identically to a genuinely missing file, but stat's stderr text is
+    # different for the two cases, and only "No such file or directory" may
+    # be treated as "this PE version predates the feature." Anything else
+    # (e.g. "Permission denied") is a real infrastructure problem that must
+    # fail loudly, not silently skip a needed migration.
+    it 'fails the install when the probe fails for a reason other than a missing file' do
+      stub_probe_command_failure(stderr: "stat: cannot stat '#{plan_file}': Permission denied")
+      expect_command(migration_command).not_be_called
+
+      result = run_plan('peadm::subplans::install', params)
+      expect(result).not_to be_ok
+      expect(result.value.msg).to match(%r{Permission denied})
+    end
+
+    # A transport/connect failure must not be silently conflated with "this
+    # PE version predates the feature" (both would otherwise present as a
+    # non-ok probe result) -- it's a real infrastructure problem and must
+    # fail the install loudly instead of skipping.
+    it 'fails the install when the probe itself cannot be run (e.g. a transport failure)' do
+      expect_command(probe_command).with_targets('primary')
+                                   .error_with('msg' => 'Connection refused', 'kind' => 'puppetlabs.tasks/connect-error')
+      expect_command(migration_command).not_be_called
+
+      result = run_plan('peadm::subplans::install', params)
+      expect(result).not_to be_ok
+      expect(result.value.msg).to match(%r{Connection refused})
+    end
+
+    # No _catch_errors on the migration run_command itself (unlike the
+    # probe): a failure here raises Bolt's own uncaught PlanFailure and
+    # halts the whole peadm::install run, matching the file's dominant
+    # convention (pe_install, rbac_token, code_manager, etc. all fail the
+    # same way). Bolt's own generated diagnostic names the exact command
+    # and target that failed -- there is no additional message to surface
+    # on top of that, per this plan's established style for uncaught
+    # run_command calls.
+    it 'fails the install when the migration itself fails' do
+      expect_command(probe_command).with_targets('primary')
+      expect_command(migration_command).with_targets('primary')
+                                       .error_with('msg' => 'CA storage import failed', 'kind' => 'puppetlabs.tasks/command-error')
+
+      result = run_plan('peadm::subplans::install', params)
+      expect(result).not_to be_ok
+      expect(result.value.msg).to match(%r{run_command.*failed on 1 target}m)
+    end
   end
 end


### PR DESCRIPTION
## Summary

Per [PE-45431](https://perforce.atlassian.net/browse/PE-45431) (CA-DB default 3.2b, epic PE-45424). On Large/XL/external-Postgres peadm topologies, `peadm::pe_install` runs on `$primary_target` **before** `$database_targets` exist, so `pe-ca` is unreachable when the primary's installer runs. `pe-installer-shim`'s own migration (PE-45430) checks `ca_storage_backend_reachable`, finds it unreachable, and skips loudly — its own error message names peadm as the orchestrator responsible for finishing the job:

> "The orchestrating installer (for example, peadm) must complete the database migration once pe-ca is reachable."

This adds that step to `peadm::subplans::install`: once `$database_targets` have converged and the primary is confirmed ready, probe the primary for the `puppet_enterprise::ca_storage_import` plan and run it via the pe-installer's own bundled Bolt project (`/opt/puppetlabs/installer/share/Boltdir`) — the same mechanism the shim itself uses, and the same one `puppet infrastructure run` uses for CA plans. No new module dependency was added to peadm; this reuses the module version that ships with the target PE build, per product intent.

**Version gating:** no ship version for this feature has been finalized, and peadm installs PE versions that predate it entirely, so this can't be a hardcoded `SemVerRange` gate (peadm's usual pattern for version-conditional behavior). Instead it probes for the plan file directly and no-ops if absent.

**Probe design (`stat`, not `test -f`):** `test -f` exits 1 identically — with empty stderr either way — whether the plan file is genuinely absent or exists but is unreadable (e.g. a permissions problem on the installer's own Boltdir). `stat`'s stderr text differs ("No such file or directory" vs "Permission denied"), confirmed empirically, and is the only way to distinguish "old PE version" from a real infrastructure problem on a version that likely *does* ship the feature. Only a genuine missing-file result is treated as an expected no-op; anything else — a permissions problem, or the probe failing to run at all (e.g. a transport error) — fails the install loudly with the real diagnostic surfaced, rather than silently skipping a needed migration.

**Idempotency:** safe to call on every topology, including Standard (where the shim has typically already migrated) — `ca_storage_import`'s bulk/delta import steps use upsert semantics and its Classifier write repeats the same value. Not a true no-op cost-wise: the plan unconditionally re-runs the Puppet agent and restarts `pe-puppetserver` (up to ~145s of readiness polling) every time it's invoked — an accepted, small fixed cost, documented inline.

## Testing

- 6 new BoltSpec cases in `spec/plans/subplans/install_spec.rb` covering: migration runs (default topology), migration runs (split/external-Postgres topology — the scenario motivating this ticket), benign no-op (missing file), hard-fail (permission-denied stderr), hard-fail (probe transport failure), hard-fail (migration command itself fails)
- `bundle exec rspec spec/plans` — 59 examples, 0 failures, 1 pre-existing unrelated pending
- `puppet-lint` on `plans/subplans/install.pp` — clean
- `rubocop` on the spec file — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)