### PR TITLE
Revert "(PE-44793) Note CA-proxy mode and opt-in ICA promotion in add_compilers output" (#692)

### DIFF
--- a/plans/add_compilers.pp
+++ b/plans/add_compilers.pp
@@ -147,8 +147,5 @@ plan peadm::add_compilers(
   ]))
 
   $compiler_names = $compiler_targets.map |$compiler_target| { $compiler_target.peadm::certname() }.join(', ')
-
-  out::message('Compilers are added in CA-proxy mode. Promotion to an Intermediate CA is opt-in and performed separately.')
-
   return("Adding or replacing compiler(s) ${compiler_names} succeeded.")
 }

--- a/spec/plans/add_compilers_spec.rb
+++ b/spec/plans/add_compilers_spec.rb
@@ -56,7 +56,6 @@ describe 'peadm::add_compilers' do
 
     it 'runs successfully when no alt-names are specified' do
       allow_standard_non_returning_calls
-      expect_out_message.with_params('Compilers are added in CA-proxy mode. Promotion to an Intermediate CA is opt-in and performed separately.')
 
       expect_task('peadm::get_peadm_config').always_return(cfg)
       expect_task('peadm::check_pe_master_rules').always_return(pe_rule_check)
@@ -66,14 +65,11 @@ describe 'peadm::add_compilers' do
       expect_plan('peadm::util::copy_file').be_called_times(1)
       expect_task('peadm::puppet_runonce').with_targets(['compiler'])
       expect_task('peadm::puppet_runonce').with_targets(['server_a'])
-      result = run_plan('peadm::add_compilers', params)
-      expect(result).to be_ok
-      expect(result.value).to eq('Adding or replacing compiler(s) compiler succeeded.')
+      expect(run_plan('peadm::add_compilers', params)).to be_ok
     end
 
     it 'handles different avail_group_letter values' do
       allow_standard_non_returning_calls
-      expect_out_message.with_params('Compilers are added in CA-proxy mode. Promotion to an Intermediate CA is opt-in and performed separately.')
       cfg['role-letter']['server']['B'] = 'server_b'
 
       expect_task('peadm::get_peadm_config').always_return(cfg)
@@ -90,7 +86,6 @@ describe 'peadm::add_compilers' do
 
     it 'handles specified primary_postgresql_host' do
       allow_standard_non_returning_calls
-      expect_out_message.with_params('Compilers are added in CA-proxy mode. Promotion to an Intermediate CA is opt-in and performed separately.')
 
       expect_task('peadm::get_peadm_config').always_return(cfg)
       expect_task('peadm::check_pe_master_rules').always_return(pe_rule_check)
@@ -105,7 +100,6 @@ describe 'peadm::add_compilers' do
 
     it 'handles external postgresql host group A' do
       allow_standard_non_returning_calls
-      expect_out_message.with_params('Compilers are added in CA-proxy mode. Promotion to an Intermediate CA is opt-in and performed separately.')
       cfg['params']['primary_postgresql_host'] = 'external_postgresql'
       cfg['params']['replica_postgresql_host'] = 'external_postgresql'
 
@@ -122,7 +116,6 @@ describe 'peadm::add_compilers' do
 
     it 'handles external postgresql host group A with replica' do
       allow_standard_non_returning_calls
-      expect_out_message.with_params('Compilers are added in CA-proxy mode. Promotion to an Intermediate CA is opt-in and performed separately.')
       cfg['params']['primary_postgresql_host'] = 'external_postgresql'
       cfg['role-letter']['server']['B'] = 'replica'
 
@@ -140,7 +133,6 @@ describe 'peadm::add_compilers' do
 
     it 'handles external postgresql host group B' do
       allow_standard_non_returning_calls
-      expect_out_message.with_params('Compilers are added in CA-proxy mode. Promotion to an Intermediate CA is opt-in and performed separately.')
       cfg['params']['replica_postgresql_host'] = 'replica_external_postgresql'
 
       expect_task('peadm::get_peadm_config').always_return(cfg)


### PR DESCRIPTION
Reverts #692.

Due to the 2025.11.3 release, PRs cannot currently be merged into main. This PR will be recreated separately and merged once the release freeze lifts next week.