### PR TITLE
(PE-46685) Fix ca_storage_import probe to resolve through Bolt's modulepath

### DIFF
--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -464,18 +464,21 @@ plan peadm::subplans::install (
   # classifier param exist on those versions, and no ship version for this
   # feature has been finalized as of this writing, so this cannot be a
   # hardcoded SemVerRange gate (peadm::assert_supported_pe_version's usual
-  # pattern) without risking a wrong guess before GA. Probe for the plan file
-  # directly instead: a PE version that ships this feature already has it in
-  # the pe-installer's own Boltdir (the same one PE-45430's shim migration
-  # reuses, and the same mechanism `puppet infrastructure run` uses for CA
-  # plans); one that doesn't fails the probe and this step no-ops. Uses
-  # `stat`, not `test -f`: `test -f` exits 1 identically (with empty stderr)
-  # whether the file is genuinely absent or exists but is unreadable (e.g. a
-  # permissions problem on the installer's own Boltdir) -- confirmed
-  # empirically. `stat` exits 1 for both cases too, but its stderr text
-  # differs ("No such file or directory" vs "Permission denied" -- also
-  # confirmed empirically), which is the only way to tell "old PE version"
-  # apart from "real infrastructure problem" here.
+  # pattern) without risking a wrong guess before GA. Probe by asking Bolt
+  # itself whether the plan resolves, instead of statting one hardcoded
+  # directory (PE-46685): the installer's own Boltdir
+  # (/opt/puppetlabs/installer/share/Boltdir) configures a three-entry
+  # modulepath in its bolt.yaml, and puppet_enterprise is shipped from the
+  # *enterprise environment* entry (.../server/data/environments/enterprise/
+  # modules), never from that Boltdir's own modules/ subdirectory --
+  # confirmed empirically against a live install. A raw `stat` against
+  # Boltdir/modules/puppet_enterprise/plans/ca_storage_import.pp therefore
+  # reports "No such file or directory" unconditionally, on every PE
+  # version, which silently no-ops this entire migration step always, not
+  # just on versions that predate the feature. `bolt ... plan show
+  # puppet_enterprise::ca_storage_import` resolves through the same
+  # modulepath the real `plan run` invocation below uses, so it can't drift
+  # from what that invocation actually finds.
   #
   # Safe to call again on every topology, including Standard, where the shim
   # (above, PE-45430) has already migrated when pe-ca was reachable at
@@ -486,9 +489,8 @@ plan peadm::subplans::install (
   # (up to ~145s: 29 retries x 5s between attempts) every time it's invoked,
   # migrated-already or not. That's an accepted, small fixed cost on every
   # peadm install, not something this step tries to skip.
-  $ca_storage_import_plan_file = '/opt/puppetlabs/installer/share/Boltdir/modules/puppet_enterprise/plans/ca_storage_import.pp'
   $ca_storage_import_probe = run_command(
-    "stat '${ca_storage_import_plan_file}'",
+    'BOLT_DISABLE_ANALYTICS=true BOLT_GEM=true /opt/puppetlabs/installer/bin/bolt --project /opt/puppetlabs/installer/share/Boltdir plan show puppet_enterprise::ca_storage_import', # lint:ignore:140chars
     $primary_target,
     '_catch_errors' => true,
   ).first
@@ -504,16 +506,18 @@ plan peadm::subplans::install (
 # lint:endignore
   } elsif $ca_storage_import_probe.error.kind == 'puppetlabs.tasks/command-error' {
     # The probe command ran (as opposed to failing to reach the target at
-    # all -- that's the else branch below), so a 'stderr' key is guaranteed
-    # present here (Bolt's for_command result always includes it). Only
-    # stat's own "No such file or directory" confirms the file is genuinely
-    # absent, not merely unreadable -- see the stat-vs-test-f rationale
-    # above. Anything else (e.g. "Permission denied") is a real problem with
-    # the installer's own Boltdir on a PE version that likely does ship
-    # this feature, and must fail loudly instead of being treated as "old
-    # PE version, nothing to do."
-    $ca_storage_import_probe_stderr = $ca_storage_import_probe['stderr']
-    if $ca_storage_import_probe_stderr =~ /No such file or directory/ {
+    # all -- that's the else branch below), so 'stdout'/'stderr' keys are
+    # guaranteed present here (Bolt's for_command result always includes
+    # both). `bolt plan show <missing-plan>` prints "Could not find a plan
+    # named '...'." to STDOUT (confirmed empirically -- NOT stderr, unlike
+    # most CLI error conventions) and exits 1. Only that specific message
+    # confirms the plan is genuinely absent from every modulepath entry, not
+    # merely that something else went wrong resolving it; anything else
+    # (e.g. a Puppetfile/module-resolution error) is a real problem on a PE
+    # version that likely does ship this feature, and must fail loudly
+    # instead of being treated as "old PE version, nothing to do."
+    $ca_storage_import_probe_stdout = $ca_storage_import_probe['stdout']
+    if $ca_storage_import_probe_stdout =~ /Could not find a plan named/ {
       # out::message, not out::verbose: an install running on a PE version
       # that predates this feature should visibly say so in a normal run,
       # not only under elevated Bolt verbosity -- matching how most
@@ -524,14 +528,15 @@ plan peadm::subplans::install (
       # default).
       out::message("puppet_enterprise::ca_storage_import is not present on ${primary_target} (this PE version predates the CA database storage feature) -- skipping.") # lint:ignore:140chars
     } else {
-      fail_plan("Could not confirm ${primary_target} predates the CA database storage feature: ${ca_storage_import_probe_stderr}") # lint:ignore:140chars
+      $ca_storage_import_probe_stderr = $ca_storage_import_probe['stderr']
+      fail_plan("Could not confirm ${primary_target} predates the CA database storage feature: ${ca_storage_import_probe_stdout} ${ca_storage_import_probe_stderr}") # lint:ignore:140chars
     }
   } else {
     # Any other failure kind (e.g. a transport/connect error) means the
-    # probe itself couldn't run at all -- no 'stderr' key exists on that
-    # kind of result, so it's never safe to read unconditionally. This is a
-    # real infrastructure problem, not "old PE version," and must not be
-    # silently treated as a no-op.
+    # probe itself couldn't run at all -- no 'stdout'/'stderr' keys exist on
+    # that kind of result, so it's never safe to read them unconditionally.
+    # This is a real infrastructure problem, not "old PE version," and must
+    # not be silently treated as a no-op.
     $ca_storage_import_probe_error = $ca_storage_import_probe.error.message
     fail_plan("Could not check whether ${primary_target} has the ca_storage_import plan available: ${ca_storage_import_probe_error}") # lint:ignore:140chars
   }

--- a/spec/plans/subplans/install_spec.rb
+++ b/spec/plans/subplans/install_spec.rb
@@ -152,8 +152,16 @@ describe 'peadm::subplans::install' do
         'version' => '2023.8.10',
       }
     end
-    let(:plan_file) { '/opt/puppetlabs/installer/share/Boltdir/modules/puppet_enterprise/plans/ca_storage_import.pp' }
-    let(:probe_command) { "stat '#{plan_file}'" }
+    # PE-46685: probes via `bolt plan show`, which resolves through the
+    # installer Boltdir's full modulepath (site-modules, the enterprise
+    # environment, then Boltdir/modules itself) -- the same resolution the
+    # migration_command below relies on -- instead of statting one hardcoded
+    # subdirectory of that modulepath that never actually contains
+    # puppet_enterprise on a real install.
+    let(:probe_command) do
+      'BOLT_DISABLE_ANALYTICS=true BOLT_GEM=true /opt/puppetlabs/installer/bin/bolt ' \
+        '--project /opt/puppetlabs/installer/share/Boltdir plan show puppet_enterprise::ca_storage_import'
+    end
     # The exact literal command text the @("CMD"/L) heredoc in install.pp
     # produces: margin-trimmed backslash-continuation joins leave the
     # multi-space gaps below, and the heredoc always keeps its trailing
@@ -168,14 +176,15 @@ describe 'peadm::subplans::install' do
     end
 
     # error_with/always_return can't simulate a real nonzero-exit command
-    # result with custom stderr (BoltSpec's CommandStub#result_for hardcodes
-    # exit_code to 0 either way) -- construct the Bolt::Result directly via
-    # a .return block instead, matching how Bolt's own Result.for_command
-    # builds a real command failure (stdout/stderr preserved, 'puppetlabs.
-    # tasks/command-error' kind attached only when exit_code != 0).
-    def stub_probe_command_failure(stderr:)
+    # result with custom stdout/stderr (BoltSpec's CommandStub#result_for
+    # hardcodes exit_code to 0 either way) -- construct the Bolt::Result
+    # directly via a .return block instead, matching how Bolt's own
+    # Result.for_command builds a real command failure (stdout/stderr
+    # preserved, 'puppetlabs.tasks/command-error' kind attached only when
+    # exit_code != 0).
+    def stub_probe_command_failure(stdout: '', stderr: '')
       expect_command(probe_command).with_targets('primary').return do |targets:, command:, params:| # rubocop:disable Lint/UnusedBlockArgument
-        value = { 'stdout' => '', 'stderr' => stderr, 'exit_code' => 1 }
+        value = { 'stdout' => stdout, 'stderr' => stderr, 'exit_code' => 1 }
         Bolt::ResultSet.new(targets.map { |target| Bolt::Result.for_command(target, value, 'command', command, []) })
       end
     end
@@ -208,26 +217,25 @@ describe 'peadm::subplans::install' do
     end
 
     it 'no-ops without running the migration when this PE version predates the feature' do
-      stub_probe_command_failure(stderr: "stat: cannot stat '#{plan_file}': No such file or directory")
+      stub_probe_command_failure(stdout: "Could not find a plan named 'puppet_enterprise::ca_storage_import'. " \
+                                          "For a list of available plans, run 'bolt plan show'.\n")
       expect_command(migration_command).not_be_called
 
       expect(run_plan('peadm::subplans::install', params)).to be_ok
     end
 
-    # The whole reason this probes with `stat` instead of `test -f`: a real
-    # permissions problem on the installer's own Boltdir exits non-zero
-    # identically to a genuinely missing file, but stat's stderr text is
-    # different for the two cases, and only "No such file or directory" may
-    # be treated as "this PE version predates the feature." Anything else
-    # (e.g. "Permission denied") is a real infrastructure problem that must
-    # fail loudly, not silently skip a needed migration.
-    it 'fails the install when the probe fails for a reason other than a missing file' do
-      stub_probe_command_failure(stderr: "stat: cannot stat '#{plan_file}': Permission denied")
+    # `bolt plan show` prints its "not found" message to STDOUT, not stderr
+    # (confirmed empirically) -- only that specific message on stdout may be
+    # treated as "this PE version predates the feature." Anything else
+    # (e.g. a Puppetfile/module-resolution error) is a real infrastructure
+    # problem that must fail loudly, not silently skip a needed migration.
+    it 'fails the install when the probe fails for a reason other than a missing plan' do
+      stub_probe_command_failure(stderr: "Fatal Puppetfile error while resolving modules: connection refused\n")
       expect_command(migration_command).not_be_called
 
       result = run_plan('peadm::subplans::install', params)
       expect(result).not_to be_ok
-      expect(result.value.msg).to match(%r{Permission denied})
+      expect(result.value.msg).to match(%r{connection refused})
     end
 
     # A transport/connect failure must not be silently conflated with "this


### PR DESCRIPTION
## Problem

The PE-45431 two-stage migration step in `plans/subplans/install.pp` (Large/XL/external-Postgres topologies) probes for the `puppet_enterprise::ca_storage_import` plan with a raw `stat` against one hardcoded directory of the installer Boltdir's modulepath:

```
/opt/puppetlabs/installer/share/Boltdir/modules/puppet_enterprise/plans/ca_storage_import.pp
```

and treats "No such file or directory" as "this PE version predates the CA database storage feature -- skipping."

That Boltdir's own `bolt.yaml` configures a three-entry modulepath:

```yaml
modulepath: "/opt/puppetlabs/installer/share/Boltdir/site-modules:/opt/puppetlabs/server/data/environments/enterprise/modules:/opt/puppetlabs/installer/share/Boltdir/modules"
```

`puppet_enterprise` ships and resolves from the **middle** entry (the enterprise environment), never from `Boltdir/modules` itself -- confirmed by inspecting a live, fully-installed host running a current dev build (`puppet-enterprise-2026.0.0-rc0-270-gcc1dd9c`): `Boltdir/modules/` contains only generic Bolt stdlib-style modules, while the real, up-to-date `ca_storage_import.pp` lives only at the enterprise-environment path.

`pe-installer-shim`'s own successful migration call (`CA_STORAGE_IMPORT_BOLT_INVOCATION`) works correctly because it runs `bolt ... plan run puppet_enterprise::ca_storage_import`, which resolves through the full modulepath -- it never stats that one subdirectory.

**Impact:** the probe's `stat` call reports "No such file or directory" and skips the migration on *every* PE version, not just ones that predate the feature. On a Large/XL/external-Postgres topology, the primary never completes stage 2 of the migration, and the CA backend silently stays on `filesystem` post-install.

## Fix

Replace the `stat <hardcoded path>` probe with:

```
bolt --project /opt/puppetlabs/installer/share/Boltdir plan show puppet_enterprise::ca_storage_import
```

which resolves through the same modulepath the actual `plan run` invocation uses just below it, so the two can't drift apart. `bolt plan show <missing-plan>` exits 1 and prints `Could not find a plan named '...'.` to **stdout** (confirmed empirically -- not stderr like the old `stat` check), so the error-string check moves accordingly.

## How this was found

Live ABS acceptance run for PE-45860 (`pe_acceptance_tests` PR #3707, `acceptance/tests/ca/ca_db/01c_external_postgres.rb`) against a fresh, correctly-configured external-postgres peadm install pinned past the real PE-45431 merge (`8d01cbd1`). The test asserted the CA backend defaults to `database` post-install and observed `filesystem`; SSH inspection of the live host confirmed the underlying PE build genuinely ships the up-to-date feature, isolating the bug to this probe.

## Testing

- `bundle exec rspec spec/plans/subplans/install_spec.rb` -- 13 examples, 0 failures (updated to match the new probe mechanism).
- `bundle exec rspec spec/plans/ spec/functions/` -- 123 examples, 0 failures, 6 pre-existing pending (unrelated).
- `bundle exec puppet-lint plans/subplans/install.pp` -- clean.
- `bundle exec rubocop spec/plans/subplans/install_spec.rb` -- clean.
- Empirically verified `bolt plan show <nonexistent-plan>`'s exit code and stdout/stderr placement locally before writing the fix.

Jira: PE-46685 (filed under epic PE-45424, CA-DB default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)