### PR TITLE
(PE-46104) Add peadm task to list all compiler ICAs and their state

### DIFF
--- a/spec/unit/task/list_compiler_icas_spec.rb
+++ b/spec/unit/task/list_compiler_icas_spec.rb
@@ -1,0 +1,193 @@
+require 'spec_helper'
+require_relative '../../../tasks/list_compiler_icas'
+
+describe ListCompilerIcas do
+  subject(:task) { described_class.new(params, https_client: https) }
+
+  let(:params) { {} }
+  let(:https) { instance_double(Net::HTTP) }
+  let(:response) { instance_double(Net::HTTPResponse, code: '200', body: intermediate_cas.to_json) }
+  let(:intermediate_cas) do
+    {
+      'intermediate-cas' => [
+        {
+          'compiler-fqdn' => 'compiler1.example.com',
+          'state' => 'active',
+          'provisioned-at' => '2026-01-01T00:00:00Z',
+          'not-after' => '2027-01-01T00:00:00Z',
+        },
+        {
+          'compiler-fqdn' => 'compiler2.example.com',
+          'state' => 'decommissioned',
+          'provisioned-at' => '2025-01-01T00:00:00Z',
+          'not-after' => '2026-01-01T00:00:00Z',
+        },
+      ],
+      'autosign-inconsistent' => false,
+      'autosign-fingerprint-baseline' => 'abc123',
+    }
+  end
+
+  before(:each) do
+    allow(STDOUT).to receive(:puts)
+    allow(https).to receive(:get).with('/puppet-ca/v1/intermediate-ca').and_return(response)
+  end
+
+  it 'returns one row per ICA with FQDN, state, provisioned-at, and not-after' do
+    expect(STDOUT).to receive(:puts) do |output|
+      expect(output).to include('compiler1.example.com', 'active', '2026-01-01T00:00:00Z', '2027-01-01T00:00:00Z')
+    end
+
+    expect { task.execute! }.to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+  end
+
+  context 'with a state filter' do
+    let(:params) { { 'state' => 'active' } }
+
+    it 'returns only ICAs matching the requested state' do
+      expect(STDOUT).to receive(:puts) do |output|
+        expect(output).to include('compiler1.example.com')
+        expect(output).not_to include('compiler2.example.com')
+      end
+
+      expect { task.execute! }.to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+    end
+  end
+
+  context 'with an unknown state value' do
+    let(:params) { { 'state' => 'bogus' } }
+
+    it 'fails and lists the valid states' do
+      expect(STDOUT).to receive(:puts) do |output|
+        parsed = JSON.parse(output)
+        expect(parsed['_error']['msg']).to include('bogus', 'active', 'draining', 'revoked', 'decommissioned')
+      end
+
+      expect { task.execute! }.to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+    end
+  end
+
+  context "with format => 'json'" do
+    let(:params) { { 'format' => 'json' } }
+
+    it "returns the endpoint's structure unmodified" do
+      expect(STDOUT).to receive(:puts) do |output|
+        expect(JSON.parse(output)).to eq(intermediate_cas)
+      end
+
+      expect { task.execute! }.to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+    end
+
+    context 'combined with a state filter' do
+      let(:params) { { 'format' => 'json', 'state' => 'active' } }
+
+      it 'keeps the same envelope shape but drops non-matching entries, passing fields through verbatim' do
+        expect(STDOUT).to receive(:puts) do |output|
+          parsed = JSON.parse(output)
+          expect(parsed['intermediate-cas'].map { |ica| ica['compiler-fqdn'] }).to eq(['compiler1.example.com'])
+          expect(parsed['intermediate-cas'].first).to eq(intermediate_cas['intermediate-cas'].first)
+        end
+
+        expect { task.execute! }.to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+      end
+    end
+  end
+
+  context 'with no ICAs registered' do
+    let(:intermediate_cas) { { 'intermediate-cas' => [], 'autosign-inconsistent' => false, 'autosign-fingerprint-baseline' => nil } }
+
+    it 'exits zero with an explicit human-readable message in table format' do
+      expect(STDOUT).to receive(:puts).with('no compiler ICAs are provisioned')
+
+      expect { task.execute! }.to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+    end
+
+    context "with format => 'json'" do
+      let(:params) { { 'format' => 'json' } }
+
+      it 'returns the unmodified empty envelope, not a message' do
+        expect(STDOUT).to receive(:puts) do |output|
+          expect(JSON.parse(output)).to eq(intermediate_cas)
+        end
+
+        expect { task.execute! }.to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+      end
+    end
+  end
+
+  context 'when the primary responds with a non-2xx status' do
+    let(:response) { instance_double(Net::HTTPResponse, code: '503', body: 'CA service unavailable') }
+
+    it 'exits non-zero surfacing the primary error body' do
+      expect(STDOUT).to receive(:puts) do |output|
+        parsed = JSON.parse(output)
+        expect(parsed['_error']['msg']).to include('503', 'CA service unavailable')
+      end
+
+      expect { task.execute! }.to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+    end
+  end
+
+  context 'with autosign fingerprint divergence across the fleet' do
+    let(:intermediate_cas) do
+      {
+        'intermediate-cas' => [
+          {
+            'compiler-fqdn' => 'compiler1.example.com',
+            'state' => 'active',
+            'provisioned-at' => '2026-01-01T00:00:00Z',
+            'not-after' => '2027-01-01T00:00:00Z',
+            'autosign-config-fingerprint' => 'aaa',
+            'autosign-state' => 'divergent',
+          },
+          {
+            'compiler-fqdn' => 'compiler2.example.com',
+            'state' => 'active',
+            'provisioned-at' => '2026-01-01T00:00:00Z',
+            'not-after' => '2027-01-01T00:00:00Z',
+            'autosign-config-fingerprint' => 'bbb',
+            'autosign-state' => 'divergent',
+          },
+        ],
+        'autosign-inconsistent' => true,
+        'autosign-fingerprint-baseline' => nil,
+      }
+    end
+
+    it 'shows each row autosign fingerprint and prints a warning naming the affected compilers' do
+      expect(STDOUT).to receive(:puts) do |output|
+        expect(output).to include('aaa', 'bbb', 'compiler1.example.com', 'compiler2.example.com')
+        expect(output).to match(%r{warning}i)
+      end
+
+      expect { task.execute! }.to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+    end
+  end
+
+  context 'with a revoked ICA (no autosign state)' do
+    let(:intermediate_cas) do
+      {
+        'intermediate-cas' => [
+          {
+            'compiler-fqdn' => 'compiler1.example.com',
+            'state' => 'revoked',
+            'provisioned-at' => '2026-01-01T00:00:00Z',
+            'not-after' => '2027-01-01T00:00:00Z',
+            'autosign-config-fingerprint' => 'aaa',
+            'autosign-state' => nil,
+          },
+        ],
+        'autosign-inconsistent' => false,
+        'autosign-fingerprint-baseline' => 'aaa',
+      }
+    end
+
+    it 'shows a dash for autosign state rather than a blank' do
+      expect(STDOUT).to receive(:puts) do |output|
+        expect(output).to match(%r{compiler1\.example\.com\s+revoked\s+.*\s-(\s|$)})
+      end
+
+      expect { task.execute! }.to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+    end
+  end
+end

--- a/tasks/list_compiler_icas.json
+++ b/tasks/list_compiler_icas.json
@@ -1,0 +1,17 @@
+{
+  "puppet_task_version": 1,
+  "supports_noop": false,
+  "description": "Run on a PE primary to list all compiler ICAs and their state, including autosign fingerprint consistency across the fleet",
+  "parameters": {
+    "state": {
+      "type": "Optional[Enum[active,draining,revoked,decommissioned]]",
+      "description": "Only return ICAs in this state. Unfiltered by default."
+    },
+    "format": {
+      "type": "Enum[table,json]",
+      "description": "table for human-readable output (default), json to return the endpoint's response unmodified for use in another plan",
+      "default": "table"
+    }
+  },
+  "input_method": "stdin"
+}

--- a/tasks/list_compiler_icas.rb
+++ b/tasks/list_compiler_icas.rb
@@ -1,0 +1,92 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'net/http'
+require 'openssl'
+require 'puppet'
+
+# Bolt task: list all compiler ICAs and their state. Runs on the primary.
+# Presentation over the existing GET /puppet-ca/v1/intermediate-ca response;
+# adds no new API surface.
+class ListCompilerIcas
+  VALID_STATES = ['active', 'draining', 'revoked', 'decommissioned'].freeze
+
+  def initialize(params, https_client: nil)
+    @state_filter = params['state']
+    @format = params.fetch('format', 'table')
+    @https_client = https_client
+  end
+
+  def execute!
+    assert_valid_state_filter!
+
+    response = https.get('/puppet-ca/v1/intermediate-ca')
+    unless response.code.to_i.between?(200, 299)
+      error!("Failed to list compiler ICAs: HTTP #{response.code} - #{response.body}", 'peadm/list_compiler_icas_failed')
+    end
+
+    body = JSON.parse(response.body)
+    icas = filtered_icas(body)
+
+    if @format == 'json'
+      STDOUT.puts(body.merge('intermediate-cas' => icas).to_json)
+    else
+      STDOUT.puts(render_table(icas, body['autosign-inconsistent']))
+    end
+    exit 0
+  end
+
+  private
+
+  def assert_valid_state_filter!
+    return if @state_filter.nil? || VALID_STATES.include?(@state_filter)
+    error!("Unknown state '#{@state_filter}': must be one of #{VALID_STATES.join(', ')}", 'peadm/list_compiler_icas_invalid_state')
+  end
+
+  def error!(msg, kind)
+    STDOUT.puts({ '_error' => { 'msg' => msg, 'kind' => kind } }.to_json)
+    exit 1
+  end
+
+  def filtered_icas(body)
+    icas = body.fetch('intermediate-cas')
+    return icas unless @state_filter
+    icas.select { |ica| ica['state'] == @state_filter }
+  end
+
+  def render_table(icas, autosign_inconsistent)
+    return 'no compiler ICAs are provisioned' if icas.empty?
+
+    rows = icas.map { |ica|
+      [
+        ica['compiler-fqdn'], ica['state'], ica['provisioned-at'], ica['not-after'],
+        ica['autosign-state'] || '-', ica['autosign-config-fingerprint'] || '-'
+      ].join(' ')
+    }.join("\n")
+
+    return rows unless autosign_inconsistent
+    "#{rows}\nwarning: autosign configuration is inconsistent across #{diverging_compilers(icas).join(', ')}"
+  end
+
+  def diverging_compilers(icas)
+    icas.select { |ica| ica['autosign-state'] == 'divergent' }.map { |ica| ica['compiler-fqdn'] }
+  end
+
+  def https
+    @https_client ||= begin
+      client = Net::HTTP.new(Puppet.settings[:certname], 8140)
+      client.use_ssl = true
+      client.cert = OpenSSL::X509::Certificate.new(File.read(Puppet.settings[:hostcert]))
+      client.key = OpenSSL::PKey::RSA.new(File.read(Puppet.settings[:hostprivkey]))
+      client.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      client.ca_file = Puppet.settings[:localcacert]
+      client
+    end
+  end
+end
+
+unless ENV['RSPEC_UNIT_TEST_MODE']
+  Puppet.initialize_settings
+  ListCompilerIcas.new(JSON.parse(STDIN.read)).execute!
+end


### PR DESCRIPTION
## Summary

- Adds `peadm::list_compiler_icas`, a task that runs on the PE primary and renders `GET /puppet-ca/v1/intermediate-ca` as an operator-facing table (FQDN, state, provisioned-at, not-after, autosign state, autosign fingerprint), with an optional `state` filter and a `json` output mode for use from other plans.
- When the endpoint reports `autosign-inconsistent`, table output prints a warning naming the affected compilers. The task renders whatever `autosign-state`/`autosign-config-fingerprint` the endpoint returns and does not classify or compare fingerprints itself.

## This PR is NOT ready to merge

peadm is currently frozen on `main`. Opened as a draft, labeled `DO NOT MERGE` and `feature`, for early visibility and review while blocked. No merge-order dependency on other branches: this task only requires stdlib/puppet at the code level, and its endpoint dependencies (tickets 3.6, 3.11, 3.14) are already closed and live elsewhere.

## Test plan

- [x] `bundle exec rspec spec/unit/task/list_compiler_icas_spec.rb` - 11 examples, 0 failures, covering: populated fleet, state filter, unknown state rejection, `json` format (unmodified passthrough, alone and combined with `state`), empty registration (table message vs. unmodified empty JSON), non-2xx from the primary, autosign fingerprint divergence warning, and the revoked/terminal-state dash.
- [x] `bundle exec rubocop tasks/list_compiler_icas.rb spec/unit/task/list_compiler_icas_spec.rb` - clean
- [x] `bundle exec rake metadata_lint` - clean