### PR TITLE
Adding support for PE 2023.8.11 and 2025.11.3

### DIFF
--- a/.github/workflows/test-add-compiler-matrix.yml
+++ b/.github/workflows/test-add-compiler-matrix.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [standard, large, extra-large]
-        version: [2021.7.9, 2023.8.10, 2025.11.2]
+        version: [2021.7.9, 2023.8.11, 2025.11.3]
         image: [almalinux-cloud/almalinux-8]
     steps:
       - name: Checkout Source

--- a/.github/workflows/test-add-compiler.yaml
+++ b/.github/workflows/test-add-compiler.yaml
@@ -14,7 +14,7 @@ on:
       version:
         description: PE version to install
         required: true
-        default: 2023.8.10
+        default: 2023.8.11
       ssh-debugging:
         description: Boolean; whether or not to pause for ssh debugging
         required: true

--- a/.github/workflows/test-add-replica-matrix.yaml
+++ b/.github/workflows/test-add-replica-matrix.yaml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [standard, standard-with-dr, large, extra-large]
-        version: [2023.8.10, 2025.11.2]
+        version: [2023.8.11, 2025.11.3]
         image: [almalinux-cloud/almalinux-8]
     steps:
       - name: Checkout Source

--- a/.github/workflows/test-add-replica.yaml
+++ b/.github/workflows/test-add-replica.yaml
@@ -14,7 +14,7 @@ on:
       version:
         description: PE version to install
         required: true
-        default: 2023.8.10
+        default: 2023.8.11
       ssh-debugging:
         description: Boolean; whether or not to pause for ssh debugging
         required: true

--- a/.github/workflows/test-backup-restore.yaml
+++ b/.github/workflows/test-backup-restore.yaml
@@ -24,14 +24,14 @@ on:
       version:
         description: PE version to install
         required: true
-        default: 2025.11.2
+        default: 2025.11.3
       ssh-debugging:
         description: Boolean; whether or not to pause for ssh debugging
         required: true
         default: 'false'
 jobs:
   backup-restore-test:
-    name: "Backup, break and restore cluster: PE ${{ github.event.inputs.version || '2025.11.2' }}\
+    name: "Backup, break and restore cluster: PE ${{ github.event.inputs.version || '2025.11.3' }}\
       \ ${{ github.event.inputs.architecture || 'extra-large' }} on ${{ github.event.inputs.image || 'almalinux-cloud/almalinux-8' }}"
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/test-failover.yaml
+++ b/.github/workflows/test-failover.yaml
@@ -14,7 +14,7 @@ on:
       version_to_upgrade:
         description: PE version to upgrade to
         required: false
-        default: 2023.8.10
+        default: 2023.8.11
       ssh-debugging:
         description: Boolean; whether or not to pause for ssh debugging
         required: true

--- a/.github/workflows/test-fips-install-matrix.yaml
+++ b/.github/workflows/test-fips-install-matrix.yaml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [standard-with-dr, large, extra-large-with-dr]
-        version: [2021.7.9, 2023.8.10, 2025.11.2]
+        version: [2021.7.9, 2023.8.11, 2025.11.3]
         image: [rhel-8]
         fips: [enable]
     steps:

--- a/.github/workflows/test-install-matrix.yaml
+++ b/.github/workflows/test-install-matrix.yaml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [standard-with-dr, large, extra-large-with-dr]
-        version: [2021.7.9, 2023.8.10, 2025.11.2]
+        version: [2021.7.9, 2023.8.11, 2025.11.3]
         image: [almalinux-cloud/almalinux-8]
     steps:
       - name: Checkout Source

--- a/.github/workflows/test-install-rhel-9.yaml
+++ b/.github/workflows/test-install-rhel-9.yaml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [standard-with-dr, large, extra-large-with-dr]
-        version: [2021.7.9, 2023.8.10, 2025.11.2]
+        version: [2021.7.9, 2023.8.11, 2025.11.3]
         image: [rhel-9]
     steps:
       - name: Checkout Source

--- a/.github/workflows/test-install.yaml
+++ b/.github/workflows/test-install.yaml
@@ -14,7 +14,7 @@ on:
       version:
         description: PE version to install
         required: true
-        default: 2023.8.10
+        default: 2023.8.11
       ssh-debugging:
         description: Boolean; whether or not to pause for ssh debugging
         required: true

--- a/.github/workflows/test-legacy-compilers.yaml
+++ b/.github/workflows/test-legacy-compilers.yaml
@@ -99,7 +99,7 @@ jobs:
             --modulepath spec/fixtures/modules \
             architecture=large-with-dr \
             console_password=${{ secrets.CONSOLE_PASSWORD }} \
-            version=2025.11.2
+            version=2025.11.3
       - name: Wait as long as the file ${HOME}/pause file is present
         if: ${{ always() && github.event.inputs.ssh-debugging == 'true' }}
         run: |

--- a/.github/workflows/test-legacy-upgrade.yaml
+++ b/.github/workflows/test-legacy-upgrade.yaml
@@ -98,7 +98,7 @@ jobs:
           legacy_compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | sed -n 2p)
           replica=$(yq '.groups[].targets[] | select(.vars.role == "replica") | .name' spec/fixtures/litmus_inventory.yaml)
           hash_random=$(LC_ALL=C tr -dc 'A-Za-z0-9!#$%&'\''()*+,-./:;<=>?@[\]^_`{|}~' </dev/urandom | head -c 30; echo)
-          echo -n '{ "download_mode": "direct", "primary_host": "'$primary'", "replica_host": "'$replica'", "legacy_compilers": ["'$legacy_compiler'"], "compiler_hosts": ["'$compiler'"], "version": "2023.8.10", "console_password": "'$hash_random'" }' > params.json
+          echo -n '{ "download_mode": "direct", "primary_host": "'$primary'", "replica_host": "'$replica'", "legacy_compilers": ["'$legacy_compiler'"], "compiler_hosts": ["'$compiler'"], "version": "2023.8.11", "console_password": "'$hash_random'" }' > params.json
       - name: Install PE with legacy compilers
         timeout-minutes: 120
         run: |
@@ -152,7 +152,7 @@ jobs:
           compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | head -n 1)
           legacy_compiler=$(yq '.groups[].targets[] | select(.vars.role == "compiler") | .name' spec/fixtures/litmus_inventory.yaml | sed -n 2p)
           replica=$(yq '.groups[].targets[] | select(.vars.role == "replica") | .name' spec/fixtures/litmus_inventory.yaml)
-          echo -n '{ "primary_host": "'$primary'", "replica_host": "'$replica'", "compiler_hosts": ["'$compiler'", "'$legacy_compiler'"], "version": "2025.11.2"}' > upgrade_params.json
+          echo -n '{ "primary_host": "'$primary'", "replica_host": "'$replica'", "compiler_hosts": ["'$compiler'", "'$legacy_compiler'"], "version": "2025.11.3"}' > upgrade_params.json
       - name: Clean cache on PE nodes before upgrade
         run: |
           bundle exec bolt command run \

--- a/.github/workflows/test-migration.yaml
+++ b/.github/workflows/test-migration.yaml
@@ -43,30 +43,30 @@ jobs:
           - extra-large
           - large-with-dr
           - extra-large-with-dr
-        version: [2021.7.9, 2023.8.10, 2025.11.2]
+        version: [2021.7.9, 2023.8.11, 2025.11.3]
         image: [almalinux-cloud/almalinux-8]
         include:
           - architecture: standard
-            version: 2023.8.10
+            version: 2023.8.11
             image: almalinux-cloud/almalinux-8
-            new_pe_version: 2025.11.2
+            new_pe_version: 2025.11.3
           - architecture: large
-            version: 2023.8.10
+            version: 2023.8.11
             image: almalinux-cloud/almalinux-8
-            new_pe_version: 2025.11.2
+            new_pe_version: 2025.11.3
           - architecture: extra-large
-            version: 2023.8.10
+            version: 2023.8.11
             image: almalinux-cloud/almalinux-8
-            new_pe_version: 2025.11.2
+            new_pe_version: 2025.11.3
           # excluding the following combinations as due to their long running nature they always fail due to
           # the test nodes in GCP that litmus provisions becoming unreachable after a time. If we address PE-40902
           # to change how we provision test nodes in CI then we will hopefully be able to include these
         exclude:
           - architecture: extra-large-with-dr
-            version: 2023.8.10
+            version: 2023.8.11
             image: almalinux-cloud/almalinux-8
           - architecture: extra-large-with-dr
-            version: 2025.11.2
+            version: 2025.11.3
             image: almalinux-cloud/almalinux-8
     steps:
       - name: Checkout Source

--- a/.github/workflows/test-replace-failed-postgresql.yaml
+++ b/.github/workflows/test-replace-failed-postgresql.yaml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         architecture: [extra-large-with-dr-and-spare-replica]
         install_architecture: [extra-large-with-dr]
-        version: [2021.7.9, 2023.8.10, 2025.11.2]
+        version: [2021.7.9, 2023.8.11, 2025.11.3]
         image: [almalinux-cloud/almalinux-8]
     steps:
       - name: Checkout Source

--- a/.github/workflows/test-upgrade-latest-dev.yaml
+++ b/.github/workflows/test-upgrade-latest-dev.yaml
@@ -23,7 +23,7 @@ on:
         type: string
         required: true
         description: The initial version of PE to install before upgrade
-        default: 2023.8.10
+        default: 2023.8.11
       ssh-debugging:
         description: Boolean; whether or not to pause for ssh debugging
         required: true

--- a/.github/workflows/test-upgrade-latest-xlarge-dev-nightly.yaml
+++ b/.github/workflows/test-upgrade-latest-xlarge-dev-nightly.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [extra-large-with-dr]
-        version: [2023.8.10]
+        version: [2023.8.11]
         image: [almalinux-cloud/almalinux-8]
     steps:
       - name: Checkout Source

--- a/.github/workflows/test-upgrade-matrix.yaml
+++ b/.github/workflows/test-upgrade-matrix.yaml
@@ -37,19 +37,19 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [standard, extra-large]  # removing xl-with dr until PE-40902 is addressed
-        version: [2021.7.9, 2023.8.10]
-        version_to_upgrade: [2021.7.9, 2023.8.10, 2025.11.2]
+        version: [2021.7.9, 2023.8.11]
+        version_to_upgrade: [2021.7.9, 2023.8.11, 2025.11.3]
         image: [almalinux-cloud/almalinux-8]
         download_mode: [direct]
         exclude:
           - version: 2021.7.9
             version_to_upgrade: 2021.7.9
           - version: 2021.7.9
-            version_to_upgrade: 2025.11.2
-          - version: 2023.8.10
+            version_to_upgrade: 2025.11.3
+          - version: 2023.8.11
             version_to_upgrade: 2021.7.9
-          - version: 2023.8.10
-            version_to_upgrade: 2023.8.10
+          - version: 2023.8.11
+            version_to_upgrade: 2023.8.11
     steps:
       - name: Start SSH session
         if: ${{ github.event.inputs.ssh-debugging == 'true' }}

--- a/.github/workflows/test-upgrade-pg-major-ha-nightly.yaml
+++ b/.github/workflows/test-upgrade-pg-major-ha-nightly.yaml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [standard-with-dr]
-        version: [2023.8.10]
+        version: [2023.8.11]
         image: [almalinux-cloud/almalinux-8]
     steps:
       - name: Checkout Source

--- a/.github/workflows/test-upgrade.yaml
+++ b/.github/workflows/test-upgrade.yaml
@@ -26,7 +26,7 @@ on:
       upgrade_version:
         description: PE version to upgrade to
         required: true
-        default: 2023.8.10
+        default: 2023.8.11
       ssh-debugging:
         description: Boolean; whether or not to pause for ssh debugging
         required: true

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2349,7 +2349,7 @@ Data type: `Peadm::Pe_version`
 
 
 
-Default value: `'2023.8.10'`
+Default value: `'2023.8.11'`
 
 ##### <a name="-peadm--install--dns_alt_names"></a>`dns_alt_names`
 

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -58,7 +58,7 @@ plan peadm::install (
 
   # Common Configuration
   String                            $console_password,
-  Peadm::Pe_version                 $version                          = '2023.8.10',
+  Peadm::Pe_version                 $version                          = '2023.8.11',
   Optional[Stdlib::HTTPSUrl]        $pe_installer_source              = undef,
   Optional[Array[String]]           $dns_alt_names                    = undef,
   Optional[String]                  $compiler_pool_address            = undef,

--- a/spec/plans/subplans/install_spec.rb
+++ b/spec/plans/subplans/install_spec.rb
@@ -88,11 +88,11 @@ describe 'peadm::subplans::install' do
     expect(run_plan('peadm::subplans::install', params)).to be_ok
   end
 
-  it 'installs 2023.8.10 with legacy compilers' do
+  it 'installs 2023.8.11 with legacy compilers' do
     params = {
       'primary_host' => 'primary',
       'console_password' => 'puppetLabs123!',
-      'version' => '2023.8.10',
+      'version' => '2023.8.11',
       'legacy_compilers' => ['compiler1', 'compiler2'],
     }
     expect(run_plan('peadm::subplans::install', params)).to be_ok
@@ -107,7 +107,7 @@ describe 'peadm::subplans::install' do
       'primary_host' => 'primary',
       'compiler_hosts' => ['compiler1'],
       'console_password' => 'puppetLabs123!',
-      'version' => '2023.8.10',
+      'version' => '2023.8.11',
     }
 
     expect_task('peadm::agent_install')
@@ -125,7 +125,7 @@ describe 'peadm::subplans::install' do
       'primary_host' => 'primary',
       'compiler_hosts' => ['compiler1'],
       'console_password' => 'puppetLabs123!',
-      'version' => '2023.8.10',
+      'version' => '2023.8.11',
       'dns_alt_names' => ['puppet', 'alt.example.com'],
     }
 
@@ -149,7 +149,7 @@ describe 'peadm::subplans::install' do
       {
         'primary_host' => 'primary',
         'console_password' => 'puppetLabs123!',
-        'version' => '2023.8.10',
+        'version' => '2023.8.11',
       }
     end
     let(:plan_file) { '/opt/puppetlabs/installer/share/Boltdir/modules/puppet_enterprise/plans/ca_storage_import.pp' }


### PR DESCRIPTION
## Summary
Bump the default install version and CI test matrices from 2023.8.10 to 2023.8.11 (LTS) and from 2025.11.2 to 2025.11.3 (STS). Paired LTS+STS release per PE-46678.

Jira: [PE-46678](https://perforce.atlassian.net/browse/PE-46678)

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.

#### Changes include test coverage?
- [x] Yes

#### Have you updated the documentation?
- [x] REFERENCE.md regenerated (default value bump only)