### PR TITLE
(PE-46689) Retry rbac_token in subplans::install after the puppetdb bounce

### DIFF
--- a/plans/subplans/install.pp
+++ b/plans/subplans/install.pp
@@ -393,10 +393,32 @@ plan peadm::subplans::install (
   # master. Explicitly stop puppetdb first to avoid any systemd interference.
   run_command('systemctl stop pe-puppetdb', $primary_target)
   run_command('systemctl start pe-puppetdb', $primary_target)
-  run_task('peadm::rbac_token', $primary_target,
-    password       => $console_password,
-    token_lifetime => $token_lifetime,
-  )
+
+  # rbac-service can briefly 500/reject auth immediately after this
+  # puppetdb bounce, before its own dependents have caught up (PE-46689,
+  # the same class of transient-unavailability window restore.pp's
+  # equivalent rbac_token call already retries around for PE-44867).
+  # Retry instead of failing the whole install on a transient error.
+  $rbac_token_max_attempts = 5
+  $rbac_token_result = range(1, $rbac_token_max_attempts).reduce(undef) |$memo, $attempt| {
+    if $memo =~ NotUndef and $memo.ok {
+      $memo
+    } else {
+      if $attempt > 1 {
+        out::message("rbac_token not ready; retrying (attempt ${attempt}) after 15s...")
+        ctrl::sleep(15)
+      }
+      run_task('peadm::rbac_token', $primary_target,
+        _catch_errors  => true,
+        password       => $console_password,
+        token_lifetime => $token_lifetime,
+      )
+    }
+  }
+  unless $rbac_token_result.ok {
+    $rbac_token_error = $rbac_token_result.first.error.message
+    fail_plan("Failed to obtain RBAC token after ${rbac_token_max_attempts} attempts: ${rbac_token_error}")
+  }
 
   # Stub a production environment and commit it to file-sync. At least one
   # commit (content irrelevant) is necessary to be able to configure

--- a/spec/plans/subplans/install_spec.rb
+++ b/spec/plans/subplans/install_spec.rb
@@ -140,6 +140,73 @@ describe 'peadm::subplans::install' do
     expect(run_plan('peadm::subplans::install', params)).to be_ok
   end
 
+  # PE-46689: rbac-service can briefly 500/reject auth immediately after
+  # the pe-puppetdb bounce just above this call, before its own dependents
+  # have caught up -- the same class of transient-unavailability window
+  # restore.pp's equivalent rbac_token call already retries around
+  # (PE-44867). subplans::install had no equivalent retry.
+  describe 'rbac_token retry (PE-46689)' do
+    let(:params) do
+      {
+        'primary_host' => 'primary',
+        'console_password' => 'puppetLabs123!',
+        'version' => '2023.8.10',
+      }
+    end
+
+    # error_with/always_return can't simulate a real failure result and then
+    # a later success from the *same* stub (they set one fixed default for
+    # every call) -- construct the Bolt::Result directly via a .return
+    # block with a closure counter instead, so each successive call to
+    # peadm::rbac_token can return a different result.
+    def stub_rbac_token(fail_count:)
+      attempts = 0
+      expected_calls = [fail_count + 1, 5].min
+      expect_task('peadm::rbac_token').with_targets('primary').be_called_times(expected_calls).return do |targets:, task:, params:| # rubocop:disable Lint/UnusedBlockArgument
+        attempts += 1
+        results = targets.map do |target|
+          if attempts <= fail_count
+            Bolt::Result.new(target, error: { 'msg' => 'User admin failed to login', 'kind' => 'puppetlabs.rbac/server-error' })
+          else
+            Bolt::Result.new(target, value: {})
+          end
+        end
+        Bolt::ResultSet.new(results)
+      end
+    end
+
+    # ctrl::sleep resolves Kernel#sleep as a private instance method (mixed
+    # into every Object via the Kernel module), not the module_function
+    # singleton `Kernel.sleep` -- stubbing the singleton doesn't intercept
+    # it, so this needs any_instance_of like the file's other Ruby-internals
+    # stubs above.
+    # rubocop:disable RSpec/AnyInstance
+    before(:each) do
+      allow_any_instance_of(Puppet::Functions::Function).to receive(:sleep)
+    end
+    # rubocop:enable RSpec/AnyInstance
+
+    it 'succeeds on the first attempt without retrying' do
+      stub_rbac_token(fail_count: 0)
+
+      expect(run_plan('peadm::subplans::install', params)).to be_ok
+    end
+
+    it 'retries and succeeds once rbac-service catches up' do
+      stub_rbac_token(fail_count: 2)
+
+      expect(run_plan('peadm::subplans::install', params)).to be_ok
+    end
+
+    it 'fails the install after exhausting all retry attempts' do
+      stub_rbac_token(fail_count: 5)
+
+      result = run_plan('peadm::subplans::install', params)
+      expect(result).not_to be_ok
+      expect(result.value.msg).to match(%r{Failed to obtain RBAC token after 5 attempts})
+    end
+  end
+
   # PE-45431: on Large/XL/external-Postgres topologies the primary's installer
   # runs before $database_targets exist, so pe-installer-shim's own
   # migration (PE-45430) finds pe-ca unreachable and skips loudly -- peadm


### PR DESCRIPTION
## Problem

`plans/subplans/install.pp` bounces `pe-puppetdb` on the primary (`systemctl stop`/`start pe-puppetdb`) and then immediately requests an RBAC token via `run_task('peadm::rbac_token', ...)`, with no retry.

`plans/restore.pp` has an equivalent call (also shortly after a service restart, via `puppet-infrastructure configure`) wrapped in a 5-attempt, 15-second-backoff retry, added for PE-44867 — rbac-service can briefly 500/reject auth immediately after a dependency it needs at startup was just restarted.

This isn't the same root cause as PE-44867 (that ticket's actual fix was restoring `public`-schema privileges after `restore.pp`'s own `DROP SCHEMA`/`CREATE SCHEMA`, which is restore-specific and unrelated here), but the *retry itself* addresses the same class of transient-unavailability window — one that `subplans::install`'s own `pe-puppetdb` bounce creates just as much as `restore.pp`'s service restart does.

## Fix

Apply the identical 5-attempt/15s-backoff retry pattern from `restore.pp` to `subplans/install.pp`'s `rbac_token` call.

Grepped the whole repo for `peadm::rbac_token` task call sites to confirm these are the only two that exist — no other unretried call sites.

## How this was found

Live ABS acceptance run for PE-45860, where `peadm::rbac_token` failed twice consecutively with "User admin failed to login" immediately after this bounce, on an otherwise-healthy install. Retrying (mirroring `restore.pp`'s pattern) resolved it after 2 attempts.

## Testing

- `bundle exec rspec spec/plans/subplans/install_spec.rb` — new `rbac_token retry (PE-46689)` describe block: 3 examples (succeeds first try, retries then succeeds, exhausts all attempts and fails), 0 failures.
- `bundle exec rspec spec/plans/ spec/functions/` — 126 examples, 0 failures, 6 pre-existing pending (unrelated).
- `bundle exec puppet-lint plans/subplans/install.pp` — clean.
- `bundle exec rubocop spec/plans/subplans/install_spec.rb` — clean.

Jira: PE-46689 (filed under epic PE-45424, CA-DB default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)